### PR TITLE
add nofile buftype to check.ok

### DIFF
--- a/lua/cmp/utils/check.lua
+++ b/lua/cmp/utils/check.lua
@@ -2,7 +2,9 @@ local check = {}
 
 check.ok = function()
   local ng = false
-  ng = ng or vim.api.nvim_buf_get_option(0, 'buftype') == 'prompt'
+  local bt = vim.api.nvim_buf_get_option(0, 'buftype')
+  ng = ng or bt == 'prompt'
+  ng = ng or bt == 'nofile'
   ng = ng or string.sub(vim.api.nvim_get_mode().mode, 1, 1) ~= 'i'
   return not ng
 end


### PR DESCRIPTION
per discussion in https://github.com/liuchengxu/vim-clap/issues/745, makes it so cmp won't start in buffers where `bt=nofile` (and consequently, the vim-clap window)