### PR TITLE
fixed supertab example

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,15 +459,19 @@ local check_back_space = function()
 end
 local luasnip = require("luasnip")
 
+local t = function(str)
+    return vim.api.nvim_replace_termcodes(str, true, true, true)
+end
+
 -- supertab-like mapping
 mapping = {
   ["<Tab>"] = cmp.mapping(function(fallback)
     if vim.fn.pumvisible() == 1 then
-      vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<C-n>"), "n")
+      vim.fn.feedkeys(t("<C-n>"), "n")
     elseif luasnip.expand_or_jumpable() then
-      vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-expand-or-jump"), "")
+      vim.fn.feedkeys(t("<Plug>luasnip-expand-or-jump"), "")
     elseif check_back_space() then
-      vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Tab>"), "n")
+      vim.fn.feedkeys(t("<Tab>"), "n")
     else
       fallback()
     end
@@ -477,9 +481,9 @@ mapping = {
   }),
   ["<S-Tab>"] = cmp.mapping(function(fallback)
     if vim.fn.pumvisible() == 1 then
-      vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<C-p>"), "n")
+      vim.fn.feedkeys(t("<C-p>"), "n")
     elseif luasnip.jumpable(-1) then
-      vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-jump-prev"), "")
+      vim.fn.feedkeys(t("<Plug>luasnip-jump-prev"), "")
     else
       fallback()
     end


### PR DESCRIPTION
the current supertab example was causing autocompletion to break because `vim.api.nvim_replace_termcodes` requires 4 parameters and the example was only passing one.

Added a function to extract it and input the remaining required parameters.