### PR TITLE
Experimental: Ghost text

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,12 @@ Specify preselect mode. The following modes are available.
 
 Default: `cmp.PreselectMode.Item`
 
+#### experimental.inline_preview (type: boolean)
+
+Specify inline_preview enables or not.
+
+Default: `false`
+
 
 Programatic API
 ====================

--- a/README.md
+++ b/README.md
@@ -354,9 +354,9 @@ Specify preselect mode. The following modes are available.
 
 Default: `cmp.PreselectMode.Item`
 
-#### experimental.inline_preview (type: boolean)
+#### experimental.ghost_text (type: boolean)
 
-Specify inline_preview enables or not.
+Specify whether to display ghost text.
 
 Default: `false`
 

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -62,7 +62,7 @@ return function()
     },
 
     experimental = {
-      inline_preview = false,
+      ghost_text = false,
     },
 
     sources = {},

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -61,6 +61,10 @@ return function()
       end
     },
 
+    experimental = {
+      inline_preview = true,
+    },
+
     sources = {},
   }
 end

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -62,7 +62,7 @@ return function()
     },
 
     experimental = {
-      inline_preview = true,
+      inline_preview = false,
     },
 
     sources = {},

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -1,5 +1,6 @@
 local debug = require('cmp.utils.debug')
 local char = require('cmp.utils.char')
+local str = require('cmp.utils.str')
 local pattern = require('cmp.utils.pattern')
 local async = require('cmp.utils.async')
 local keymap = require('cmp.utils.keymap')

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -20,6 +20,14 @@ core.suspending = false
 
 core.INLINE_PREVIEW_NS = vim.api.nvim_create_namespace('cmp:INLINE_PREVIEW_NS');
 
+vim.api.nvim_set_decoration_provider(core.INLINE_PREVIEW_NS, {
+  on_win = function()
+    if config.get().experimental.inline_preview then
+      core.inline_preview(core.menu:get_first_entry())
+    end
+  end,
+})
+
 ---@type cmp.Menu
 core.menu = menu.new({
   on_select = function(e)
@@ -30,7 +38,6 @@ core.menu = menu.new({
 })
 
 core.inline_preview = function(e)
-  vim.api.nvim_buf_clear_namespace(0, core.INLINE_PREVIEW_NS, 0, -1)
   if not e then
     return
   end
@@ -52,15 +59,13 @@ core.inline_preview = function(e)
       ctx.cursor.row - 1,
       ctx.cursor.col - 1,
       {
-        end_line = ctx.cursor.row - 1,
-        end_col = ctx.cursor.col - 1,
-        right_gravity = false,
-        end_right_gravity = false,
+        right_gravity = true,
         virt_text = { { text, 'Comment' } },
         virt_text_pos = 'overlay',
         virt_text_win_col = ctx.cursor.col - 1,
-        hl_mode = 'combine',
+        hl_mode = 'blend',
         priority = 0,
+        ephemeral = true,
       }
     )
   end

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -19,12 +19,12 @@ core.SOURCE_TIMEOUT = 500
 ---Suspending state.
 core.suspending = false
 
-core.INLINE_PREVIEW_NS = vim.api.nvim_create_namespace('cmp:INLINE_PREVIEW_NS');
+core.GHOST_TEXT_NS = vim.api.nvim_create_namespace('cmp:GHOST_TEXT');
 
-vim.api.nvim_set_decoration_provider(core.INLINE_PREVIEW_NS, {
+vim.api.nvim_set_decoration_provider(core.GHOST_TEXT_NS, {
   on_win = function()
-    if config.get().experimental.inline_preview then
-      core.inline_preview(core.menu:get_first_entry())
+    if config.get().experimental.ghost_text then
+      core.ghost_text(core.menu:get_first_entry())
     end
   end,
 })
@@ -38,10 +38,13 @@ core.menu = menu.new({
   end,
 })
 
-core.inline_preview = function(e)
+---Show ghost text if possible
+---@param e cmp.Entry
+core.ghost_text = function(e)
   if not e then
     return
   end
+
   local ctx = context.new()
   if ctx.cursor_after_line ~= '' then
     return
@@ -56,7 +59,7 @@ core.inline_preview = function(e)
   if #text > 0 then
     vim.api.nvim_buf_set_extmark(
       ctx.bufnr,
-      core.INLINE_PREVIEW_NS,
+      core.GHOST_TEXT_NS,
       ctx.cursor.row - 1,
       ctx.cursor.col - 1,
       {

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -263,9 +263,6 @@ core.filter = async.throttle(function()
   end
 
   core.menu:update(ctx, core.get_sources())
-  vim.schedule(function()
-    core.inline_preview(core.menu:get_first_entry())
-  end)
 end, 50)
 
 ---Confirm completion.
@@ -379,7 +376,6 @@ core.reset = function()
     s:reset()
   end
   core.menu:reset()
-  core.inline_preview()
 
   core.get_context() -- To prevent new event
 end

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -59,6 +59,8 @@ core.inline_preview = function(e)
         virt_text = { { text, 'Comment' } },
         virt_text_pos = 'overlay',
         virt_text_win_col = ctx.cursor.col - 1,
+        hl_mode = 'combine',
+        priority = 0,
       }
     )
   end

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -40,7 +40,11 @@ core.inline_preview = function(e)
   end
 
   local diff = ctx.cursor.col - e:get_offset()
-  local text = string.sub(vim.lsp.util.parse_snippet(str.oneline(e:get_insert_text())), diff + 1)
+  local text = e:get_insert_text()
+  if e.completion_item.insertTextFormat == types.lsp.InsertTextFormat.Snippet then
+    text = vim.lsp.util.parse_snippet(text)
+  end
+  text = string.sub(str.oneline(text), diff + 1)
   if #text > 0 then
     vim.api.nvim_buf_set_extmark(
       ctx.bufnr,
@@ -48,10 +52,13 @@ core.inline_preview = function(e)
       ctx.cursor.row - 1,
       ctx.cursor.col - 1,
       {
+        end_line = ctx.cursor.row - 1,
+        end_col = ctx.cursor.col - 1,
+        right_gravity = false,
+        end_right_gravity = false,
         virt_text = { { text, 'Comment' } },
         virt_text_pos = 'overlay',
         virt_text_win_col = ctx.cursor.col - 1,
-        hl_mode = 'blend',
       }
     )
   end

--- a/lua/cmp/menu.lua
+++ b/lua/cmp/menu.lua
@@ -193,58 +193,39 @@ end
 ---Geta current active entry
 ---@return cmp.Entry|nil
 menu.get_active_entry = function(self)
-  local completed_item = vim.v.completed_item or {}
-  if vim.fn.pumvisible() == 0 or not completed_item.user_data then
+  if vim.fn.pumvisible() == 0 or not (vim.v.completed_item or {}).user_data then
     return nil
   end
-
-  local id = completed_item.user_data.cmp
-  if id then
-    return self.entry_map[id]
-  end
-  return nil
+  return self:get_selected_entry()
 end
 
 ---Get current selected entry
 ---@return cmp.Entry|nil
 menu.get_selected_entry = function(self)
-  local e = self:get_active_entry()
-  if e then
-    return e
+  if not self:is_valid_mode() then
+    return nil
   end
 
   local selected = vim.fn.complete_info({ 'selected' }).selected
   if selected == -1 then
     return nil
   end
-  local items = vim.fn.complete_info({ 'items' }).items
-
-  local completed_item = items[math.max(selected, 0) + 1] or {}
-  if not completed_item.user_data then
-    return nil
-  end
-
-  local id = completed_item.user_data.cmp
-  if id then
-    return self.entry_map[id]
-  end
-  return nil
+  return self.entries[math.max(selected, 0) + 1]
 end
 
 ---Get first entry
 ---@param self cmp.Entry|nil
 menu.get_first_entry = function(self)
-  local info = vim.fn.complete_info({ 'items' })
-  local completed_item = info.items[1] or {}
-  if not completed_item.user_data then
+  if not self:is_valid_mode() then
     return nil
   end
+  return self.entries[1]
+end
 
-  local id = completed_item.user_data.cmp
-  if id then
-    return self.entry_map[id]
-  end
-  return nil
+---Return the completion menu is visible or not.
+---@return boolean
+menu.is_valid_mode = function()
+  return vim.fn.complete_info({ 'mode' }).mode == 'eval'
 end
 
 return menu

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -57,6 +57,7 @@ cmp.PreselectMode.None = 'none'
 ---@field public event cmp.EventConfig
 ---@field public mapping table<string, fun(core: cmp.Core, fallback: function)>
 ---@field public sources cmp.SourceConfig[]
+---@field public experimental cmp.ExperimentalConfig
 
 ---@class cmp.CompletionConfig
 ---@field public autocomplete cmp.TriggerEvent[]
@@ -87,6 +88,9 @@ cmp.PreselectMode.None = 'none'
 
 ---@class cmp.EventConfig
 ---@field on_confirm_done function(e: cmp.Entry)
+
+---@class cmp.ExperimentalConfig
+---@field public inline_preview boolean
 
 ---@class cmp.SourceConfig
 ---@field public name string

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -90,7 +90,7 @@ cmp.PreselectMode.None = 'none'
 ---@field on_confirm_done function(e: cmp.Entry)
 
 ---@class cmp.ExperimentalConfig
----@field public inline_preview boolean
+---@field public ghost_text boolean
 
 ---@class cmp.SourceConfig
 ---@field public name string


### PR DESCRIPTION
This PR adds the ability to show the first candidate's preview as inline.

This is still a much experimental feature. I think we should remove this feature after VSCode's ghost text feature ships to LSP spec.

https://user-images.githubusercontent.com/629908/131284635-74da4ef7-289e-440a-abe8-bb36dc6af279.mp4