### PR TITLE
[fix, docs]: add default ghost text hl group, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,14 @@ Specify whether to display ghost text.
 Default: `false`
 
 
+#### experimental.ghost_text.hl_group (type: string)
+
+Specify the hightlight group used for ghost text.
+
+Default: `Comment`
+
+
+
 Programatic API
 ====================
 

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -66,6 +66,7 @@ return function()
 
     experimental = {
       ghost_text = false,
+      ghost_text_highlight_group = "Comment",
     },
 
     sources = {},

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -36,8 +36,10 @@ core.menu = menu.new({
 core.ghost_text = function(e)
   vim.api.nvim_buf_clear_namespace(0, core.GHOST_TEXT_NS, 0, -1)
 
-  local c = config.get().experimental.ghost_text
-  if not c then
+  local experimental_cfg = config.get().experimental
+
+  local use_ghost_text = experimental_cfg.ghost_text
+  if not use_ghost_text then
     return
   end
 
@@ -59,9 +61,10 @@ core.ghost_text = function(e)
   if #text > 0 then
     vim.api.nvim_buf_set_extmark(ctx.bufnr, core.GHOST_TEXT_NS, ctx.cursor.row - 1, ctx.cursor.col - 1, {
       right_gravity = false,
-      virt_text = { { text, c.hl_group or "Comment" } },
+      virt_text = { { text, experimental_cfg.ghost_text_highlight_group } },
       virt_text_pos = 'overlay',
       virt_text_win_col = ctx.virtcol - 1,
+      hl_mode = 'combine',
       priority = 1,
     })
   end

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -59,7 +59,7 @@ core.ghost_text = function(e)
   if #text > 0 then
     vim.api.nvim_buf_set_extmark(ctx.bufnr, core.GHOST_TEXT_NS, ctx.cursor.row - 1, ctx.cursor.col - 1, {
       right_gravity = false,
-      virt_text = { { text, c.hl_group } },
+      virt_text = { { text, c.hl_group or "Comment" } },
       virt_text_pos = 'overlay',
       virt_text_win_col = ctx.virtcol - 1,
       priority = 1,


### PR DESCRIPTION
Edit: Thank you for adding the hl group for ghost text! I added a default so that specifying the hl group is not absolutely necessary and added a little piece of documentation about the ghost text hl group in the README. If this isn't desired, I totally understand!

Why:
    - using ghost text without specifying hl group gave errors
    - the ghost text hl group has no docs