### PR TITLE
fix StyLua command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: fmt
 fmt:
-	stylua --config-path stylua.toml --glob lua/**/*.lua -- lua
+	stylua --config-path stylua.toml --glob 'lua/**/*.lua' -- lua
 
 .PHONY: lint
 lint:
@@ -12,13 +12,13 @@ test:
 
 .PHONY: pre-commit
 pre-commit:
-	./utils/stylua --config-path stylua.toml --glob lua/**/*.lua -- lua
+	./utils/stylua --config-path stylua.toml --glob 'lua/**/*.lua' -- lua
 	luacheck lua
 	vusted lua
 
 .PHONY: integration
 integration:
-	./utils/stylua --config-path stylua.toml --check --glob lua/**/*.lua -- lua
+	./utils/stylua --config-path stylua.toml --check --glob 'lua/**/*.lua' -- lua
 	luacheck lua
 	vusted lua
 

--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -1,5 +1,5 @@
-local types = require'cmp.types'
-local misc  = require 'cmp.utils.misc'
+local types = require('cmp.types')
+local misc = require('cmp.utils.misc')
 
 local compare = {}
 
@@ -85,4 +85,3 @@ compare.order = function(entry1, entry2)
 end
 
 return compare
-

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -15,7 +15,7 @@ return function()
       keyword_length = 1,
       get_trigger_characters = function(trigger_characters)
         return trigger_characters
-      end
+      end,
     },
 
     snippet = {
@@ -37,7 +37,7 @@ return function()
       default_behavior = types.cmp.ConfirmBehavior.Insert,
       get_commit_characters = function(commit_characters)
         return commit_characters
-      end
+      end,
     },
 
     sorting = {
@@ -50,7 +50,7 @@ return function()
         compare.sort_text,
         compare.length,
         compare.order,
-      }
+      },
     },
 
     event = {},
@@ -61,7 +61,7 @@ return function()
       deprecated = true,
       format = function(_, vim_item)
         return vim_item
-      end
+      end,
     },
 
     experimental = {
@@ -71,4 +71,3 @@ return function()
     sources = {},
   }
 end
-

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -104,4 +104,3 @@ cmp.PreselectMode.None = 'none'
 ---@field public max_item_count number
 
 return cmp
-

--- a/lua/cmp/types/init.lua
+++ b/lua/cmp/types/init.lua
@@ -5,4 +5,3 @@ types.lsp = require('cmp.types.lsp')
 types.vim = require('cmp.types.vim')
 
 return types
-

--- a/lua/cmp/types/lsp.lua
+++ b/lua/cmp/types/lsp.lua
@@ -1,5 +1,4 @@
-
-local misc = require "cmp.utils.misc"
+local misc = require('cmp.utils.misc')
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/
 ---@class lsp
 local lsp = {}
@@ -18,7 +17,7 @@ lsp.Position.to_vim = function(buf, position)
   if #lines > 0 then
     return {
       row = position.line + 1,
-      col = misc.to_vimindex(lines[1], position.character)
+      col = misc.to_vimindex(lines[1], position.character),
     }
   end
   return {
@@ -196,4 +195,3 @@ lsp.CompletionItemKind = vim.tbl_add_reverse_lookup(lsp.CompletionItemKind)
 ---@field public dup boolean|nil
 
 return lsp
-

--- a/lua/cmp/types/lsp_spec.lua
+++ b/lua/cmp/types/lsp_spec.lua
@@ -1,9 +1,9 @@
-local spec = require'cmp.utils.spec'
-local lsp = require'cmp.types.lsp'
+local spec = require('cmp.utils.spec')
+local lsp = require('cmp.types.lsp')
 
-describe('types.lsp', function ()
+describe('types.lsp', function()
   before_each(spec.before)
-  describe('Position', function ()
+  describe('Position', function()
     vim.fn.setline('1', {
       'あいうえお',
       'かきくけこ',
@@ -44,4 +44,3 @@ describe('types.lsp', function ()
     assert.are.equal(lsp_position.character, 5)
   end)
 end)
-

--- a/lua/cmp/types/vim.lua
+++ b/lua/cmp/types/vim.lua
@@ -15,4 +15,3 @@
 ---@class vim.Range
 ---@field public start vim.Position
 ---@field public end vim.Position
-

--- a/lua/cmp/utils/async.lua
+++ b/lua/cmp/utils/async.lua
@@ -27,11 +27,15 @@ async.throttle = function(fn, timeout)
       timer:stop()
 
       local delta = math.max(0, self.timeout - (vim.loop.now() - time))
-      timer:start(delta, 0, vim.schedule_wrap(function()
-        time = nil
-        fn(unpack(args))
-      end))
-    end
+      timer:start(
+        delta,
+        0,
+        vim.schedule_wrap(function()
+          time = nil
+          fn(unpack(args))
+        end)
+      )
+    end,
   })
 end
 
@@ -52,4 +56,3 @@ async.dedup = function()
 end
 
 return async
-

--- a/lua/cmp/utils/async_spec.lua
+++ b/lua/cmp/utils/async_spec.lua
@@ -1,7 +1,6 @@
-local async = require "cmp.utils.async"
+local async = require('cmp.utils.async')
 
 describe('utils.async', function()
-
   it('throttle', function()
     local count = 0
     local now
@@ -13,14 +12,18 @@ describe('utils.async', function()
     now = vim.loop.now()
     f.timeout = 100
     f()
-    vim.wait(1000, function() return count == 1 end)
+    vim.wait(1000, function()
+      return count == 1
+    end)
     assert.is.truthy(math.abs(f.timeout - (vim.loop.now() - now)) < 10)
 
     -- 2. delay for 500ms
     now = vim.loop.now()
     f.timeout = 500
     f()
-    vim.wait(1000, function() return count == 2 end)
+    vim.wait(1000, function()
+      return count == 2
+    end)
     assert.is.truthy(math.abs(f.timeout - (vim.loop.now() - now)) < 10)
 
     -- 4. delay for 500ms and wait 100ms (remain 400ms)
@@ -32,9 +35,9 @@ describe('utils.async', function()
     now = vim.loop.now()
     f.timeout = 100
     f()
-    vim.wait(1000, function() return count == 3 end)
+    vim.wait(1000, function()
+      return count == 3
+    end)
     assert.is.truthy(math.abs(vim.loop.now() - now) < 10)
   end)
-
 end)
-

--- a/lua/cmp/utils/cache.lua
+++ b/lua/cmp/utils/cache.lua
@@ -54,4 +54,3 @@ cache.key = function(_, key)
 end
 
 return cache
-

--- a/lua/cmp/utils/char.lua
+++ b/lua/cmp/utils/char.lua
@@ -110,4 +110,3 @@ char.match = function(byte1, byte2)
 end
 
 return char
-

--- a/lua/cmp/utils/keymap.lua
+++ b/lua/cmp/utils/keymap.lua
@@ -26,7 +26,7 @@ keymap.escape = function(keys)
   while i <= #keys do
     if string.sub(keys, i, i) == '<' then
       if not vim.tbl_contains({ '<lt>', '<Lt>', '<lT>', '<LT>' }, string.sub(keys, i, i + 3)) then
-        keys = string.sub(keys, 1, i -1) .. '<LT>' ..  string.sub(keys, i + 1)
+        keys = string.sub(keys, 1, i - 1) .. '<LT>' .. string.sub(keys, i + 1)
         i = i + 3
       end
     end
@@ -80,7 +80,7 @@ end
 
 ---Feedkeys with callback
 keymap.feedkeys = setmetatable({
-  callbacks = {}
+  callbacks = {},
 }, {
   __call = function(self, keys, mode, callback)
     if #keys ~= 0 then
@@ -104,7 +104,7 @@ keymap.feedkeys = setmetatable({
         wait()
       end
     end
-  end
+  end,
 })
 misc.set(_G, { 'cmp', 'utils', 'keymap', 'feedkeys', 'run' }, function(id)
   if keymap.feedkeys.callbacks[id] then
@@ -201,4 +201,3 @@ misc.set(_G, { 'cmp', 'utils', 'keymap', 'listen', 'run' }, function(mode, keys)
 end)
 
 return keymap
-

--- a/lua/cmp/utils/misc.lua
+++ b/lua/cmp/utils/misc.lua
@@ -21,8 +21,8 @@ end
 ---@param v2 T
 ---@return T
 misc.merge = function(v1, v2)
-  local merge1 = type(v1) == "table" and (not vim.tbl_islist(v1) or vim.tbl_isempty(v1))
-  local merge2 = type(v2) == "table" and (not vim.tbl_islist(v1) or vim.tbl_isempty(v1))
+  local merge1 = type(v1) == 'table' and (not vim.tbl_islist(v1) or vim.tbl_isempty(v1))
+  local merge2 = type(v2) == 'table' and (not vim.tbl_islist(v1) or vim.tbl_isempty(v1))
   if merge1 and merge2 then
     local new_tbl = {}
     for k, v in pairs(v2) do
@@ -48,16 +48,15 @@ misc.merge = function(v1, v2)
   return v1
 end
 
-
 ---Generate id for group name
 misc.id = setmetatable({
-  group = {}
+  group = {},
 }, {
   __call = function(_, group)
     misc.id.group[group] = misc.id.group[group] or 0
     misc.id.group[group] = misc.id.group[group] + 1
     return misc.id.group[group]
-  end
+  end,
 })
 
 ---Check the value is nil or not.

--- a/lua/cmp/utils/misc_spec.lua
+++ b/lua/cmp/utils/misc_spec.lua
@@ -8,21 +8,20 @@ describe('misc', function()
   it('merge', function()
     local merged
     merged = misc.merge({
-      a = {}
+      a = {},
     }, {
       a = {
-        b = 1
-      }
+        b = 1,
+      },
     })
     assert.are.equal(merged.a.b, 1)
     merged = misc.merge({
-      a = false
+      a = false,
     }, {
       a = {
-        b = 1
-      }
+        b = 1,
+      },
     })
     assert.are.equal(merged.a, false)
   end)
 end)
-

--- a/lua/cmp/utils/pattern.lua
+++ b/lua/cmp/utils/pattern.lua
@@ -26,4 +26,3 @@ pattern.matchstr = function(p, text)
 end
 
 return pattern
-

--- a/lua/cmp/utils/spec.lua
+++ b/lua/cmp/utils/spec.lua
@@ -1,15 +1,15 @@
-local context = require'cmp.context'
-local source  = require 'cmp.source'
+local context = require('cmp.context')
+local source = require('cmp.source')
 local types = require('cmp.types')
 
 local spec = {}
 
 spec.before = function()
-  vim.cmd [[
+  vim.cmd([[
     bdelete!
     enew!
     setlocal virtualedit=all
-  ]]
+  ]])
 end
 
 spec.state = function(text, row, col)
@@ -17,8 +17,7 @@ spec.state = function(text, row, col)
   vim.fn.cursor(row, col)
   local ctx = context.empty()
   local s = source.new('spec', {
-    complete = function()
-    end
+    complete = function() end,
   })
   return {
     context = function()
@@ -46,9 +45,8 @@ spec.state = function(text, row, col)
       ctx = context.new(ctx, { reason = types.cmp.ContextReason.Manual })
       s:complete(ctx, function() end)
       return ctx
-    end
+    end,
   }
 end
 
 return spec
-

--- a/lua/cmp/utils/str.lua
+++ b/lua/cmp/utils/str.lua
@@ -1,5 +1,5 @@
-local char = require'cmp.utils.char'
-local pattern = require 'cmp.utils.pattern'
+local char = require('cmp.utils.char')
+local pattern = require('cmp.utils.pattern')
 
 local str = {}
 
@@ -179,4 +179,3 @@ str.escape = function(text, chars)
 end
 
 return str
-

--- a/lua/cmp/utils/str_spec.lua
+++ b/lua/cmp/utils/str_spec.lua
@@ -1,7 +1,6 @@
-local str = require "cmp.utils.str"
+local str = require('cmp.utils.str')
 
 describe('utils.str', function()
-
   it('get_word', function()
     assert.are.equal(str.get_word('print'), 'print')
     assert.are.equal(str.get_word('$variable'), '$variable')
@@ -27,7 +26,4 @@ describe('utils.str', function()
     assert.are.equal(str.escape('plain\\"', {}), 'plain\\\\"')
     assert.are.equal(str.escape('pla"in', { '"' }), 'pla\\"in')
   end)
-
 end)
-
-


### PR DESCRIPTION
Fixed StyLua's glob pattern to be enabled.
[Needed to be enclosed in quotation marks, as in `--glob 'lua/**/*.lua'`.](https://github.com/JohnnyMorganz/StyLua#glob-filtering)

The style has also been fixed.