### PR TITLE
Experimental: Active preview

### DIFF
--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -19,7 +19,6 @@ return function()
       get_trigger_characters = function(trigger_characters)
         return trigger_characters
       end,
-      prepreview = false,
     },
 
     snippet = {
@@ -70,6 +69,7 @@ return function()
 
     experimental = {
       ghost_text = false,
+      active_preview = false,
     },
 
     sources = {},

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -19,6 +19,7 @@ return function()
       get_trigger_characters = function(trigger_characters)
         return trigger_characters
       end,
+      prepreview = false,
     },
 
     snippet = {

--- a/lua/cmp/menu.lua
+++ b/lua/cmp/menu.lua
@@ -32,6 +32,9 @@ menu.new = function(opts)
   self:reset()
   autocmd.subscribe('CompleteChanged', function()
     local e = self:get_selected_entry()
+    if not e and config.get().completion.prepreview then
+      e = self:get_first_entry()
+    end
     if e then
       self:select(e)
     else
@@ -40,6 +43,7 @@ menu.new = function(opts)
   end)
   return self
 end
+
 
 ---Close menu
 menu.close = function(self)
@@ -180,6 +184,10 @@ menu.select = function(self, e)
   e:resolve(self.resolve_dedup(vim.schedule_wrap(function()
     if self:get_selected_entry() == e then
       self.float:show(e)
+    elseif config.get().completion.prepreview then
+      if self:get_first_entry() == e then
+        self.float:show(e)
+      end
     end
   end)))
 
@@ -208,11 +216,11 @@ menu.get_selected_entry = function(self)
   end
 
   local selected = vim.fn.complete_info({ 'selected' }).selected
-  if not config.get().completion.prepreview then
-    if selected == -1 then
-      return nil
-    end
+  if selected == -1 then
+    return nil
   end
+
+  -- end
   return self.deduped_entries[math.max(selected, 0) + 1]
 end
 

--- a/lua/cmp/menu.lua
+++ b/lua/cmp/menu.lua
@@ -32,7 +32,7 @@ menu.new = function(opts)
   self:reset()
   autocmd.subscribe('CompleteChanged', function()
     local e = self:get_selected_entry()
-    if not e and config.get().completion.prepreview then
+    if not e and config.get().experimental.active_preview then
       e = self:get_first_entry()
     end
     if e then
@@ -184,7 +184,7 @@ menu.select = function(self, e)
   e:resolve(self.resolve_dedup(vim.schedule_wrap(function()
     if self:get_selected_entry() == e then
       self.float:show(e)
-    elseif config.get().completion.prepreview then
+    elseif config.get().experimental.active_preview then
       if self:get_first_entry() == e then
         self.float:show(e)
       end

--- a/lua/cmp/menu.lua
+++ b/lua/cmp/menu.lua
@@ -208,8 +208,10 @@ menu.get_selected_entry = function(self)
   end
 
   local selected = vim.fn.complete_info({ 'selected' }).selected
-  if selected == -1 then
-    return nil
+  if not config.get().completion.prepreview then
+    if selected == -1 then
+      return nil
+    end
   end
   return self.deduped_entries[math.max(selected, 0) + 1]
 end

--- a/lua/cmp/menu.lua
+++ b/lua/cmp/menu.lua
@@ -44,7 +44,6 @@ menu.new = function(opts)
   return self
 end
 
-
 ---Close menu
 menu.close = function(self)
   vim.schedule(function()
@@ -219,8 +218,6 @@ menu.get_selected_entry = function(self)
   if selected == -1 then
     return nil
   end
-
-  -- end
   return self.deduped_entries[math.max(selected, 0) + 1]
 end
 

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -66,7 +66,6 @@ cmp.PreselectMode.None = 'none'
 ---@field public keyword_pattern string
 ---@field public keyword_length number
 ---@field public get_trigger_characters fun(trigger_characters: string[]): string[]
----@field public prepreview boolean
 
 ---@class cmp.DocumentationConfig
 ---@field public border string[]
@@ -94,6 +93,7 @@ cmp.PreselectMode.None = 'none'
 
 ---@class cmp.ExperimentalConfig
 ---@field public ghost_text cmp.GhostTextConfig|"false"
+---@field public active_preview boolean
 
 ---@class cmp.GhostTextConfig
 ---@field hl_group string

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -63,6 +63,7 @@ cmp.PreselectMode.None = 'none'
 ---@class cmp.CompletionConfig
 ---@field public autocomplete cmp.TriggerEvent[]
 ---@field public completeopt string
+---@field public prepreview boolean
 ---@field public keyword_pattern string
 ---@field public keyword_length number
 ---@field public get_trigger_characters fun(trigger_characters: string[]): string[]

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -63,10 +63,10 @@ cmp.PreselectMode.None = 'none'
 ---@class cmp.CompletionConfig
 ---@field public autocomplete cmp.TriggerEvent[]
 ---@field public completeopt string
----@field public prepreview boolean
 ---@field public keyword_pattern string
 ---@field public keyword_length number
 ---@field public get_trigger_characters fun(trigger_characters: string[]): string[]
+---@field public prepreview boolean
 
 ---@class cmp.DocumentationConfig
 ---@field public border string[]


### PR DESCRIPTION
This PR adds the ability to show the first candidate's preview as ~~inline~~ if it were selected.

This is still a much experimental feature. I think we should remove this feature after VSCode's ~~ghost text~~ active preview feature ships to LSP spec.

Honestly though, this is a pretty useful feature to have when using `noselect` in completeopts

Note: this method works without interfering with the get_selected_entry call

https://user-images.githubusercontent.com/48777455/133379793-cc80637c-a4e4-424b-919b-16b4e77e1fd6.mp4

