### PR TITLE
Fix: bad function usage in README for UltiSnips expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ lua <<EOF
         -- require('luasnip').lsp_expand(args.body)
 
         -- For `ultisnips` user.
-        -- vim.fn["vsnip#anonymous"](args.body)
+        -- vim.fn["UtiliSnips#Anon"](args.body)
       end,
     },
     mapping = {


### PR DESCRIPTION
This commit fixes an issue with using vsnip#anonymous in the snippet expand function for Ultisnip
The main issue, is that when using `vsnip#anonymous` instead of `UltiSnip#Anon` when calling the `cmp.mapping.confirm` map on a non-snippet option would "crash" cmp, ceasing its normal functionality. Using `UltiSnps#Anon` fixes this issue.