### PR TITLE
Improvement idea: option to disables insert on select item

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,12 @@ Specify whether to display ghost text.
 
 Default: `false`
 
+#### experimental.disables_insert_on_selection (type: boolean)
+
+Disables insertion on `select_prev_item()` and `select_next_item()`
+if `experimental.ghost_text` is set to `true` it would refresh the ghost text on next/prev item if this is setted to true
+
+Default: `false`
 
 Commands
 ====================

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ If you want to remove an option, you can set it to `false` instead.
 
 Built in helper `cmd.mappings` are:
 
-- *cmp.mapping.select_prev_item({ disable_insert_on_selection = boolean })*
-- *cmp.mapping.select_next_item({ disable_insert_on_selection = boolean })*
+- *cmp.mapping.select_prev_item({ cmp.SelectBehavior.{Insert,Select} } })*
+- *cmp.mapping.select_next_item({ cmp.SelectBehavior.{Insert,Select} })*
 - *cmp.mapping.scroll_docs(number)*
 - *cmp.mapping.complete()*
 - *cmp.mapping.close()*
@@ -291,6 +291,12 @@ Default: `menu,menuone,noselect`
 A default `cmp.ConfirmBehavior` value when to use confirmed by commitCharacters
 
 Default: `cmp.ConfirmBehavior.Insert`
+
+#### selection.default_behavior (type: cmp.SelectBehavior)
+
+A default `cmp.SelectBehavior` value to use when selecting a menu value
+
+Default: `cmp.SelectBehavior.Insert`
 
 #### confirmation.get_commit_characters (type: fun(commit_characters: string[]): string[])
 
@@ -454,11 +460,11 @@ Close current completion menu.
 
 Close current completion menu and restore current line (similar to native `<C-e>` behavior).
 
-#### `cmp.select_next_item({ disable_insert_on_selection = boolean })`
+#### `cmp.select_next_item({ cmp.SelectBehavior.{Insert,Select} })`
 
 Select next completion item if possible.
 
-#### `cmp.select_prev_item({ disable_insert_on_selection = boolean })`
+#### `cmp.select_prev_item({ cmp.SelectBehavior.{Insert,Select} })`
 
 Select prev completion item if possible.
 
@@ -527,21 +533,37 @@ autocmd FileType TelescopePrompt lua require('cmp').setup.buffer { enabled = fal
 ```
 
 #### How to disable insert on select next/prev item
-You can change this behavior on the mapping.
+
+You can disable this changing the behavior to just select `cmp.SelectBehavior.Select` 
+
+passing the option on the mapping.
+
 ```lua
 cmp.setup {
   mapping = {
-    ["<C-p>"] = cmp.mapping.select_prev_item{ disables_insert_on_selection = true },
-    ["<C-n>"] = cmp.mapping.select_next_item{ disables_insert_on_selection = true },
+    ["<C-p>"] = cmp.mapping.select_prev_item{ behavior = cmp.SelectBehavior.Select },
+    ["<C-n>"] = cmp.mapping.select_next_item{ behavior = cmp.SelectBehavior.Select },
   },
 }
 ```
+
 Or when using the Programatic API.
+
 ```lua
-cmp.select_prev_item{ disables_insert_on_selection = true }
-cmp.select_next_item{ disables_insert_on_selection = true }
+cmp.select_prev_item{ behavior = cmp.SelectBehavior.Select },
+cmp.select_next_item{ behavior = cmp.SelectBehavior.Select },
 ```
 
+You may also change the selection default behavior
+
+```lua
+cmp.setup {
+  selection = {
+    default_behavior = cmp.SelectBehavior.Select,
+  },
+
+}
+```
 
 #### nvim-cmp is slow.
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ If you want to remove an option, you can set it to `false` instead.
 
 Built in helper `cmd.mappings` are:
 
-- *cmp.mapping.select_prev_item()*
-- *cmp.mapping.select_next_item()*
+- *cmp.mapping.select_prev_item({ disable_insert_on_selection = boolean })*
+- *cmp.mapping.select_next_item({ disable_insert_on_selection = boolean })*
 - *cmp.mapping.scroll_docs(number)*
 - *cmp.mapping.complete()*
 - *cmp.mapping.close()*
@@ -397,13 +397,6 @@ Specify whether to display ghost text.
 
 Default: `false`
 
-#### experimental.disables_insert_on_selection (type: boolean)
-
-Disables insertion on `select_prev_item()` and `select_next_item()`
-if `experimental.ghost_text` is set to `true` it would refresh the ghost text on next/prev item if this is setted to true
-
-Default: `false`
-
 Commands
 ====================
 
@@ -461,11 +454,11 @@ Close current completion menu.
 
 Close current completion menu and restore current line (similar to native `<C-e>` behavior).
 
-#### `cmp.select_next_item()`
+#### `cmp.select_next_item({ disable_insert_on_selection = boolean })`
 
 Select next completion item if possible.
 
-#### `cmp.select_prev_item()`
+#### `cmp.select_prev_item({ disable_insert_on_selection = boolean })`
 
 Select prev completion item if possible.
 

--- a/README.md
+++ b/README.md
@@ -526,6 +526,23 @@ You can specify `enabled = false` like this.
 autocmd FileType TelescopePrompt lua require('cmp').setup.buffer { enabled = false }
 ```
 
+#### How to disable insert on select next/prev item
+You can change this behavior on the mapping.
+```lua
+cmp.setup {
+  mapping = {
+    ["<C-p>"] = cmp.mapping.select_prev_item{ disables_insert_on_selection = true },
+    ["<C-n>"] = cmp.mapping.select_next_item{ disables_insert_on_selection = true },
+  },
+}
+```
+Or when using the Programatic API.
+```lua
+cmp.select_prev_item{ disables_insert_on_selection = true }
+cmp.select_next_item{ disables_insert_on_selection = true }
+```
+
+
 #### nvim-cmp is slow.
 
 I've optimized `nvim-cmp` as much as possible, but there are currently some known / unfixable issues.

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -43,6 +43,10 @@ return function()
       end,
     },
 
+    selection = {
+      default_behavior = types.cmp.SelectBehavior.Insert,
+    },
+
     sorting = {
       priority_weight = 2,
       comparators = {

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -69,6 +69,7 @@ return function()
     experimental = {
       custom_menu = true,
       ghost_text = false,
+      disables_insert_on_selection = false
     },
 
     sources = {},

--- a/lua/cmp/config/mapping.lua
+++ b/lua/cmp/config/mapping.lua
@@ -47,18 +47,18 @@ mapping.scroll_docs = function(delta)
 end
 
 ---Select next completion item.
-mapping.select_next_item = function()
+mapping.select_next_item = function(option)
   return function(fallback)
-    if not require('cmp').select_next_item() then
+    if not require('cmp').select_next_item(option) then
       fallback()
     end
   end
 end
 
 ---Select prev completion item.
-mapping.select_prev_item = function()
+mapping.select_prev_item = function(option)
   return function(fallback)
-    if not require('cmp').select_prev_item() then
+    if not require('cmp').select_prev_item(option) then
       fallback()
     end
   end

--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -72,9 +72,10 @@ cmp.abort = function()
 end
 
 ---Select next item if possible
-cmp.select_next_item = function()
+cmp.select_next_item = function(option)
+  option = option or {}
   if cmp.core.view:visible() then
-    cmp.core.view:select_next_item()
+    cmp.core.view:select_next_item(option)
     cmp.core:get_context()
     return true
   else
@@ -83,9 +84,10 @@ cmp.select_next_item = function()
 end
 
 ---Select prev item if possible
-cmp.select_prev_item = function()
+cmp.select_prev_item = function(option)
+  option = option or {}
   if cmp.core.view:visible() then
-    cmp.core.view:select_prev_item()
+    cmp.core.view:select_prev_item(option)
     cmp.core:get_context()
     return true
   else

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -5,6 +5,11 @@ cmp.ConfirmBehavior = {}
 cmp.ConfirmBehavior.Insert = 'insert'
 cmp.ConfirmBehavior.Replace = 'replace'
 
+---@alias cmp.SelectBehavior "'insert'" | "'select'"
+cmp.SelectBehavior = {}
+cmp.SelectBehavior.Insert = 'insert'
+cmp.SelectBehavior.Select = 'select'
+
 ---@alias cmp.ContextReason "'auto'" | "'manual'" | "'none'"
 cmp.ContextReason = {}
 cmp.ContextReason.Auto = 'auto'
@@ -27,6 +32,9 @@ cmp.PreselectMode.None = 'none'
 
 ---@class cmp.ConfirmOption
 ---@field public behavior cmp.ConfirmBehavior
+
+---@class cmp.SelectOption
+---@field public behavior cmp.SelectBehavior
 
 ---@class cmp.SnippetExpansionParams
 ---@field public body string
@@ -52,6 +60,7 @@ cmp.PreselectMode.None = 'none'
 ---@field public completion cmp.CompletionConfig
 ---@field public documentation cmp.DocumentationConfig|"false"
 ---@field public confirmation cmp.ConfirmationConfig
+---@field public selection cmp.SelectionConfig
 ---@field public sorting cmp.SortingConfig
 ---@field public formatting cmp.FormattingConfig
 ---@field public snippet cmp.SnippetConfig
@@ -76,6 +85,9 @@ cmp.PreselectMode.None = 'none'
 ---@class cmp.ConfirmationConfig
 ---@field public default_behavior cmp.ConfirmBehavior
 ---@field public get_commit_characters fun(commit_characters: string[]): string[]
+
+---@class cmp.SelectionConfig
+---@field public default_behavior cmp.SelectBehavior
 
 ---@class cmp.SortingConfig
 ---@field public priority_weight number

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -93,8 +93,10 @@ cmp.PreselectMode.None = 'none'
 ---@class cmp.ExperimentalConfig
 ---@field public custom_menu boolean
 ---@field public ghost_text cmp.GhostTextConfig|"false"
+---@field public disables_insert_on_selection cmp.DisablesInsertOnSelectionConfig|"false"
 
 ---@class cmp.GhostTextConfig
+---@class cmp.DisablesInsertOnSelectionConfig
 ---@field hl_group string
 
 ---@class cmp.SourceConfig

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -93,10 +93,8 @@ cmp.PreselectMode.None = 'none'
 ---@class cmp.ExperimentalConfig
 ---@field public custom_menu boolean
 ---@field public ghost_text cmp.GhostTextConfig|"false"
----@field public disables_insert_on_selection cmp.DisablesInsertOnSelectionConfig|"false"
 
 ---@class cmp.GhostTextConfig
----@class cmp.DisablesInsertOnSelectionConfig
 ---@field hl_group string
 
 ---@class cmp.SourceConfig

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -114,12 +114,12 @@ view.scroll_docs = function(self, delta)
   self.docs_view:scroll(delta)
 end
 
-view.select_next_item = function(self)
-  self:get_entries_view():select_next_item()
+view.select_next_item = function(self, option)
+  self:get_entries_view():select_next_item(option)
 end
 
-view.select_prev_item = function(self)
-  self:get_entries_view():select_prev_item()
+view.select_prev_item = function(self, option)
+  self:get_entries_view():select_prev_item(option)
 end
 
 ---Get first entry

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -1,3 +1,4 @@
+local config = require('cmp.config')
 local event = require('cmp.utils.event')
 local window = require('cmp.utils.window')
 local ghost_text_view = require('cmp.view.ghost_text_view')
@@ -175,42 +176,63 @@ end
 custom_entries_view.select_next_item = function(self)
   if self.entries_win:visible() then
     local cursor = vim.api.nvim_win_get_cursor(self.entries_win.win)[1]
-    local e
+    local word = self.prefix
+    local entry
     if not self.entries_win:option('cursorline') then
       self.prefix = string.sub(vim.api.nvim_get_current_line(), self.offset, vim.api.nvim_win_get_cursor(0)[2])
       self.entries_win:option('cursorline', true)
       vim.api.nvim_win_set_cursor(self.entries_win.win, { 1, 0 })
-      e = self.entries[1]
+      word = self.entries[1]:get_word()
+      entry = self.entries[1]
     elseif cursor == #self.entries then
       self.entries_win:option('cursorline', false)
       vim.api.nvim_win_set_cursor(self.entries_win.win, { 1, 0 })
     else
       self.entries_win:option('cursorline', true)
       vim.api.nvim_win_set_cursor(self.entries_win.win, { cursor + 1, 0 })
-      e = self.entries[cursor + 1]
+      word = self.entries[cursor + 1]:get_word()
+      entry = self.entries[cursor + 1]
     end
-    self.ghost_text_view:show(e or self:get_first_entry())
+
+    local c = config.get().experimental.disables_insert_on_selection
+    if c then
+        self.ghost_text_view:show(entry or self:get_first_entry())
+    else
+        self:insert(word)
+        self.entries_win:update()
+        self.event:emit('change')
+    end
   end
 end
 
 custom_entries_view.select_prev_item = function(self)
   if self.entries_win:visible() then
     local cursor = vim.api.nvim_win_get_cursor(self.entries_win.win)[1]
-    local e
+    local word = self.prefix
+    local entry
     if not self.entries_win:option('cursorline') then
       self.prefix = string.sub(vim.api.nvim_get_current_line(), self.offset, vim.api.nvim_win_get_cursor(0)[2])
       self.entries_win:option('cursorline', true)
       vim.api.nvim_win_set_cursor(self.entries_win.win, { #self.entries, 0 })
-      e = self.entries[#self.entries]
+      word = self.entries[#self.entries]:get_word()
+      entry = self.entries[#self.entries]
     elseif cursor == 1 then
       self.entries_win:option('cursorline', false)
       vim.api.nvim_win_set_cursor(self.entries_win.win, { 1, 0 })
     else
       self.entries_win:option('cursorline', true)
       vim.api.nvim_win_set_cursor(self.entries_win.win, { cursor - 1, 0 })
-      e = self.entries[cursor - 1]
+      word = self.entries[cursor - 1]:get_word()
+      entry = self.entries[cursor - 1]
     end
-    self.ghost_text_view:show(e or self:get_first_entry())
+    local c = config.get().experimental.disables_insert_on_selection
+    if c then
+        self.ghost_text_view:show(entry or self:get_first_entry())
+    else
+        self:insert(word)
+        self.entries_win:update()
+        self.event:emit('change')
+    end
   end
 end
 

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -1,4 +1,3 @@
-local config = require('cmp.config')
 local event = require('cmp.utils.event')
 local window = require('cmp.utils.window')
 local ghost_text_view = require('cmp.view.ghost_text_view')
@@ -140,7 +139,7 @@ custom_entries_view.open = function(self, offset, entries)
       col = vim.fn.screencol() - 1 - delta - 1,
       width = width,
       height = height,
-      zindex = 1001
+      zindex = 1001,
     })
     vim.api.nvim_win_set_cursor(self.entries_win.win, { 1, 0 })
     self.entries_win:option('cursorline', false)
@@ -173,7 +172,7 @@ custom_entries_view.preselect = function(self, idx)
   end
 end
 
-custom_entries_view.select_next_item = function(self)
+custom_entries_view.select_next_item = function(self, option)
   if self.entries_win:visible() then
     local cursor = vim.api.nvim_win_get_cursor(self.entries_win.win)[1]
     local word = self.prefix
@@ -194,18 +193,17 @@ custom_entries_view.select_next_item = function(self)
       entry = self.entries[cursor + 1]
     end
 
-    local c = config.get().experimental.disables_insert_on_selection
-    if c then
-        self.ghost_text_view:show(entry or self:get_first_entry())
+    if option.disables_insert_on_selection then
+      self.ghost_text_view:show(entry or self:get_first_entry())
     else
-        self:insert(word)
-        self.entries_win:update()
-        self.event:emit('change')
+      self:_insert(word)
     end
+    self.entries_win:update()
+    self.event:emit('change')
   end
 end
 
-custom_entries_view.select_prev_item = function(self)
+custom_entries_view.select_prev_item = function(self, option)
   if self.entries_win:visible() then
     local cursor = vim.api.nvim_win_get_cursor(self.entries_win.win)[1]
     local word = self.prefix
@@ -225,14 +223,13 @@ custom_entries_view.select_prev_item = function(self)
       word = self.entries[cursor - 1]:get_word()
       entry = self.entries[cursor - 1]
     end
-    local c = config.get().experimental.disables_insert_on_selection
-    if c then
-        self.ghost_text_view:show(entry or self:get_first_entry())
+    if option.disables_insert_on_selection then
+      self.ghost_text_view:show(entry or self:get_first_entry())
     else
-        self:insert(word)
-        self.entries_win:update()
-        self.event:emit('change')
+      self:_insert(word)
     end
+    self.entries_win:update()
+    self.event:emit('change')
   end
 end
 


### PR DESCRIPTION
Following up on this https://github.com/hrsh7th/nvim-cmp/pull/224#issuecomment-925111914 I started to check the code, and it might make sense to insert on each selection, this might be a design choice, but this would add a configuration option that disables this behavior, making the `select_prev_item()` and  `selec_next_item()`  just move through the menu without inserting until `confirm()` is called.

these are some examples with the config combination

```
  mapping = {
    ["<C-p>"] = cmp.mapping.select_prev_item{behavior = cmp.SelectBehavior.Select},
    ["<C-n>"] = cmp.mapping.select_next_item{behavior = cmp.SelectBehavior.Select},
  },
  experimental = {
    ghost_text = true,
  },

```

https://user-images.githubusercontent.com/18682359/134438815-d2914d1a-ce66-4137-b14d-73bf7ac514ba.mov

```
  mapping = {
    ["<C-p>"] = cmp.mapping.select_prev_item{behavior = cmp.SelectBehavior.Select},
    ["<C-n>"] = cmp.mapping.select_next_item{behavior = cmp.SelectBehavior.Select},
  },
  experimental = {
    ghost_text = false,
  },
```

https://user-images.githubusercontent.com/18682359/134438970-f40bdb6b-8aef-414a-a34f-9a2f739ae31c.mov

Both flags in false, or not changing anything (the default config) would result in the current behavior.

Let me know if this idea makes sense to you,  and if there are some required changes here :) 


