### PR TITLE
Check whether option exists

### DIFF
--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -45,6 +45,10 @@ end
 ---@param key string
 ---@param value any
 window.option = function(self, key, value)
+  if vim.fn.exists('+' .. key) == 0 then
+    return
+  end
+
   if value == nil then
     return self.opt[key]
   end


### PR DESCRIPTION
This PR fixes an issue where an error occurs when the `cursorlineopt` option doesn't exist (https://github.com/hrsh7th/nvim-cmp/pull/295#issuecomment-939233273).

I forgot that `cursorlineopt` only exists in Neovim nightly. Sorry!