### PR TITLE
adding the pumblend property to floating pum window

### DIFF
--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -14,7 +14,6 @@ local misc = require('cmp.utils.misc')
 ---@field private column_width any
 ---@field public event cmp.Event
 local custom_entries_view = {}
-local blend = vim.opt.pumblend:get()
 
 custom_entries_view.ns = vim.api.nvim_create_namespace('cmp.view.custom_entries_view')
 
@@ -27,7 +26,7 @@ custom_entries_view.new = function()
   self.entries_win:option('foldenable', false)
   self.entries_win:option('wrap', false)
   self.entries_win:option('scrolloff', 0)
-  self.entries_win:option('winblend', blend)
+  self.entries_win:option('winblend', vim.opt.pumblend:get())
   self.entries_win:option('winhighlight', 'Normal:Pmenu,FloatBorder:Pmenu,CursorLine:PmenuSel,Search:None')
   self.event = event.new()
   self.offset = -1


### PR DESCRIPTION
setting the blend option for pum menu, by setting default blend to `vim.opt.pumblend:get()`