### PR TITLE
Remove experimental.cusom_menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,8 +405,6 @@ Invoke after nvim-cmp setup.
 Highlights
 ====================
 
-※ The following highlights are used only when enabling `experimental.cusom_menu = true`.
-
 #### `CmpItemAbbr`
 
 The abbr field.


### PR DESCRIPTION
If I understood correctly, now we only have the `experimental.native_menu`, which is disabled by default (e.g, the custom menu is used by default).

Also do we need to set `completeopt`? If no, we could remove `How to set up like nvim-compe's preselect = 'always'` section