### PR TITLE
Make the pum window property respect future changes of &pumblend

### DIFF
--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -26,7 +26,6 @@ custom_entries_view.new = function()
   self.entries_win:option('foldenable', false)
   self.entries_win:option('wrap', false)
   self.entries_win:option('scrolloff', 0)
-  self.entries_win:option('winblend', vim.opt.pumblend:get())
   self.entries_win:option('winhighlight', 'Normal:Pmenu,FloatBorder:Pmenu,CursorLine:PmenuSel,Search:None')
   self.event = event.new()
   self.offset = -1
@@ -94,6 +93,9 @@ custom_entries_view.open = function(self, offset, entries)
   self.entries = {}
   self.column_bytes = { abbr = 0, kind = 0, menu = 0 }
   self.column_width = { abbr = 0, kind = 0, menu = 0 }
+
+  -- Apply window options (that might be changed) on the custom completion menu.
+  self.entries_win:option('winblend', vim.opt.pumblend:get())
 
   local lines = {}
   local dedup = {}


### PR DESCRIPTION
PR #310 added a support for the pumblend property for the custom
floating completion pop-up menu, but the winblend option is set
globally which doesn't respect future changes (e.g., `set pumblend=..`).

Such window options for the pop-up window that might be changed later
would need to be set when the floating window is being opened.

/cc @tamton-aquib (the author of #310)