### PR TITLE
Allow disabling default keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ mapping = {
   ['<CR>'] = cmp.mapping.confirm({
     behavior = cmp.ConfirmBehavior.Replace,
     select = true,
-  })
+  }),
+  ['<C-c>'] = false, -- Override with `false` to disable mapping
 }
 ```
 

--- a/lua/cmp/utils/misc_spec.lua
+++ b/lua/cmp/utils/misc_spec.lua
@@ -66,5 +66,36 @@ describe('misc', function()
       assert.are.equal(merged.boo, false)
       assert.are.equal(merged.str, 'world')
     end)
+
+    it('deletes key when function is merged with false', function()
+      local placeholder = function() end
+
+      local merged = misc.merge({
+        mappings = {
+          k = false,
+        },
+        options = {
+          store = false,
+        },
+        new = {
+          value = false,
+        },
+      }, {
+        mappings = {
+          j = placeholder,
+          k = placeholder,
+        },
+        options = {
+          store = true,
+        },
+      })
+
+      -- Key is not in the new list anymore
+      assert.are.same(merged.mappings, { j = placeholder })
+
+      -- But non-functions are still here and set to false
+      assert.are.same(merged.options, { store = false })
+      assert.are.same(merged.new, { value = false })
+    end)
   end)
 end)


### PR DESCRIPTION
I have an insert mode keybind on `<C-c><C-c>`, which conflicts with the default `<C-c>` keybinding in `nvim-cmp` in such a way to cause Neovim to get stuck in an infinite loop and using up 100% CPU until I kill the process as soon as I press `<C-c>`.

…but that's a different issue for a different day.
There does not seem to be a way for me to disable this keybind currently, which is what I intend to address here.

Trying to configure it to `nil` does not work, as Lua cannot tell the difference between the key not being set and the key being set to `nil`.

The README mentions that you can get rid of entire tables by setting the value to `false`, but here I only want to remove a single table value and not the entire table. Setting the mapping to `false` causes an error to happen on every keypress instead since the keypress logic assumes all mappings are functions.

Setting the key to a placeholder function that just calls `fallback` (`function(fallback) fallback() end`) also does not work as it still triggers the bug for me.

This MR extends `utils.misc.merge` with this feature:
- When base value is a function and the override is `false`, then the key is removed instead.

I understand that this is a very weird way to go about it. This is my initial suggestion with the least amount of changes needed, but I have some other alternatives that we could consider:

* **Alternative 1:** We introduce our own sentinel value, like `cmp.remove_key` that you assign it to.
* **Alternative 2:** In the system using `mappings`, filter out all non-functions before using it.

I hope this can open us up for a bit of discussion on how to solve this particular thing. I personally prefer **Alternative 1** to the solution in this PR.

I added some more tests to the `merge` function before I remade it. I might have missed some feature of it, so please check my work here.