### PR TITLE
feature: add underline compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Default:
   cmp.config.compare.offset,
   cmp.config.compare.exact,
   cmp.config.compare.score,
+  cmp.config.compare.under,
   cmp.config.compare.kind,
   cmp.config.compare.sort_text,
   cmp.config.compare.length,

--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -84,4 +84,23 @@ compare.order = function(entry1, entry2)
   end
 end
 
+compare.under = function(entry1, entry2)
+  local entry1_under = vim.startswith(entry1.completion_item.label, '_')
+  local entry2_under = vim.startswith(entry2.completion_item.label, '_')
+  if entry1_under and not entry2_under then
+    return false
+  elseif not entry1_under and entry2_under then
+    return true
+  end
+  if entry1_under and entry2_under then
+    local entry1_dunder = vim.startswith(entry1.completion_item.label, '__')
+    local entry2_dunder = vim.startswith(entry2.completion_item.label, '__')
+    if entry1_dunder and not entry2_dunder then
+      return false
+    elseif not entry1_dunder and entry2_dunder then
+      return true
+    end
+  end
+end
+
 return compare

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -61,6 +61,10 @@ return function()
           if diff ~= nil then
             return diff
           end
+          diff = compare.under(e1, e2)
+          if diff ~= nil then
+            return diff
+          end
           diff = compare.kind(e1, e2)
           if diff ~= nil then
             return diff


### PR DESCRIPTION
Most languages use `_` and `__` to indicate private variables.
These should score lower when completing.