### PR TITLE
Respect completeopt's `noselect` in custom menu

### DIFF
--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -162,7 +162,7 @@ custom_entries_view.open = function(self, offset, entries)
 
   if preselect > 0 and config.get().preselect == types.cmp.PreselectMode.Item then
     self:preselect(preselect)
-  elseif string.match(config.get().completion.completeopt, 'noinsert') then
+  elseif not string.match(config.get().completion.completeopt, 'noselect') then
     self:preselect(1)
   else
     self:draw()


### PR DESCRIPTION
From NeoVim's `completeopt` documentation:

> noselect  Do not select a match in the menu, force the user to
>           select one from the menu. Only works in combination with
>           "menu" or "menuone".

When `completeopt = "menu,menuone,noselect"` is used, custom completion
menu does not respect `noselect` and preselects the first item. No
preselection happens in case of native menu.

This patch addresses the bug and ensures that in case of custom menu no
items are preselected if `noselect` is specified in `completeopt`.

Fixes #332