### PR TITLE
Add `cmp.event:on` as public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,10 +414,6 @@ cmp.setup {
 }
 ```
 
-#### event.on_confirm_done (type: fun(entry: cmp.Entry))
-
-A callback function called when the item is confirmed.
-
 #### experimental.native_menu (type: boolean)
 
 Use vim's native completion menu instead of custom floating menu.
@@ -475,6 +471,12 @@ Programatic API
 ====================
 
 You can use the following APIs.
+
+#### `cmp.event:on(name: string, callback: string)`
+
+Subscribe the following events.
+
+- `confirm_done`
 
 #### `cmp.visible()`
 

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -99,6 +99,32 @@ return function()
           fallback()
         end,
       }),
+      ['<Tab>'] = mapping({
+        c = function(fallback)
+          local c = require('cmp.config')
+          local cmp = require('cmp')
+          if cmp.visible() then
+            cmp.select_next_item()
+          elseif not c.get().experimental.native_menu then
+            cmp.complete()
+          else
+            fallback()
+          end
+        end
+      }),
+      ['<S-Tab>'] = mapping({
+        c = function(fallback)
+          local c = require('cmp.config')
+          local cmp = require('cmp')
+          if cmp.visible() then
+            cmp.select_prev_item()
+          elseif not c.get().experimental.native_menu then
+            cmp.complete()
+          else
+            fallback()
+          end
+        end
+      }),
       ['<C-n>'] = mapping(mapping.select_next_item({ behavior = types.cmp.SelectBehavior.Insert }), { 'i', 'c' }),
       ['<C-p>'] = mapping(mapping.select_prev_item({ behavior = types.cmp.SelectBehavior.Insert }), { 'i', 'c' }),
       ['<C-y>'] = mapping.confirm({ select = false }),

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -10,6 +10,7 @@ local misc = require('cmp.utils.misc')
 local config = require('cmp.config')
 local types = require('cmp.types')
 local api = require('cmp.utils.api')
+local event = require('cmp.utils.event')
 
 local SOURCE_TIMEOUT = 500
 local THROTTLE_TIME = 120
@@ -21,6 +22,7 @@ local DEBOUNCE_TIME = 20
 ---@field public sources cmp.Source[]
 ---@field public sources_by_name table<string, cmp.Source>
 ---@field public context cmp.Context
+---@field public event cmp.Event
 local core = {}
 
 core.new = function()
@@ -29,6 +31,7 @@ core.new = function()
   self.sources = {}
   self.sources_by_name = {}
   self.context = context.new()
+  self.event = event.new()
   self.view = view.new()
   self.view.event:on('keymap', function(...)
     self:on_keymap(...)
@@ -398,7 +401,8 @@ core.confirm = function(self, e, option, callback)
         end
         e:execute(vim.schedule_wrap(function()
           release()
-
+          self.event:emit('confirm_done', e)
+          --For backward compatibility
           if config.get().event.on_confirm_done then
             config.get().event.on_confirm_done(e)
           end

--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -22,6 +22,9 @@ cmp.config.disable = misc.none
 cmp.config.compare = require('cmp.config.compare')
 cmp.config.sources = require('cmp.config.sources')
 
+---Expose event
+cmp.event = cmp.core.event
+
 ---Export mapping
 cmp.mapping = require('cmp.config.mapping')
 

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -69,7 +69,6 @@ cmp.ItemField.Menu = 'menu'
 ---@field public sorting cmp.SortingConfig
 ---@field public formatting cmp.FormattingConfig
 ---@field public snippet cmp.SnippetConfig
----@field public event cmp.EventConfig
 ---@field public mapping table<string, fun(core: cmp.Core, fallback: function)>
 ---@field public sources cmp.SourceConfig[]
 ---@field public experimental cmp.ExperimentalConfig
@@ -102,9 +101,6 @@ cmp.ItemField.Menu = 'menu'
 
 ---@class cmp.SnippetConfig
 ---@field public expand fun(args: cmp.SnippetExpansionParams)
-
----@class cmp.EventConfig
----@field on_confirm_done function(e: cmp.Entry)
 
 ---@class cmp.ExperimentalConfig
 ---@field public native_menu boolean


### PR DESCRIPTION
This PR contains the breaking change that is removing `cmp.setup { event = ... }`

@windwp Could you update `nvim-autopairs` after merging this?