### PR TITLE
Add mappings for visual mode

### DIFF
--- a/lua/cmp/config/mapping.lua
+++ b/lua/cmp/config/mapping.lua
@@ -22,6 +22,8 @@ mapping = setmetatable({}, {
             return invoke.c(fallback)
           elseif api.is_select_mode() and invoke.s then
             return invoke.s(fallback)
+          elseif api.is_visual_mode() and invoke.x then
+            return invoke.x(fallback)
           else
             fallback()
           end

--- a/lua/cmp/utils/api.lua
+++ b/lua/cmp/utils/api.lua
@@ -23,6 +23,13 @@ api.is_select_mode = function()
   }, vim.api.nvim_get_mode().mode)
 end
 
+api.is_visual_mode = function()
+  return vim.tbl_contains({
+    'v',
+    'V',
+  }, vim.api.nvim_get_mode().mode)
+end
+
 api.is_suitable_mode = function()
   return api.is_insert_mode() or api.is_cmdline_mode()
 end


### PR DESCRIPTION
Mappings for visual mode are useful, for example, in snippets.
[Here](http://vimcasts.org/episodes/ultisnips-visual-placeholder/) is the vimcast which shows how it can be used.