### PR TITLE
README: clarify that a snippet plugin is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ lua <<EOF
 
   cmp.setup({
     snippet = {
-      -- REQUIRED - you must specify at least snippet plugin
+      -- REQUIRED - you must specify a snippet engine
       expand = function(args)
         vim.fn["vsnip#anonymous"](args.body) -- For `vsnip` users.
         -- require('luasnip').lsp_expand(args.body) -- For `luasnip` users.
@@ -574,12 +574,12 @@ cmp.setup {
 
 #### I don't use a snippet plugin.
 
-At the moment, nvim-cmp requires a snippet plugin to function correctly.
-You need to specify one in `snippet`:
+At the moment, nvim-cmp requires a snippet engine to function correctly.
+You need to specify one in `snippet`.
 
 ```lua
 snippet = {
-  -- REQUIRED - you must specify at least snippet plugin
+  -- REQUIRED - you must specify at least snippet engine
   expand = function(args)
     vim.fn["vsnip#anonymous"](args.body) -- For `vsnip` users.
     -- require('luasnip').lsp_expand(args.body) -- For `luasnip` users.

--- a/README.md
+++ b/README.md
@@ -572,6 +572,23 @@ cmp.setup {
 }
 ```
 
+#### I don't use a snippet plugin.
+
+At the moment, nvim-cmp requires a snippet plugin to function correctly.
+You need to specify one in `snippet`:
+
+```lua
+snippet = {
+  -- REQUIRED - you must specify at least snippet plugin
+  expand = function(args)
+    vim.fn["vsnip#anonymous"](args.body) -- For `vsnip` users.
+    -- require('luasnip').lsp_expand(args.body) -- For `luasnip` users.
+    -- vim.fn["UltiSnips#Anon"](args.body) -- For `ultisnips` users.
+    -- require'snippy'.expand_snippet(args.body) -- For `snippy` users.
+  end,
+}
+```
+
 
 #### I dislike auto-completion
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ lua <<EOF
 
   cmp.setup({
     snippet = {
+      -- REQUIRED - you must specify at least snippet plugin
       expand = function(args)
         vim.fn["vsnip#anonymous"](args.body) -- For `vsnip` users.
         -- require('luasnip').lsp_expand(args.body) -- For `luasnip` users.

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ You need to specify one in `snippet`.
 
 ```lua
 snippet = {
-  -- REQUIRED - you must specify at least snippet engine
+  -- REQUIRED - you must specify a snippet engine
   expand = function(args)
     vim.fn["vsnip#anonymous"](args.body) -- For `vsnip` users.
     -- require('luasnip').lsp_expand(args.body) -- For `luasnip` users.


### PR DESCRIPTION
I don't use a snippet plugin normally and I was running to issues with autocompletion until I came across [this comment](https://github.com/hrsh7th/nvim-cmp/issues/274#issuecomment-939500416).

Therefore, I think it's best to clearly document that a snippet engine is required at the moment. Adds comment to suggested sample and the FAQ.