### PR TITLE
misc.merge: ensure that `misc.none` is never returned

### DIFF
--- a/lua/cmp/utils/misc.lua
+++ b/lua/cmp/utils/misc.lua
@@ -46,7 +46,7 @@ misc.merge = function(v1, v2)
       new_tbl[k] = misc.merge(v1[k], v)
     end
     for k, v in pairs(v1) do
-      if v2[k] == nil then
+      if v2[k] == nil and v ~= misc.none then
         new_tbl[k] = v
       end
     end
@@ -56,7 +56,11 @@ misc.merge = function(v1, v2)
     return nil
   end
   if v1 == nil then
-    return v2
+    if v2 == misc.none then
+      return nil
+    else
+      return v2
+    end
   end
   if v1 == true then
     if merge2 then

--- a/lua/cmp/utils/misc_spec.lua
+++ b/lua/cmp/utils/misc_spec.lua
@@ -33,5 +33,19 @@ describe('misc', function()
       },
     })
     assert.are.equal(merged.a, nil)
+
+    merged = misc.merge({
+      a = misc.none,
+    }, {
+      a = nil,
+    })
+    assert.are.equal(merged.a, nil)
+
+    merged = misc.merge({
+      a = nil,
+    }, {
+      a = misc.none,
+    })
+    assert.are.equal(merged.a, nil)
   end)
 end)


### PR DESCRIPTION
Before this change:

1. `misc.merge({a = misc.none}, {a = nil})` returned `{a = misc.none}`
2. `misc.merge({a = nil}, {a = misc.none})` returned `{a = misc.none}`

(1) can cause error if a non-existing mapping is set to `config.disable`
(which is an alias for `misc.none`).

(2) does not cause any issue to date, but is inconsistent with the
expected behavior of `misc.merge(…)`.

After this change:

1. `misc.merge({a = misc.none}, {a = nil})` returns `{a = nil}`
2. `misc.merge({a = nil}, {a = misc.none})` returns `{a = nil}`

Fixes #440.