### PR TITLE
feat: completion menu borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You can search for various completion sources [here](https://github.com/topics/n
 
 ### Where can I find the advanced configuration examples?
 
-Please see the corresponding [FAQ](#how-to-show-name-of-item-kind-and-source-like-compe) section or [Wiki pages](https://github.com/hrsh7th/nvim-cmp/wiki).
+Please see the corresponding [FAQ](#how-to-show-name-of-item-kind-and-source-like-compe) section, as well as the [`completion.border`](#completion.border) and [`completion.scrollbar`](#completion.scrollbar) options.
 
 
 Advanced configuration example

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -17,8 +17,6 @@ Config                                                              |cmp-config|
 Develop                                                            |cmp-develop|
 FAQ                                                                    |cmp-faq|
 
-
-
 ==============================================================================
 Abstract                                                          *cmp-abstract*
 
@@ -29,8 +27,6 @@ This is nvim-cmp's document.
 2. The advanced configuration is noted in wiki.
   - https://github.com/hrsh7th/nvim-cmp/wiki
 
-
-
 ==============================================================================
 Concept                                                            *cmp-concept*
 
@@ -39,8 +35,6 @@ Concept                                                            *cmp-concept*
 - Smart handling of key mapping
 - No flicker
 
-
-
 ==============================================================================
 Usage                                                                *cmp-usage*
 
@@ -48,7 +42,7 @@ The recommendation configurations are the below.
 
 NOTE:
   1. You must setup `snippet.expand` function.
-  2. The `cmp.setup.cmdline` won't work if you are using `native` completion menu. 
+  2. The `cmp.setup.cmdline` won't work if you are using `native` completion menu.
   3. You can disable the `default` options via specifying `cmp.config.disable` value.
 >
   call plug#begin(s:plug_dir)
@@ -138,7 +132,6 @@ NOTE:
     }
   EOF
 <
-
 
 ==============================================================================
 Function                                                          *cmp-function*
@@ -231,8 +224,6 @@ NOTE: You can call these functions in mapping via `<Cmd>lua require('cmp').compl
   - `complete_done`: emit after current completion is done.
   - `confirm_done`: emit after confirmation is done.
 
-
-
 ==============================================================================
 Mapping                                                            *cmp-mapping*
 
@@ -304,8 +295,6 @@ You can also use built-in mapping helpers.
 The built-in mapping helper is only available as a configuration option.
 If you want to call the nvim-cmp features directly, please use |cmp-function| instead.
 
-
-
 ==============================================================================
 Command                                                            *cmp-command*
 
@@ -313,8 +302,6 @@ Command                                                            *cmp-command*
   Prints source statuses for the current buffer and states.
   Sometimes `unknown` source will be printed but it isn't problem. (e.g. `cmp-nvim-lsp`)
   That the reason is the `cmp-nvim-lsp` will registered on the InsertEnter autocmd.
-
-
 
 ==============================================================================
 Highlight                                                        *cmp-highlight*
@@ -343,7 +330,77 @@ Highlight                                                        *cmp-highlight*
 *CmpItemMenu*
   The menu field's highlight group.
 
+  Default: |hl-Pmenu|
 
+*CmpCompletionWindow*
+  The highlight group for the completion window.
+
+  Default: |hl-Pmenu|
+
+*CmpCompletionWindowBorder*
+  The highlight group for borders to completion window.
+
+  Default: |hl-NormalFloat|
+  Recommended: |hl-FloatBorder|
+
+*CmpCompletionWindowBordered*
+  The highlight group for a bordered documentation window.
+
+  Default: |CmpCompletionWindow|
+
+*CmpCompletionWindowPadding*
+  The highlight group for borders to the completion window which are made up of
+  entirely invisible / whitespace characters. For example: >
+  cmp.setup {
+    window = {
+      completion = {
+        border = {'', '', '', ' ', '', '', '', ' '},
+      },
+    },
+  }
+<
+
+  Default: |CmpCompletionWindow|
+
+*CmpDocumentationWindow*
+  The highlight group for the documentation window.
+
+  Default: |hl-Pmenu|
+
+*CmpDocumentationWindowBorder*
+  The highlight group for borders to documentation window.
+
+  Default: |CmpCompletionWindowBorder|
+
+*CmpDocumentationWindowBordered*
+  The highlight group for a bordered documentation window.
+
+  Default: |CmpDocumentationWindow|
+
+*CmpDocumentationWindowPadding*
+  The highlight group for borders to the documentation window which are made
+  up of entirely invisible / whitespace characters. For example: >
+  cmp.setup {
+    window = {
+      documentation = {
+        border = {'', '', '', ' ', '', '', '', ' '},
+      },
+    },
+  }
+<
+
+  Default: |CmpDocumentationWindow|
+
+*CmpScrollBar*
+  The highlight group for the background of a scrollbar; present when there
+  is no border on a window.
+
+  Default: |hl-PmenuSbar|
+
+*CmpScrollThumb*
+  The highlight group for the thumb of a scrollbar.
+
+  Default: |hl-PmenuThumb|
 
 ==============================================================================
 Autocmd                                                            *cmp-autocmd*
@@ -353,8 +410,6 @@ autocommands for the User event with the following patterns.
 
 *CmpReady*
   Invoked when nvim-cmp gets sourced from `plugin/cmp.lua`.
-
-
 
 ==============================================================================
 Config                                                              *cmp-config*
@@ -417,7 +472,7 @@ formatting.fields~
 formatting.format~
   `fun(entry: cmp.Entry, vim_item: vim.CompletedItem): vim.CompletedItem`
   The function to customize the completion menu appearance. See |complete-items|.
-  This value also can be used to modify `dup` property. 
+  This value also can be used to modify `dup` property.
   NOTE: The `vim.CompletedItem` can have special properties `abbr_hl_group`,
   `kind_hl_group` and `menu_hl_group`.
 
@@ -523,12 +578,87 @@ view~
   Specify the view class to customize appearance.
   Currently, the possible configurations are:
 
+                                           *cmp-config.window.completion.border*
+window.completion.border~
+  `string | string[] | nil`
+  Border characters used for the completion popup menu when
+  |experimental.native_menu| is disabled.
+
+                                        *cmp-config.window.completion.scrollbar*
+window.completion.scrollbar~
+  `string | false`
+  A setting defining which character to use for the scrollbar.
+
+  * If an empty string (`""`), |hl-PmenuThumb| will be used.
+  * If `false`, no scrollbar will be rendered.
+  * If |experimental.native_menu| is `true`, this setting will be ignored.
+
+  Default: `""`
+  Recommended: `"║"`
+
+                                     *cmp-config.window.completion.winhighlight*
+window.completion.winhighlight~
+  `string | cmp.WinhighlightConfig`
+  Is either a `string` matching the 'winhighlight' syntax, or a `table` of
+  `bordered` and `default` options which both specify 'winhighlight' settings
+  for when the completion window has and does not have a border, respectively.
+
+                                           *cmp-config.window.completion.zindex*
+window.completion.zindex~
+  `number`
+  The completion window's zindex.
+
+                                               *cmp-config.window.documentation*
+window.documentation~
+  `false | cmp.DocumentationConfig`
+  If set to `false`, the documentation of each item will not be shown.
+  Else, a table representing documentation configuration should be provided.
+  The following are possible options.
+
+                                        *cmp-config.window.documentation.border*
+window.documentation.border~
+  `string | string[] | nil`
+
+  Border characters used for documentation window.
+
+                                     *cmp-config.window.documentation.max_width*
+window.documentation.max_width~
+  `number`
+  The documentation window's max width.
+
+                                    *cmp-config.window.documentation.max_height*
+window.documentation.max_height~
+  `number`
+  The documentation window's max height.
+
+                                     *cmp-config.window.documentation.scrollbar*
+window.documentation.scrollbar~
+  `string`
+  A setting defining which character to use for the scrollbar.
+
+  * If an empty string (`""`), |hl-PmenuThumb| will be used.
+  * If `false`, no scrollbar will be rendered.
+
+  Default: `""`
+  Recommended: `"║"`
+
+                                  *cmp-config.window.documentation.winhighlight*
+window.documentation.winhighlight~
+  `string | cmp.WinhighlightConfig`
+  Is either a `string` matching the 'winhighlight' syntax, or a `table` of
+  `bordered` and `default` options which both specify 'winhighlight' settings
+  for when the documentation window has and does not have a border,
+  respectively.
+
+                                        *cmp-config.window.documentation.zindex*
+window.documentation.zindex~
+  `number`
+  The documentation window's zindex.
+
                                             *cmp-config.experimental.ghost_text*
 experimental.ghost_text~
   `boolean | { hl_group = string }`
   The boolean value to enable or disable the ghost_text feature.
-
-
 
 ==============================================================================
 Develop                                                            *cmp-develop*
@@ -610,7 +740,6 @@ You can create custom source like the following example.
   require('cmp').register_source('month', source.new())
 <
 
-
 ==============================================================================
 FAQ                                                                    *cmp-faq*
 
@@ -649,8 +778,5 @@ How to customize menu appearance?~
 
 You can see the nvim-cmp wiki (https://github.com/hrsh7th/nvim-cmp/wiki).
 
-
-
 ==============================================================================
- vim:tw=78:ts=4:et:ft=help:norl:
-
+ vim:tw=78:ts=2:et:ft=help:norl:

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -141,8 +141,8 @@ return function()
       },
       documentation = {
         border = {'', '', '', ' ', '', '', '', ' '},
-        maxheight = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
-        maxwidth = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
+        max_height = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
+        max_width = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
         scrollbar = '',
       },
     },

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -140,7 +140,7 @@ return function()
         scrollbar = '',
       },
       documentation = {
-        border = {'', '', '', '', '', '', '', ''},
+        border = {'', '', '', ' ', '', '', '', ' '},
         maxheight = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
         maxwidth = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
         scrollbar = '',

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -138,14 +138,20 @@ return function()
       completion = {
         border = {'', '', '', '', '', '', '', ''},
         scrollbar = '',
-        winhighlight = 'Normal:CmpCompletionWindow,FloatBorder:CmpCompletionWindowBorder,CursorLine:PmenuSel,Search:None',
+        winhighlight = {
+          bordered = 'Normal:CmpCompletionWindow,FloatBorder:CmpCompletionWindowPadding,CursorLine:PmenuSel,Search:None',
+          default = 'Normal:CmpCompletionWindowBordered,FloatBorder:CmpCompletionWindowBorder,CursorLine:PmenuSel,Search:None',
+        },
       },
       documentation = {
         border = {'', '', '', ' ', '', '', '', ' '},
         max_height = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
         max_width = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
         scrollbar = '',
-        winhighlight = 'Normal:CmpDocumentationWindow,FloatBorder:CmpDocumentationWindowBorder',
+        winhighlight = {
+          bordered = 'Normal:CmpDocumentationWindowBordered,FloatBorder:CmpDocumentationWindowBorder',
+          default = 'Normal:CmpDocumentationWindow,FloatBorder:CmpDocumentationWindowPadding',
+        },
       },
     },
   }

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -133,5 +133,18 @@ return function()
     view = {
       entries = 'custom',
     },
+
+    window = {
+      completion = {
+        border = {'', '', '', '', '', '', '', ''},
+        scrollbar = '',
+      },
+      documentation = {
+        border = {'', '', '', '', '', '', '', ''},
+        maxheight = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
+        maxwidth = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
+        scrollbar = '',
+      },
+    },
   }
 end

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -139,8 +139,8 @@ return function()
         border = {'', '', '', '', '', '', '', ''},
         scrollbar = '',
         winhighlight = {
-          bordered = 'Normal:CmpCompletionWindow,FloatBorder:CmpCompletionWindowPadding,CursorLine:PmenuSel,Search:None',
-          default = 'Normal:CmpCompletionWindowBordered,FloatBorder:CmpCompletionWindowBorder,CursorLine:PmenuSel,Search:None',
+          bordered = 'Normal:CmpCompletionWindowBordered,FloatBorder:CmpCompletionWindowBorder,CursorLine:PmenuSel,Search:None',
+          default = 'Normal:CmpCompletionWindow,FloatBorder:CmpCompletionWindowPadding,CursorLine:PmenuSel,Search:None',
         },
       },
       documentation = {

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -110,13 +110,6 @@ return function()
 
     sources = {},
 
-    documentation = {
-      border = { '', '', '', ' ', '', '', '', ' ' },
-      winhighlight = 'NormalFloat:NormalFloat,FloatBorder:NormalFloat',
-      maxwidth = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
-      maxheight = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
-    },
-
     confirmation = {
       default_behavior = types.cmp.ConfirmBehavior.Insert,
       get_commit_characters = function(commit_characters)

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -138,12 +138,14 @@ return function()
       completion = {
         border = {'', '', '', '', '', '', '', ''},
         scrollbar = '',
+        winhighlight = 'Normal:CmpCompletionWindow,FloatBorder:CmpCompletionWindowBorder,CursorLine:PmenuSel,Search:None',
       },
       documentation = {
         border = {'', '', '', ' ', '', '', '', ' '},
         max_height = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
         max_width = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
         scrollbar = '',
+        winhighlight = 'Normal:CmpDocumentationWindow,FloatBorder:CmpDocumentationWindowBorder',
       },
     },
   }

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -73,12 +73,12 @@ return function()
     },
 
     completion = {
-      keyword_length = 1,
-      keyword_pattern = [[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%(-\w*\)*\)]],
       autocomplete = {
         types.cmp.TriggerEvent.TextChanged,
       },
       completeopt = 'menu,menuone,noselect',
+      keyword_pattern = [[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%(-\w*\)*\)]],
+      keyword_length = 1,
     },
 
     formatting = {

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -101,6 +101,7 @@ cmp.ItemField.Menu = 'menu'
 ---@class cmp.CompletionWindowConfig
 ---@field public border string|string[]
 ---@field public scrollbar string
+---@field public winhighlight string
 ---@field public zindex number|nil
 
 ---@class cmp.DocumentationConfig
@@ -108,6 +109,7 @@ cmp.ItemField.Menu = 'menu'
 ---@field public max_height number|nil
 ---@field public max_width number|nil
 ---@field public scrollbar string
+---@field public winhighlight string
 ---@field public zindex number|nil
 
 ---@class cmp.ConfirmationConfig

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -101,6 +101,7 @@ cmp.ItemField.Menu = 'menu'
 ---@class cmp.CompletionWindowConfig
 ---@field public border string|string[]
 ---@field public scrollbar string
+---@field public zindex number|nil
 
 ---@class cmp.DocumentationConfig
 ---@field public border string|string[]

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -88,16 +88,19 @@ cmp.ItemField.Menu = 'menu'
 
 ---@class cmp.CompletionConfig
 ---@field public autocomplete cmp.TriggerEvent[]
+---@field public border string|string[]
 ---@field public completeopt string
----@field public keyword_pattern string
----@field public keyword_length number
 ---@field public get_trigger_characters fun(trigger_characters: string[]): string[]
+---@field public keyword_length number
+---@field public keyword_pattern string
+---@field public thin_scrollbar boolean|nil
 
 ---@class cmp.DocumentationConfig
----@field public border string[]
----@field public winhighlight string
----@field public maxwidth number|nil
+---@field public border string|string[]
 ---@field public maxheight number|nil
+---@field public maxwidth number|nil
+---@field public thin_scrollbar boolean|nil
+---@field public winhighlight string
 ---@field public zindex number|nil
 
 ---@class cmp.ConfirmationConfig

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -93,13 +93,13 @@ cmp.ItemField.Menu = 'menu'
 ---@field public get_trigger_characters fun(trigger_characters: string[]): string[]
 ---@field public keyword_length number
 ---@field public keyword_pattern string
----@field public thin_scrollbar boolean|nil
+---@field public scrollbar string
 
 ---@class cmp.DocumentationConfig
 ---@field public border string|string[]
 ---@field public maxheight number|nil
 ---@field public maxwidth number|nil
----@field public thin_scrollbar boolean|nil
+---@field public scrollbar string
 ---@field public winhighlight string
 ---@field public zindex number|nil
 

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -101,7 +101,7 @@ cmp.ItemField.Menu = 'menu'
 ---@class cmp.CompletionWindowConfig
 ---@field public border string|string[]
 ---@field public scrollbar string
----@field public winhighlight string
+---@field public winhighlight string|cmp.WinhighlightConfig
 ---@field public zindex number|nil
 
 ---@class cmp.DocumentationConfig
@@ -109,8 +109,12 @@ cmp.ItemField.Menu = 'menu'
 ---@field public max_height number|nil
 ---@field public max_width number|nil
 ---@field public scrollbar string
----@field public winhighlight string
+---@field public winhighlight string|cmp.WinhighlightConfig
 ---@field public zindex number|nil
+
+---@class cmp.WinhighlightConfig
+---@field public bordered string
+---@field public default string
 
 ---@class cmp.ConfirmationConfig
 ---@field public default_behavior cmp.ConfirmBehavior

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -100,7 +100,6 @@ cmp.ItemField.Menu = 'menu'
 ---@field public maxheight number|nil
 ---@field public maxwidth number|nil
 ---@field public scrollbar string
----@field public winhighlight string
 ---@field public zindex number|nil
 
 ---@class cmp.ConfirmationConfig

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -75,6 +75,7 @@ cmp.ItemField.Menu = 'menu'
 ---@field public enabled fun():boolean|boolean
 ---@field public preselect cmp.PreselectMode
 ---@field public completion cmp.CompletionConfig
+---@field public window cmp.WindowConfig|nil
 ---@field public documentation cmp.DocumentationConfig|"false"
 ---@field public confirmation cmp.ConfirmationConfig
 ---@field public matching cmp.MatchingConfig
@@ -86,13 +87,19 @@ cmp.ItemField.Menu = 'menu'
 ---@field public view cmp.ViewConfig
 ---@field public experimental cmp.ExperimentalConfig
 
+--- @class cmp.WindowConfig
+--- @field completion cmp.CompletionWindowConfig
+--- @field documentation cmp.DocumentationConfig
+
 ---@class cmp.CompletionConfig
 ---@field public autocomplete cmp.TriggerEvent[]
----@field public border string|string[]
 ---@field public completeopt string
 ---@field public get_trigger_characters fun(trigger_characters: string[]): string[]
 ---@field public keyword_length number
 ---@field public keyword_pattern string
+
+---@class cmp.CompletionWindowConfig
+---@field public border string|string[]
 ---@field public scrollbar string
 
 ---@class cmp.DocumentationConfig

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -105,8 +105,8 @@ cmp.ItemField.Menu = 'menu'
 
 ---@class cmp.DocumentationConfig
 ---@field public border string|string[]
----@field public maxheight number|nil
----@field public maxwidth number|nil
+---@field public max_height number|nil
+---@field public max_width number|nil
 ---@field public scrollbar string
 ---@field public zindex number|nil
 

--- a/lua/cmp/utils/str.lua
+++ b/lua/cmp/utils/str.lua
@@ -195,7 +195,7 @@ end
 
 --- @param c string|nil the char to check
 --- @return boolean visible `true` if `s` matches `%s*`
-str.is_visible = function(c)
+str.is_invisible = function(c)
   return c == '' or c == ' '
 end
 

--- a/lua/cmp/utils/str.lua
+++ b/lua/cmp/utils/str.lua
@@ -193,4 +193,10 @@ str.escape = function(text, chars)
   return table.concat(escaped, '')
 end
 
+--- @param c string|nil the string to check
+--- @return boolean is_whitespace `true` if `s` matches `%s*`
+str.is_whitespace_char = function(c)
+  return c == '' or c == ' '
+end
+
 return str

--- a/lua/cmp/utils/str.lua
+++ b/lua/cmp/utils/str.lua
@@ -193,9 +193,9 @@ str.escape = function(text, chars)
   return table.concat(escaped, '')
 end
 
---- @param c string|nil the string to check
---- @return boolean is_whitespace `true` if `s` matches `%s*`
-str.is_whitespace_char = function(c)
+--- @param c string|nil the char to check
+--- @return boolean visible `true` if `s` matches `%s*`
+str.is_visible = function(c)
   return c == '' or c == ' '
 end
 

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -2,6 +2,7 @@ local cache = require('cmp.utils.cache')
 local misc = require('cmp.utils.misc')
 local buffer = require('cmp.utils.buffer')
 local api = require('cmp.utils.api')
+local str = require('cmp.utils.str')
 
 ---@class cmp.WindowStyle
 ---@field public relative string
@@ -135,13 +136,13 @@ window.update = function(self)
     info.scrollbar.style = 'minimal'
 
     -- Draw the background of the scrollbar
-    if self.style.border[2] == '' or self.style.border[2] == ' ' or math.max(info.border.height, info.border.width) < 1 then
+    if str.is_whitespace_char(self.style.border[2]) or math.max(info.border.height, info.border.width) < 1 then
       local style = {
         relative = info.scrollbar.relative,
         style = info.scrollbar.style,
         width = info.scrollbar.width,
         height = self.style.height,
-        row = info.row + ((self.style.border[2] == '' or self.style.border[2] == ' ' or self.style.border == 'shadow') and 0 or 1),
+        row = info.row + ((str.is_whitespace_char(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1),
         col = info.scrollbar.col,
         zindex = (self.style.zindex and (self.style.zindex + 1) or 1),
       }
@@ -246,10 +247,10 @@ window.info = function(self)
         height = math.ceil(self.style.height * (self.style.height / content_height)),
         width = 1,
       }
-      info.scrollbar.col = info.col + info.width - ((self.style.border[4] == '' or self.style.border[4] == ' ') and 0 or 1)
+      info.scrollbar.col = info.col + info.width - ((str.is_whitespace_char(self.style.border[4])) and 0 or 1)
       info.scrollbar.row = info.row +
         math.min(self.style.height - info.scrollbar.height, math.floor(self.style.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
-        ((self.style.border[2] == '' or self.style.border[2] == ' ' or self.style.border == 'shadow') and 0 or 1)
+        ((str.is_whitespace_char(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1)
       if border_width < 1 then
         info.width = info.width + info.scrollbar.width
       end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -199,13 +199,13 @@ window.info = function(self)
     local content_height = self:get_content_height()
     if content_height > self.style.height then
       info.scrollbar = {
-        height = math.max(1, math.ceil(info.height * (info.height / content_height) - 0.49) - info.border.height - 1),
+        height = math.max(1, math.ceil(info.height * (info.height / content_height) - 0.49)),
         width = 1,
       }
       info.scrollbar.col = info.col + info.width - info.scrollbar.width
       info.scrollbar.row = info.row +
-      math.min(info.height - info.scrollbar.height, math.floor(info.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
-      (self.style.border ~= 'shadow' and self.style.border[4] ~= '' and 1 or 0)
+        math.min(self.style.height - info.scrollbar.height, math.floor(self.style.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
+        (self.style.border ~= 'shadow' and self.style.border[4] ~= '' and 1 or 0)
       info.width = info.width + info.scrollbar.width
     end
   end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -136,13 +136,13 @@ window.update = function(self)
     info.scrollbar.style = 'minimal'
 
     -- Draw the background of the scrollbar
-    if str.is_visible(self.style.border[2]) or math.max(info.border.height, info.border.width) < 1 then
+    if str.is_invisible(self.style.border[2]) or math.max(info.border.height, info.border.width) < 1 then
       local style = {
         relative = info.scrollbar.relative,
         style = info.scrollbar.style,
         width = info.scrollbar.width,
         height = self.style.height,
-        row = info.row + ((str.is_visible(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1),
+        row = info.row + ((str.is_invisible(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1),
         col = info.scrollbar.col,
         zindex = (self.style.zindex and (self.style.zindex + 1) or 1),
       }
@@ -247,10 +247,10 @@ window.info = function(self)
         height = math.ceil(self.style.height * (self.style.height / content_height)),
         width = 1,
       }
-      info.scrollbar.col = info.col + info.width - ((str.is_visible(self.style.border[4])) and 0 or 1)
+      info.scrollbar.col = info.col + info.width - ((str.is_invisible(self.style.border[4])) and 0 or 1)
       info.scrollbar.row = info.row +
         math.min(self.style.height - info.scrollbar.height, math.floor(self.style.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
-        ((str.is_visible(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1)
+        ((str.is_invisible(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1)
       if border_width < 1 then
         info.width = info.width + info.scrollbar.width
       end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -239,7 +239,7 @@ window.info = function(self)
     local content_height = self:get_content_height()
     if content_height > self.style.height then
       info.scrollbar = {
-        height = math.max(1, math.ceil(self.style.height * (self.style.height / content_height) - 0.49)),
+        height = math.ceil(self.style.height * (self.style.height / content_height)),
         width = 1,
       }
       info.scrollbar.col = info.col + info.width - info.scrollbar.width

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -175,7 +175,7 @@ window.update = function(self)
 
       if self.scrollbar ~= '' then
         local replace = {}
-        for i = 1, style2.height do replace[i] = '║' end
+        for i = 1, style2.height do replace[i] = self.scrollbar end
 
         vim.api.nvim_buf_set_lines(sbuf2, 0, 1, true, replace)
       end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -143,7 +143,7 @@ window.update = function(self)
         style = info.scrollbar.style,
         width = info.scrollbar.width,
         height = self.style.height,
-        row = info.scrollbar.row,
+        row = info.row + (self.style.border ~= 'shadow' and self.style.border[2] ~= '' and 1 or 0),
         col = info.scrollbar.col,
         zindex = (self.style.zindex and (self.style.zindex + 1) or 1),
       }

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -251,7 +251,7 @@ window.info = function(self)
       info.scrollbar.col = info.col + info.width - info.scrollbar.width
       info.scrollbar.row = info.row +
         math.min(self.style.height - info.scrollbar.height, math.floor(self.style.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
-        (self.style.border ~= 'shadow' and self.style.border[4] ~= '' and 1 or 0)
+        (self.style.border ~= 'shadow' and self.style.border[2] ~= '' and 1 or 0)
       if border_width < 1 then
         info.width = info.width + info.scrollbar.width
       end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -102,18 +102,16 @@ end
 window.set_style = function(self, style)
   local border_offset = window.border_offset(style)
 
-  if vim.o.lines and vim.o.lines <= style.row + style.height + border_offset + 1 then
-    style.height = vim.o.lines - style.row - border_offset - 1
+  -- If the popup will open above the cursor
+  if vim.fn.screenrow() - 1 > style.row or api.is_cmdline_mode() then
+    -- shrink row by `border_offset`
+    style.row = style.row - border_offset
+    -- compensate for negative row with height adjustment
+    if style.row < 0 then style.height = style.height + style.row end
   end
 
-  -- If the popup will open above the cursor
-  if vim.fn.screenrow() - 1 > style.row then
-    -- shrink row by `border_offset_row`
-    style.row = style.row - border_offset
-    if style.row < 0 then -- compensate for negative row with height adjustment
-      style.height = style.height + style.row
-      style.row = 0
-    end
+  if vim.o.lines and vim.o.lines <= style.row + style.height + border_offset + 1 then
+    style.height = vim.o.lines - style.row - border_offset - 1
   end
 
   self.style = style

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -114,8 +114,10 @@ window.set_style = function(self, style)
   end
 
   -- If the popup will open above the cursor
-  if vim.fn.screenrow() > style.row then
-    style.height = style.height - border_offset
+  if vim.fn.screenrow() - 1 > style.row then
+    style.height = math.max(1, style.height - border_offset)
+    -- If there is so little space that the `height` is one, make more space by adjusting the row.
+    if style.height == 1 then style.row = style.row - 1 end
   end
 
   self.style = style

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -107,17 +107,23 @@ window.set_style = function(self, style)
     style.width = vim.o.columns - style.col - 1
   end
 
-  local border_offset = window.border_offset(style)
+  -- If there too little space on the right side of the screen.
+  if vim.o.columns and vim.o.columns <= style.col + style.width + border_offset_col + 1 then
+    style.col = math.max(1, vim.o.columns - style.width - border_offset_col - 1)
+  end
 
-  if vim.o.lines and vim.o.lines <= style.row + style.height then
+  if vim.o.lines and vim.o.lines <= style.row + style.height + border_offset + 1 then
     style.height = vim.o.lines - style.row - border_offset - 1
   end
 
   -- If the popup will open above the cursor
   if vim.fn.screenrow() - 1 > style.row then
-    style.height = math.max(1, style.height - border_offset)
-    -- If there is so little space that the `height` is one, make more space by adjusting the row.
-    if style.height == 1 then style.row = style.row - 1 end
+    -- shrink row by `border_offset_row`
+    style.row = style.row - border_offset_row
+    if style.row < 0 then -- compensate for negative row with height adjustment
+      style.height = style.height + style.row
+      style.row = 0
+    end
   end
 
   self.style = style

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -152,7 +152,7 @@ window.update = function(self)
       else
         style.noautocmd = true
         self.scroll_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'scroll_buf'), false, style)
-        local highlight = self.scrollbar == '' and 'PmenuSbar' or 'CmpWindowScrollBar'
+        local highlight = self.scrollbar == '' and 'PmenuSbar' or 'CmpScrollBar'
         vim.api.nvim_win_set_option(self.scroll_win, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
       end
 
@@ -172,7 +172,7 @@ window.update = function(self)
     else
       info.scrollbar.noautocmd = true
       self.thumb_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'thumb_buf'), false, info.scrollbar)
-      local highlight = self.scrollbar == '' and 'PmenuThumb' or 'CmpWindowScrollThumb'
+      local highlight = self.scrollbar == '' and 'PmenuThumb' or 'CmpScrollThumb'
       vim.api.nvim_win_set_option(self.thumb_win, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
     end
 

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -136,13 +136,13 @@ window.update = function(self)
     info.scrollbar.style = 'minimal'
 
     -- Draw the background of the scrollbar
-    if str.is_whitespace_char(self.style.border[2]) or math.max(info.border.height, info.border.width) < 1 then
+    if str.is_visible(self.style.border[2]) or math.max(info.border.height, info.border.width) < 1 then
       local style = {
         relative = info.scrollbar.relative,
         style = info.scrollbar.style,
         width = info.scrollbar.width,
         height = self.style.height,
-        row = info.row + ((str.is_whitespace_char(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1),
+        row = info.row + ((str.is_visible(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1),
         col = info.scrollbar.col,
         zindex = (self.style.zindex and (self.style.zindex + 1) or 1),
       }
@@ -247,10 +247,10 @@ window.info = function(self)
         height = math.ceil(self.style.height * (self.style.height / content_height)),
         width = 1,
       }
-      info.scrollbar.col = info.col + info.width - ((str.is_whitespace_char(self.style.border[4])) and 0 or 1)
+      info.scrollbar.col = info.col + info.width - ((str.is_visible(self.style.border[4])) and 0 or 1)
       info.scrollbar.row = info.row +
         math.min(self.style.height - info.scrollbar.height, math.floor(self.style.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
-        ((str.is_whitespace_char(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1)
+        ((str.is_visible(self.style.border[2]) or self.style.border == 'shadow') and 0 or 1)
       if border_width < 1 then
         info.width = info.width + info.scrollbar.width
       end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -173,7 +173,7 @@ window.update = function(self)
     else
       info.scrollbar.noautocmd = true
       self.thumb_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'thumb_buf'), false, info.scrollbar)
-      local highlight = self.scrollbar == '' and 'PmenuThumb' or 'Cmp'..(has_border and 'Bordered' or '')..'WindowScrollThumb'
+      local highlight = self.scrollbar == '' and 'PmenuThumb' or 'CmpWindow'..(has_border and 'Bordered' or '')..'ScrollThumb'
       vim.api.nvim_win_set_option(self.thumb_win, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
     end
 

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -127,23 +127,23 @@ end
 
 ---Update
 window.update = function(self)
-  local info = self:info().scrollbar
-  if info and info.width > 0 then
-    info.relative = 'editor'
-    info.style = 'minimal'
-    info.zindex = (self.style.zindex and (self.style.zindex + 2) or 2)
+  local info = self:info()
+  if info.scrollbar and info.scrollbar.width > 0 then
+    info.scrollbar.relative = 'editor'
+    info.scrollbar.style = 'minimal'
+    info.scrollbar.zindex = (self.style.zindex and (self.style.zindex + 2) or 2)
     if self.swin and vim.api.nvim_win_is_valid(self.swin) then
-      vim.api.nvim_win_set_config(self.swin, info)
+      vim.api.nvim_win_set_config(self.swin, info.scrollbar)
     else
-      info.noautocmd = true
+      info.scrollbar.noautocmd = true
       local sbuf2 = buffer.ensure(self.name .. 'sbuf2')
-      self.swin = vim.api.nvim_open_win(sbuf2, false, info)
+      self.swin = vim.api.nvim_open_win(sbuf2, false, info.scrollbar)
       local highlight = self.scrollbar == '' and 'PmenuThumb' or 'Cmp'..(math.max(info.border.height, info.border.width) > 0 and 'Bordered' or '')..'WindowScrollBar'
       vim.api.nvim_win_set_option(self.swin, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
 
       if self.scrollbar ~= '' then
         local replace = {}
-        for i = 1, info.height do replace[i] = self.scrollbar end
+        for i = 1, info.scrollbar.height do replace[i] = self.scrollbar end
 
         vim.api.nvim_buf_set_lines(sbuf2, 0, 1, true, replace)
       end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -114,7 +114,7 @@ window.set_style = function(self, style)
   end
 
   -- If the popup will open above the cursor
-  if -(vim.fn.line 'w0' - vim.api.nvim_win_get_cursor(0)[1]) > style.row then
+  if vim.fn.screenrow() > style.row then
     style.height = style.height - border_offset
   end
 

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -183,9 +183,15 @@ window.update = function(self)
 
       vim.api.nvim_buf_set_lines(vim.api.nvim_win_get_buf(self.thumb_win), 0, -1, true, replace)
     end
-  elseif self.thumb_win and vim.api.nvim_win_is_valid(self.thumb_win) then
-    vim.api.nvim_win_hide(self.thumb_win)
-    self.thumb_win = nil
+  else
+    if self.scroll_win and vim.api.nvim_win_is_valid(self.scroll_win) then
+      vim.api.nvim_win_hide(self.scroll_win)
+      self.scroll_win = nil
+    end
+    if self.thumb_win and vim.api.nvim_win_is_valid(self.thumb_win) then
+      vim.api.nvim_win_hide(self.thumb_win)
+      self.thumb_win = nil
+    end
   end
 
   -- In cmdline, vim does not redraw automatically.

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -152,7 +152,7 @@ window.update = function(self)
   if self:has_scrollbar() then
     local total = self:get_content_height()
     local info = self:info()
-    local bar_height = math.ceil(info.height * (info.height / total) - 0.49)
+    local bar_height = math.max(1, math.ceil(info.height * (info.height / total) - 0.49))
     local bar_offset = math.min(info.height - bar_height, math.floor(info.height * (vim.fn.getwininfo(self.win)[1].topline / total)))
     local border_offset_row, border_offset_col = window.border_offset_scrollbar(self.style)
 

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -199,7 +199,7 @@ window.info = function(self)
     local content_height = self:get_content_height()
     if content_height > self.style.height then
       info.scrollbar = {
-        height = math.max(1, math.ceil(info.height * (info.height / content_height) - 0.49)),
+        height = math.max(1, math.ceil(self.style.height * (self.style.height / content_height) - 0.49)),
         width = 1,
       }
       info.scrollbar.col = info.col + info.width - info.scrollbar.width

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -152,7 +152,7 @@ window.update = function(self)
   if self:has_scrollbar() then
     local total = self:get_content_height()
     local info = self:info()
-    local bar_height = math.ceil(info.height * (info.height / total))
+    local bar_height = math.ceil(info.height * (info.height / total) - 0.49)
     local bar_offset = math.min(info.height - bar_height, math.floor(info.height * (vim.fn.getwininfo(self.win)[1].topline / total)))
     local border_offset_row, border_offset_col = window.border_offset_scrollbar(self.style)
 

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -18,6 +18,7 @@ local api = require('cmp.utils.api')
 ---@field public swin number|nil
 ---@field public style cmp.WindowStyle
 ---@field public opt table<string, any>
+---@field public thin_scrollbar boolean|nil
 ---@field public buffer_opt table<string, any>
 ---@field public cache cmp.Cache
 local window = {}
@@ -178,10 +179,15 @@ window.update = function(self)
       style2.noautocmd = true
       local sbuf2 = buffer.ensure(self.name .. 'sbuf2')
       self.swin = vim.api.nvim_open_win(sbuf2, false, style2)
-      vim.api.nvim_win_set_option(self.swin, 'winhighlight', 'EndOfBuffer:PmenuThumb,NormalFloat:CmpItemMenuThumb')
+      local highlight = self.thin_scrollbar and 'CmpItemMenuThumb' or 'PmenuThumb'
+      vim.api.nvim_win_set_option(self.swin, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
 
-      local replace = {}
-      for i = 1, style2.height do replace[i] = '║' end
+      if self.thin_scrollbar then
+        local replace = {}
+        for i = 1, style2.height do replace[i] = '║' end
+
+        vim.api.nvim_buf_set_lines(sbuf2, 0, 1, true, replace)
+      end
 
       vim.api.nvim_buf_set_lines(sbuf2, 0, 1, true, replace)
     end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -152,17 +152,16 @@ window.update = function(self)
         vim.api.nvim_win_set_config(self.scroll_win, style)
       else
         style.noautocmd = true
-        local scroll_buf = buffer.ensure(self.name .. 'scroll_buf')
-        self.scroll_win = vim.api.nvim_open_win(scroll_buf, false, style)
+        self.scroll_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'scroll_buf'), false, style)
         local highlight = self.scrollbar == '' and 'PmenuSbar' or 'CmpWindowScrollBar'
         vim.api.nvim_win_set_option(self.scroll_win, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
+      end
 
-        if self.scrollbar ~= '' then
-          local replace = {}
-          for i = 1, style.height do replace[i] = self.scrollbar end
+      if self.scrollbar ~= '' then
+        local replace = {}
+        for i = 1, style.height do replace[i] = self.scrollbar end
 
-          vim.api.nvim_buf_set_lines(scroll_buf, 0, 1, true, replace)
-        end
+        vim.api.nvim_buf_set_lines(vim.api.nvim_win_get_buf(self.scroll_win), 0, -1, true, replace)
       end
     end
 
@@ -173,17 +172,16 @@ window.update = function(self)
       vim.api.nvim_win_set_config(self.thumb_win, info.scrollbar)
     else
       info.scrollbar.noautocmd = true
-      local thumb_buf = buffer.ensure(self.name .. 'thumb_buf')
-      self.thumb_win = vim.api.nvim_open_win(thumb_buf, false, info.scrollbar)
+      self.thumb_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'thumb_buf'), false, info.scrollbar)
       local highlight = self.scrollbar == '' and 'PmenuThumb' or 'Cmp'..(has_border and 'Bordered' or '')..'WindowScrollThumb'
       vim.api.nvim_win_set_option(self.thumb_win, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
+    end
 
-      if self.scrollbar ~= '' then
-        local replace = {}
-        for i = 1, info.scrollbar.height do replace[i] = self.scrollbar end
+    if self.scrollbar ~= '' then
+      local replace = {}
+      for i = 1, info.scrollbar.height do replace[i] = self.scrollbar end
 
-        vim.api.nvim_buf_set_lines(thumb_buf, 0, 1, true, replace)
-      end
+      vim.api.nvim_buf_set_lines(vim.api.nvim_win_get_buf(self.thumb_win), 0, -1, true, replace)
     end
   elseif self.thumb_win and vim.api.nvim_win_is_valid(self.thumb_win) then
     vim.api.nvim_win_hide(self.thumb_win)

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -209,8 +209,6 @@ window.info = function(self)
       info.width = info.width + info.scrollbar.width
     end
   end
-    -- local info = self:info()
-    -- local bar_height = math.max(1, math.ceil(info.height * (info.height / total) - 0.49))
 
   return info
 end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -15,8 +15,7 @@ local api = require('cmp.utils.api')
 ---@class cmp.Window
 ---@field public name string
 ---@field public win number|nil
----@field public swin1 number|nil
----@field public swin2 number|nil
+---@field public swin number|nil
 ---@field public style cmp.WindowStyle
 ---@field public opt table<string, any>
 ---@field public buffer_opt table<string, any>
@@ -50,8 +49,7 @@ window.new = function()
   local self = setmetatable({}, { __index = window })
   self.name = misc.id('cmp.utils.window.new')
   self.win = nil
-  self.swin1 = nil
-  self.swin2 = nil
+  self.swin = nil
   self.style = {}
   self.cache = cache.new()
   self.opt = {}
@@ -174,28 +172,22 @@ window.update = function(self)
     style2.row = info.row + bar_offset + border_offset_row
     style2.col = info.col + info.width - (info.has_scrollbar and 1 or 0) - border_offset_col
     style2.zindex = (self.style.zindex and (self.style.zindex + 2) or 2)
-    if self.swin2 and vim.api.nvim_win_is_valid(self.swin2) then
-      vim.api.nvim_win_set_config(self.swin2, style2)
+    if self.swin and vim.api.nvim_win_is_valid(self.swin) then
+      vim.api.nvim_win_set_config(self.swin, style2)
     else
       style2.noautocmd = true
       local sbuf2 = buffer.ensure(self.name .. 'sbuf2')
-      self.swin2 = vim.api.nvim_open_win(sbuf2, false, style2)
-      vim.api.nvim_win_set_option(self.swin2, 'winhighlight', 'EndOfBuffer:PmenuThumb,NormalFloat:CmpItemMenuThumb')
+      self.swin = vim.api.nvim_open_win(sbuf2, false, style2)
+      vim.api.nvim_win_set_option(self.swin, 'winhighlight', 'EndOfBuffer:PmenuThumb,NormalFloat:CmpItemMenuThumb')
 
       local replace = {}
       for i = 1, style2.height do replace[i] = '║' end
 
       vim.api.nvim_buf_set_lines(sbuf2, 0, 1, true, replace)
     end
-  else
-    if self.swin1 and vim.api.nvim_win_is_valid(self.swin1) then
-      vim.api.nvim_win_hide(self.swin1)
-      self.swin1 = nil
-    end
-    if self.swin2 and vim.api.nvim_win_is_valid(self.swin2) then
-      vim.api.nvim_win_hide(self.swin2)
-      self.swin2 = nil
-    end
+  elseif self.swin and vim.api.nvim_win_is_valid(self.swin) then
+    vim.api.nvim_win_hide(self.swin)
+    self.swin = nil
   end
 
   -- In cmdline, vim does not redraw automatically.
@@ -213,13 +205,9 @@ window.close = function(self)
       vim.api.nvim_win_hide(self.win)
       self.win = nil
     end
-    if self.swin1 and vim.api.nvim_win_is_valid(self.swin1) then
-      vim.api.nvim_win_hide(self.swin1)
-      self.swin1 = nil
-    end
-    if self.swin2 and vim.api.nvim_win_is_valid(self.swin2) then
-      vim.api.nvim_win_hide(self.swin2)
-      self.swin2 = nil
+    if self.swin and vim.api.nvim_win_is_valid(self.swin) then
+      vim.api.nvim_win_hide(self.swin)
+      self.swin = nil
     end
   end
 end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -248,7 +248,7 @@ window.info = function(self)
         height = math.ceil(self.style.height * (self.style.height / content_height)),
         width = 1,
       }
-      info.scrollbar.col = info.col + info.width - info.scrollbar.width
+      info.scrollbar.col = info.col + info.width - (self.style.border[4] ~= '' and 1 or 0)
       info.scrollbar.row = info.row +
         math.min(self.style.height - info.scrollbar.height, math.floor(self.style.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
         (self.style.border ~= 'shadow' and self.style.border[2] ~= '' and 1 or 0)

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -134,16 +134,14 @@ window.update = function(self)
     info.scrollbar.relative = 'editor'
     info.scrollbar.style = 'minimal'
 
-    local has_border = math.max(info.border.height, info.border.width) > 0
-
     -- Draw the background of the scrollbar
-    if not has_border then
+    if self.style.border[2] == '' or self.style.border[2] == ' ' or math.max(info.border.height, info.border.width) < 1 then
       local style = {
         relative = info.scrollbar.relative,
         style = info.scrollbar.style,
         width = info.scrollbar.width,
         height = self.style.height,
-        row = info.row + (self.style.border ~= 'shadow' and self.style.border[2] ~= '' and 1 or 0),
+        row = info.row + ((self.style.border[2] == '' or self.style.border[2] == ' ' or self.style.border == 'shadow') and 0 or 1),
         col = info.scrollbar.col,
         zindex = (self.style.zindex and (self.style.zindex + 1) or 1),
       }
@@ -173,7 +171,7 @@ window.update = function(self)
     else
       info.scrollbar.noautocmd = true
       self.thumb_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'thumb_buf'), false, info.scrollbar)
-      local highlight = self.scrollbar == '' and 'PmenuThumb' or 'CmpWindow'..(has_border and 'Bordered' or '')..'ScrollThumb'
+      local highlight = self.scrollbar == '' and 'PmenuThumb' or 'CmpWindowScrollThumb'
       vim.api.nvim_win_set_option(self.thumb_win, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
     end
 
@@ -248,10 +246,10 @@ window.info = function(self)
         height = math.ceil(self.style.height * (self.style.height / content_height)),
         width = 1,
       }
-      info.scrollbar.col = info.col + info.width - (self.style.border[4] ~= '' and 1 or 0)
+      info.scrollbar.col = info.col + info.width - ((self.style.border[4] == '' or self.style.border[4] == ' ') and 0 or 1)
       info.scrollbar.row = info.row +
         math.min(self.style.height - info.scrollbar.height, math.floor(self.style.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
-        (self.style.border ~= 'shadow' and self.style.border[2] ~= '' and 1 or 0)
+        ((self.style.border[2] == '' or self.style.border[2] == ' ' or self.style.border == 'shadow') and 0 or 1)
       if border_width < 1 then
         info.width = info.width + info.scrollbar.width
       end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -18,8 +18,8 @@ local api = require('cmp.utils.api')
 ---@field public swin number|nil
 ---@field public style cmp.WindowStyle
 ---@field public opt table<string, any>
----@field public thin_scrollbar boolean|nil
 ---@field public buffer_opt table<string, any>
+---@field public scrollbar string
 ---@field public cache cmp.Cache
 local window = {}
 
@@ -170,17 +170,15 @@ window.update = function(self)
       style2.noautocmd = true
       local sbuf2 = buffer.ensure(self.name .. 'sbuf2')
       self.swin = vim.api.nvim_open_win(sbuf2, false, style2)
-      local highlight = self.thin_scrollbar and 'CmpItemMenuThumb' or 'PmenuThumb'
+      local highlight = self.scrollbar ~= '' and 'CmpItemMenuThumb' or 'PmenuThumb'
       vim.api.nvim_win_set_option(self.swin, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
 
-      if self.thin_scrollbar then
+      if self.scrollbar ~= '' then
         local replace = {}
         for i = 1, style2.height do replace[i] = '║' end
 
         vim.api.nvim_buf_set_lines(sbuf2, 0, 1, true, replace)
       end
-
-      vim.api.nvim_buf_set_lines(sbuf2, 0, 1, true, replace)
     end
   elseif self.swin and vim.api.nvim_win_is_valid(self.swin) then
     vim.api.nvim_win_hide(self.swin)

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -138,7 +138,7 @@ window.update = function(self)
       info.noautocmd = true
       local sbuf2 = buffer.ensure(self.name .. 'sbuf2')
       self.swin = vim.api.nvim_open_win(sbuf2, false, info)
-      local highlight = self.scrollbar ~= '' and 'CmpItemMenuThumb' or 'PmenuThumb'
+      local highlight = self.scrollbar == '' and 'PmenuThumb' or 'Cmp'..(math.max(info.border.height, info.border.width) > 0 and 'Bordered' or '')..'WindowScrollBar'
       vim.api.nvim_win_set_option(self.swin, 'winhighlight', 'EndOfBuffer:'..highlight..',NormalFloat:'..highlight)
 
       if self.scrollbar ~= '' then
@@ -204,15 +204,15 @@ window.info = function(self)
       }
       info.scrollbar.col = info.col + info.width - info.scrollbar.width
       info.scrollbar.row = info.row +
-			math.min(info.height - info.scrollbar.height, math.floor(info.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
-			(self.style.border ~= 'shadow' and self.style.border[4] ~= '' and 1 or 0)
+      math.min(info.height - info.scrollbar.height, math.floor(info.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
+      (self.style.border ~= 'shadow' and self.style.border[4] ~= '' and 1 or 0)
       info.width = info.width + info.scrollbar.width
     end
   end
     -- local info = self:info()
     -- local bar_height = math.max(1, math.ceil(info.height * (info.height / total) - 0.49))
 
-	return info
+  return info
 end
 
 --- @return number height, number width

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -103,17 +103,17 @@ end
 ---Set style.
 ---@param style cmp.WindowStyle
 window.set_style = function(self, style)
-  if vim.o.columns and vim.o.columns <= style.col + style.width then
-    style.width = vim.o.columns - style.col - 1
-  end
+  local border_offset_row = window.border_offset(style)
+  local _, border_offset_col = window.border_offset_scrollbar(style)
+  border_offset_col = border_offset_col * 2
 
   -- If there too little space on the right side of the screen.
   if vim.o.columns and vim.o.columns <= style.col + style.width + border_offset_col + 1 then
     style.col = math.max(1, vim.o.columns - style.width - border_offset_col - 1)
   end
 
-  if vim.o.lines and vim.o.lines <= style.row + style.height + border_offset + 1 then
-    style.height = vim.o.lines - style.row - border_offset - 1
+  if vim.o.lines and vim.o.lines <= style.row + style.height + border_offset_row + 1 then
+    style.height = vim.o.lines - style.row - border_offset_row - 1
   end
 
   -- If the popup will open above the cursor

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -27,10 +27,11 @@ local window = {}
 --- @return integer row the offset needed to account for the popup window
 window.border_offset = function(style)
   if style.border then
-    return (style.border[2] ~= '' and 1 or 0) + (style.border[6] ~= '' and 1 or 0)
+    return (style.border[2] ~= '' and 1 or 0) + (style.border[6] ~= '' and 1 or 0),
+           (style.border[4] ~= '' and 1 or 0) + (style.border[8] ~= '' and 1 or 0)
   end
 
-  return 0
+  return 0, 0
 end
 
 --- @param style cmp.WindowStyle
@@ -101,14 +102,6 @@ end
 ---@param style cmp.WindowStyle
 window.set_style = function(self, style)
   local border_offset = window.border_offset(style)
-
-  -- If the popup will open above the cursor
-  if vim.fn.screenrow() - 1 > style.row or api.is_cmdline_mode() then
-    -- shrink row by `border_offset`
-    style.row = style.row - border_offset
-    -- compensate for negative row with height adjustment
-    if style.row < 0 then style.height = style.height + style.row end
-  end
 
   if vim.o.lines and vim.o.lines <= style.row + style.height + border_offset + 1 then
     style.height = vim.o.lines - style.row - border_offset - 1

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -206,7 +206,9 @@ window.info = function(self)
       info.scrollbar.row = info.row +
         math.min(self.style.height - info.scrollbar.height, math.floor(self.style.height * (vim.fn.getwininfo(self.win)[1].topline / content_height))) +
         (self.style.border ~= 'shadow' and self.style.border[4] ~= '' and 1 or 0)
-      info.width = info.width + info.scrollbar.width
+      if border_width < 1 then
+        info.width = info.width + info.scrollbar.width
+      end
     end
   end
 

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -165,21 +165,7 @@ window.update = function(self)
     local bar_height = math.ceil(info.height * (info.height / total))
     local bar_offset = math.min(info.height - bar_height, math.floor(info.height * (vim.fn.getwininfo(self.win)[1].topline / total)))
     local border_offset_row, border_offset_col = window.border_offset_scrollbar(self.style)
-    local style1 = {}
-    style1.relative = 'editor'
-    style1.style = 'minimal'
-    style1.width = 1
-    style1.height = info.height
-    style1.row = info.row + border_offset_row
-    style1.col = info.col + info.width - (info.has_scrollbar and 1 or 0) - border_offset_col
-    style1.zindex = (self.style.zindex and (self.style.zindex + 1) or 1)
-    if self.swin1 and vim.api.nvim_win_is_valid(self.swin1) then
-      vim.api.nvim_win_set_config(self.swin1, style1)
-    else
-      style1.noautocmd = true
-      self.swin1 = vim.api.nvim_open_win(buffer.ensure(self.name .. 'sbuf1'), false, style1)
-      vim.api.nvim_win_set_option(self.swin1, 'winhighlight', 'EndOfBuffer:PmenuSbar,Normal:PmenuSbar,NormalNC:PmenuSbar,NormalFloat:PmenuSbar')
-    end
+
     local style2 = {}
     style2.relative = 'editor'
     style2.style = 'minimal'
@@ -192,8 +178,14 @@ window.update = function(self)
       vim.api.nvim_win_set_config(self.swin2, style2)
     else
       style2.noautocmd = true
-      self.swin2 = vim.api.nvim_open_win(buffer.ensure(self.name .. 'sbuf2'), false, style2)
-      vim.api.nvim_win_set_option(self.swin2, 'winhighlight', 'EndOfBuffer:PmenuThumb,Normal:PmenuThumb,NormalNC:PmenuThumb,NormalFloat:PmenuThumb')
+      local sbuf2 = buffer.ensure(self.name .. 'sbuf2')
+      self.swin2 = vim.api.nvim_open_win(sbuf2, false, style2)
+      vim.api.nvim_win_set_option(self.swin2, 'winhighlight', 'EndOfBuffer:PmenuThumb,NormalFloat:CmpItemMenuThumb')
+
+      local replace = {}
+      for i = 1, style2.height do replace[i] = '║' end
+
+      vim.api.nvim_buf_set_lines(sbuf2, 0, 1, true, replace)
     end
   else
     if self.swin1 and vim.api.nvim_win_is_valid(self.swin1) then

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -81,13 +81,13 @@ end
 ---Set style.
 ---@param style cmp.WindowStyle
 window.set_style = function(self, style)
-  local border_height = self:get_border_dimensions()
+  self.style = style
+  local info = self:info()
 
-  if vim.o.lines and vim.o.lines <= style.row + style.height + border_height + 1 then
-    style.height = vim.o.lines - style.row - border_height - 1
+  if vim.o.lines and vim.o.lines <= info.row + info.height + 1 then
+    self.style.height = vim.o.lines - info.row - info.border.height - 1
   end
 
-  self.style = style
   self.style.zindex = self.style.zindex or 1
 end
 

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -214,7 +214,7 @@ end
 
 ---Return the scrollbar will shown or not.
 window.has_scrollbar = function(self)
-  return (self.style.height or 0) < self:get_content_height()
+  return self.scrollbar and (self.style.height or 0) < self:get_content_height()
 end
 
 ---Return win info.

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -25,6 +25,8 @@ custom_entries_view.ns = vim.api.nvim_create_namespace('cmp.view.custom_entries_
 
 custom_entries_view.new = function()
   local self = setmetatable({}, { __index = custom_entries_view })
+  local border_height, border_width = window.get_border_dimensions({style=config.get().completion})
+
   self.entries_win = window.new()
   self.entries_win:option('conceallevel', 2)
   self.entries_win:option('concealcursor', 'n')
@@ -32,7 +34,7 @@ custom_entries_view.new = function()
   self.entries_win:option('foldenable', false)
   self.entries_win:option('wrap', false)
   self.entries_win:option('scrolloff', 0)
-  self.entries_win:option('winhighlight', 'Normal:Pmenu,CursorLine:PmenuSel,Search:None')
+  self.entries_win:option('winhighlight', 'Normal:Cmp'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..'Window,FloatBorder:CmpWindowBorder,CursorLine:PmenuSel,Search:None')
   -- This is done so that strdisplaywidth calculations for lines in the
   -- custom_entries_view window exactly match with what is really displayed,
   -- see comment in cmp.Entry.get_view. Setting tabstop to 1 makes all tabs be

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -175,7 +175,7 @@ custom_entries_view.open = function(self, offset, entries)
     width = width,
     height = height,
     border = completion.border,
-    zindex = 1001,
+    zindex = completion.zindex or 1001,
   })
   if preselect > 0 and config.get().preselect == types.cmp.PreselectMode.Item then
     self:_select(preselect, { behavior = types.cmp.SelectBehavior.Select })

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -25,7 +25,6 @@ custom_entries_view.ns = vim.api.nvim_create_namespace('cmp.view.custom_entries_
 
 custom_entries_view.new = function()
   local self = setmetatable({}, { __index = custom_entries_view })
-  local border_height, border_width = window.get_border_dimensions({style=config.get().window.completion})
 
   self.entries_win = window.new()
   self.entries_win:option('conceallevel', 2)
@@ -34,7 +33,7 @@ custom_entries_view.new = function()
   self.entries_win:option('foldenable', false)
   self.entries_win:option('wrap', false)
   self.entries_win:option('scrolloff', 0)
-  self.entries_win:option('winhighlight', 'Normal:CmpCompletionWIndow'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..',FloatBorder:CmpCompletionWindowBorder,CursorLine:PmenuSel,Search:None')
+  self.entries_win:option('winhighlight', 'Normal:CmpCompletionWindow,FloatBorder:CmpCompletionWindowBorder,CursorLine:PmenuSel,Search:None')
   -- This is done so that strdisplaywidth calculations for lines in the
   -- custom_entries_view window exactly match with what is really displayed,
   -- see comment in cmp.Entry.get_view. Setting tabstop to 1 makes all tabs be

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -33,7 +33,7 @@ custom_entries_view.new = function()
   self.entries_win:option('foldenable', false)
   self.entries_win:option('wrap', false)
   self.entries_win:option('scrolloff', 0)
-  self.entries_win:option('winhighlight', 'Normal:CmpCompletionWindow,FloatBorder:CmpCompletionWindowBorder,CursorLine:PmenuSel,Search:None')
+  self.entries_win:option('winhighlight', config.get().window.completion.winhighlight)
   -- This is done so that strdisplaywidth calculations for lines in the
   -- custom_entries_view window exactly match with what is really displayed,
   -- see comment in cmp.Entry.get_view. Setting tabstop to 1 makes all tabs be

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -154,7 +154,6 @@ custom_entries_view.open = function(self, offset, entries)
   local row, col = pos[1], pos[2] - delta - 1
 
   local completion = config.get().window.completion
-  -- TODO: centralize this logic
   local border_offset_row, border_offset_col = window.get_border_dimensions({style=completion})
 
   if math.floor(vim.o.lines * 0.5) <= row + border_offset_row and vim.o.lines - row - border_offset_row <= math.min(DEFAULT_HEIGHT, height) then

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -33,7 +33,6 @@ custom_entries_view.new = function()
   self.entries_win:option('foldenable', false)
   self.entries_win:option('wrap', false)
   self.entries_win:option('scrolloff', 0)
-  self.entries_win:option('winhighlight', config.get().window.completion.winhighlight)
   -- This is done so that strdisplaywidth calculations for lines in the
   -- custom_entries_view window exactly match with what is really displayed,
   -- see comment in cmp.Entry.get_view. Setting tabstop to 1 makes all tabs be
@@ -107,12 +106,14 @@ custom_entries_view.on_change = function(self)
 end
 
 custom_entries_view.open = function(self, offset, entries)
+  local completion = config.get().window.completion
   self.offset = offset
   self.entries = {}
   self.column_width = { abbr = 0, kind = 0, menu = 0 }
 
   -- Apply window options (that might be changed) on the custom completion menu.
   self.entries_win:option('winblend', vim.o.pumblend)
+  self.entries_win:option('winhighlight', completion.winhighlight)
 
   local entries_buf = self.entries_win:get_buffer()
   local lines = {}
@@ -152,9 +153,7 @@ custom_entries_view.open = function(self, offset, entries)
   local delta = cursor[2] + 1 - self.offset
   local row, col = pos[1], pos[2] - delta - 1
 
-  local completion = config.get().window.completion
   local border_offset_row, border_offset_col = window.get_border_dimensions({style=completion})
-
   if math.floor(vim.o.lines * 0.5) <= row + border_offset_row and vim.o.lines - row - border_offset_row <= math.min(DEFAULT_HEIGHT, height) then
     height = math.min(height, row - 1)
     row = row - height - border_offset_row - 1

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -159,7 +159,7 @@ custom_entries_view.open = function(self, offset, entries)
     row = row - height - border_offset_row - 1
     if row < 0 then height = height + row end
   end
-  if math.floor(vim.o.columns * 0.5) <= col + border_offset_col and vim.o.columns - col <= width + border_offset_col then
+  if math.floor(vim.o.columns * 0.5) <= col + border_offset_col and vim.o.columns - col - border_offset_col <= width then
     width = math.min(width, vim.o.columns - 1)
     col = vim.o.columns - width - border_offset_col - 1
     if col < 0 then width = width + col end

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -166,7 +166,7 @@ custom_entries_view.open = function(self, offset, entries)
     if col < 0 then width = width + col end
   end
 
-  self.entries_win.thin_scrollbar = completion.thin_scrollbar
+  self.entries_win.scrollbar = completion.scrollbar
   self.entries_win:open({
     relative = 'editor',
     style = 'minimal',

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -25,7 +25,7 @@ custom_entries_view.ns = vim.api.nvim_create_namespace('cmp.view.custom_entries_
 
 custom_entries_view.new = function()
   local self = setmetatable({}, { __index = custom_entries_view })
-  local border_height, border_width = window.get_border_dimensions({style=config.get().completion})
+  local border_height, border_width = window.get_border_dimensions({style=config.get().window.completion})
 
   self.entries_win = window.new()
   self.entries_win:option('conceallevel', 2)
@@ -153,7 +153,7 @@ custom_entries_view.open = function(self, offset, entries)
   local delta = cursor[2] + 1 - self.offset
   local row, col = pos[1], pos[2] - delta - 1
 
-  local completion = config.get().completion
+  local completion = config.get().window.completion
   -- TODO: centralize this logic
   local border_offset_row, border_offset_col = window.get_border_dimensions({style=completion})
 

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -26,6 +26,7 @@ custom_entries_view.ns = vim.api.nvim_create_namespace('cmp.view.custom_entries_
 custom_entries_view.new = function()
   local self = setmetatable({}, { __index = custom_entries_view })
   local border_height, border_width = window.get_border_dimensions({style=config.get().window.completion})
+  local has_border = math.max(border_height, border_width) > 0
 
   self.entries_win = window.new()
   self.entries_win:option('conceallevel', 2)
@@ -34,7 +35,7 @@ custom_entries_view.new = function()
   self.entries_win:option('foldenable', false)
   self.entries_win:option('wrap', false)
   self.entries_win:option('scrolloff', 0)
-  self.entries_win:option('winhighlight', 'Normal:Cmp'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..'Window,FloatBorder:CmpWindowBorder,CursorLine:PmenuSel,Search:None')
+  self.entries_win:option('winhighlight', 'Normal:Cmp'..(has_border and 'Bordered' or '')..'Window,FloatBorder:CmpWindowBorder,CursorLine:PmenuSel,Search:None')
   -- This is done so that strdisplaywidth calculations for lines in the
   -- custom_entries_view window exactly match with what is really displayed,
   -- see comment in cmp.Entry.get_view. Setting tabstop to 1 makes all tabs be
@@ -65,7 +66,7 @@ custom_entries_view.new = function()
       for i = top, bot do
         local e = self.entries[i + 1]
         if e then
-          local v = e:get_view(self.offset, buf)
+          local v = e:get_view(self.offset, buf, has_border)
           local o = SIDE_PADDING
           local a = 0
           for _, field in ipairs(fields) do

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -149,13 +149,12 @@ custom_entries_view.open = function(self, offset, entries)
   local pos = api.get_screen_cursor()
   local cursor = api.get_cursor()
   local delta = cursor[2] + 1 - self.offset
-  local has_bottom_space = (vim.o.lines - pos[1]) >= DEFAULT_HEIGHT
   local row, col = pos[1], pos[2] - delta - 1
 
   local completion = config.get().completion
   local border_offset_row, border_offset_col = window.border_offset(completion)
 
-  if not has_bottom_space and math.floor(vim.o.lines * 0.5) <= row + border_offset_row and vim.o.lines - row <= height + border_offset_row then
+  if math.floor(vim.o.lines * 0.5) <= row + border_offset_row and vim.o.lines - row - border_offset_row <= math.min(DEFAULT_HEIGHT, height) then
     height = math.min(height, row - 1)
     row = row - height - border_offset_row - 1
     if row < 0 then height = height + row end

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -34,7 +34,7 @@ custom_entries_view.new = function()
   self.entries_win:option('foldenable', false)
   self.entries_win:option('wrap', false)
   self.entries_win:option('scrolloff', 0)
-  self.entries_win:option('winhighlight', 'Normal:Cmp'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..'Window,FloatBorder:CmpWindowBorder,CursorLine:PmenuSel,Search:None')
+  self.entries_win:option('winhighlight', 'Normal:CmpCompletionWIndow'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..',FloatBorder:CmpCompletionWindowBorder,CursorLine:PmenuSel,Search:None')
   -- This is done so that strdisplaywidth calculations for lines in the
   -- custom_entries_view window exactly match with what is really displayed,
   -- see comment in cmp.Entry.get_view. Setting tabstop to 1 makes all tabs be

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -160,7 +160,9 @@ custom_entries_view.open = function(self, offset, entries)
     width = math.min(width, vim.o.columns - 1)
     col = vim.o.columns - width - 1
   end
+  local completion = config.get().completion
 
+  self.entries_win.thin_scrollbar = completion.thin_scrollbar
   self.entries_win:open({
     relative = 'editor',
     style = 'minimal',
@@ -168,7 +170,7 @@ custom_entries_view.open = function(self, offset, entries)
     col = math.max(0, col),
     width = width,
     height = height,
-    border = config.get().completion.border,
+    border = completion.border,
     zindex = 1001,
   })
   if preselect > 0 and config.get().preselect == types.cmp.PreselectMode.Item then

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -152,15 +152,19 @@ custom_entries_view.open = function(self, offset, entries)
   local has_bottom_space = (vim.o.lines - pos[1]) >= DEFAULT_HEIGHT
   local row, col = pos[1], pos[2] - delta - 1
 
-  if not has_bottom_space and math.floor(vim.o.lines * 0.5) <= row and vim.o.lines - row <= height then
-    height = math.min(height, row - 1)
-    row = row - height - 1
-  end
-  if math.floor(vim.o.columns * 0.5) <= col and vim.o.columns - col <= width then
-    width = math.min(width, vim.o.columns - 1)
-    col = vim.o.columns - width - 1
-  end
   local completion = config.get().completion
+  local border_offset_row, border_offset_col = window.border_offset(completion)
+
+  if not has_bottom_space and math.floor(vim.o.lines * 0.5) <= row + border_offset_row and vim.o.lines - row <= height + border_offset_row then
+    height = math.min(height, row - 1)
+    row = row - height - border_offset_row - 1
+    if row < 0 then height = height + row end
+  end
+  if math.floor(vim.o.columns * 0.5) <= col + border_offset_col and vim.o.columns - col <= width + border_offset_col then
+    width = math.min(width, vim.o.columns - 1)
+    col = vim.o.columns - width - border_offset_col - 1
+    if col < 0 then width = width + col end
+  end
 
   self.entries_win.thin_scrollbar = completion.thin_scrollbar
   self.entries_win:open({

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -152,7 +152,8 @@ custom_entries_view.open = function(self, offset, entries)
   local row, col = pos[1], pos[2] - delta - 1
 
   local completion = config.get().completion
-  local border_offset_row, border_offset_col = window.border_offset(completion)
+  -- TODO: centralize this logic
+  local border_offset_row, border_offset_col = window.get_border_dimensions({style=completion})
 
   if math.floor(vim.o.lines * 0.5) <= row + border_offset_row and vim.o.lines - row - border_offset_row <= math.min(DEFAULT_HEIGHT, height) then
     height = math.min(height, row - 1)

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -26,7 +26,6 @@ custom_entries_view.ns = vim.api.nvim_create_namespace('cmp.view.custom_entries_
 custom_entries_view.new = function()
   local self = setmetatable({}, { __index = custom_entries_view })
   local border_height, border_width = window.get_border_dimensions({style=config.get().window.completion})
-  local has_border = math.max(border_height, border_width) > 0
 
   self.entries_win = window.new()
   self.entries_win:option('conceallevel', 2)
@@ -35,7 +34,7 @@ custom_entries_view.new = function()
   self.entries_win:option('foldenable', false)
   self.entries_win:option('wrap', false)
   self.entries_win:option('scrolloff', 0)
-  self.entries_win:option('winhighlight', 'Normal:Cmp'..(has_border and 'Bordered' or '')..'Window,FloatBorder:CmpWindowBorder,CursorLine:PmenuSel,Search:None')
+  self.entries_win:option('winhighlight', 'Normal:Cmp'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..'Window,FloatBorder:CmpWindowBorder,CursorLine:PmenuSel,Search:None')
   -- This is done so that strdisplaywidth calculations for lines in the
   -- custom_entries_view window exactly match with what is really displayed,
   -- see comment in cmp.Entry.get_view. Setting tabstop to 1 makes all tabs be
@@ -66,7 +65,7 @@ custom_entries_view.new = function()
       for i = top, bot do
         local e = self.entries[i + 1]
         if e then
-          local v = e:get_view(self.offset, buf, has_border)
+          local v = e:get_view(self.offset, buf)
           local o = SIDE_PADDING
           local a = 0
           for _, field in ipairs(fields) do

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -82,7 +82,7 @@ docs_view.open = function(self, e, view)
   end
 
   local border_height, border_width = window.get_border_dimensions({style=documentation})
-  self.window:option('winhighlight', 'Normal:Cmp'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..'Window,FloatBorder:CmpWindowBorder')
+  self.window:option('winhighlight', 'Normal:CmpDocumentationWindow'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..',FloatBorder:CmpDocumentationWindowBorder')
   self.window:set_style({
     relative = 'editor',
     style = 'minimal',

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -61,8 +61,9 @@ docs_view.open = function(self, e, view)
     return self:close()
   end
 
+  local _, border_offset_col = window.border_offset(documentation)
   local right_col = view.col + view.width
-  local left_col = view.col - width - 2
+  local left_col = view.col - width - border_offset_col
 
   local col, left
   if right_space >= width and left_space >= width then

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -82,7 +82,7 @@ docs_view.open = function(self, e, view)
   end
 
   local _, border_width = window.get_border_dimensions({style=documentation})
-  self.window:option('winhighlight', 'Normal:CmpDocumentationWindow,FloatBorder:CmpDocumentationWindowBorder')
+  self.window:option('winhighlight', documentation.winhighlight)
   self.window:set_style({
     relative = 'editor',
     style = 'minimal',

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -93,7 +93,7 @@ docs_view.open = function(self, e, view)
     border = documentation.border,
     zindex = documentation.zindex or 50,
   })
-  self.window.thin_scrollbar = documentation.thin_scrollbar
+  self.window.scrollbar = documentation.scrollbar
   if left and self.window:has_scrollbar() then
     self.window.style.col = self.window.style.col - 1
   end

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -92,6 +92,7 @@ docs_view.open = function(self, e, view)
     border = documentation.border,
     zindex = documentation.zindex or 50,
   })
+  self.window.thin_scrollbar = documentation.thin_scrollbar
   if left and self.window:has_scrollbar() then
     self.window.style.col = self.window.style.col - 1
   end

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -81,8 +81,8 @@ docs_view.open = function(self, e, view)
     return self:close()
   end
 
-  local border_height, border_width = window.get_border_dimensions({style=documentation})
-  self.window:option('winhighlight', 'Normal:CmpDocumentationWindow'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..',FloatBorder:CmpDocumentationWindowBorder')
+  local _, border_width = window.get_border_dimensions({style=documentation})
+  self.window:option('winhighlight', 'Normal:CmpDocumentationWindow,FloatBorder:CmpDocumentationWindowBorder')
   self.window:set_style({
     relative = 'editor',
     style = 'minimal',

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -95,7 +95,7 @@ docs_view.open = function(self, e, view)
   })
   self.window.scrollbar = documentation.scrollbar
   if left then
-    self.window.style.col = self.window.style.col - self.window:info().border.width - 1
+    self.window.style.col = self.window.style.col - border_width - 1
   else
     self.window.style.col = self.window.style.col + 1
   end

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -23,7 +23,7 @@ end
 ---@param e cmp.Entry
 ---@param view cmp.WindowStyle
 docs_view.open = function(self, e, view)
-  local documentation = config.get().documentation
+  local documentation = config.get().window.documentation
   if not documentation then
     return
   end

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -34,7 +34,7 @@ docs_view.open = function(self, e, view)
 
   local right_space = vim.o.columns - (view.col + view.width) - 2
   local left_space = view.col - 2
-  local maxwidth = math.min(documentation.maxwidth, math.max(left_space, right_space) - 1)
+  local max_width = math.min(documentation.max_width, math.max(left_space, right_space) - 1)
 
   -- update buffer content if needed.
   if not self.entry or e.id ~= self.entry.id then
@@ -48,14 +48,14 @@ docs_view.open = function(self, e, view)
       vim.cmd([[syntax clear]])
     end)
     vim.lsp.util.stylize_markdown(self.window:get_buffer(), documents, {
-      max_width = maxwidth,
-      max_height = documentation.maxheight,
+      max_width = max_width,
+      max_height = documentation.max_height,
     })
   end
 
   local width, height = vim.lsp.util._make_floating_popup_size(vim.api.nvim_buf_get_lines(self.window:get_buffer(), 0, -1, false), {
-    max_width = maxwidth,
-    max_height = documentation.maxheight,
+    max_width = max_width,
+    max_height = documentation.max_height,
   })
   if width <= 0 or height <= 0 then
     return self:close()

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -95,9 +95,9 @@ docs_view.open = function(self, e, view)
   })
   self.window.scrollbar = documentation.scrollbar
   if left then
-    self.window.style.col = self.window.style.col - border_width - 1
+    self.window.style.col = self.window.style.col - border_width
   else
-    self.window.style.col = self.window.style.col + 1
+    self.window.style.col = self.window.style.col
   end
   self.window:open()
 end

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -61,9 +61,8 @@ docs_view.open = function(self, e, view)
     return self:close()
   end
 
-  local _, border_offset_col = window.border_offset(documentation)
   local right_col = view.col + view.width
-  local left_col = view.col - width - border_offset_col
+  local left_col = view.col - width
 
   local col, left
   if right_space >= width and left_space >= width then
@@ -94,8 +93,10 @@ docs_view.open = function(self, e, view)
     zindex = documentation.zindex or 50,
   })
   self.window.scrollbar = documentation.scrollbar
-  if left and self.window:has_scrollbar() then
-    self.window.style.col = self.window.style.col - 1
+  if left then
+    self.window.style.col = self.window.style.col - self.window:info().border.width - 1
+  else
+    self.window.style.col = self.window.style.col + 1
   end
   self.window:open()
 end

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -81,7 +81,8 @@ docs_view.open = function(self, e, view)
     return self:close()
   end
 
-  self.window:option('winhighlight', documentation.winhighlight)
+  local border_height, border_width = window.get_border_dimensions({style=documentation})
+  self.window:option('winhighlight', 'Normal:Cmp'..(math.max(border_height, border_width) > 0 and 'Bordered' or '')..'Window,FloatBorder:CmpWindowBorder')
   self.window:set_style({
     relative = 'editor',
     style = 'minimal',

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -90,11 +90,11 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
     end
   end
 
-  highlight.inherit('CmpWindowScrollBar', 'PmenuSbar', {
+  highlight.inherit('CmpCompletionScrollBar', 'PmenuSbar', {
     guifg = 'NONE',
     ctermfg = 'NONE',
   })
-  highlight.inherit('CmpWindowScrollThumb', 'PmenuThumb', {
+  highlight.inherit('CmpCompletionScrollThumb', 'PmenuThumb', {
     guibg = 'NONE',
     ctermbg = 'NONE',
   })
@@ -110,12 +110,11 @@ vim.cmd [[
   highlight default link CmpItemMenu CmpItemMenuDefault
 
   highlight default link CmpCompletionWindow Pmenu
-  highlight default link CmpCompletionWindowBorder CmpWindowBorder
-
+  highlight default link CmpCompletionWindowBorder NormalFloat
   highlight default link CmpDocumentationWindow NormalFloat
-  highlight default link CmpDocumentationWindowBorder CmpWindowBorder
-
-  highlight default link CmpWindowBorder NormalFloat
+  highlight default link CmpDocumentationWindowBorder CmpCompletionWindowBorder
+  highlight default link CmpDocumentationScrollThumb CmpCompletionScrollThumb
+  highlight default link CmpDocumentationScrollBar CmpCompletionScrollBar
 ]]
 
 for name in pairs(types.lsp.CompletionItemKind) do

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -111,7 +111,7 @@ vim.cmd [[
   highlight default link CmpItemKind CmpItemKindDefault
   highlight default link CmpItemMenu CmpItemMenuDefault
   highlight default link CmpWindow Pmenu
-  highlight default link CmpWindowBorder FloatBorder
+  highlight default link CmpWindowBorder CmpWindow
 ]]
 
 for name in pairs(types.lsp.CompletionItemKind) do

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -85,36 +85,26 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
       vim.cmd(([[highlight default link CmpItemKind%sDefault CmpItemKind]]):format(name))
     end
   end
-  highlight.inherit('CmpItemMenuDefault', 'Pmenu', {
-    guibg = 'NONE',
-    ctermbg = 'NONE',
-  })
-  highlight.inherit('CmpItemMenuThumb', 'PmenuThumb', {
+
+  highlight.inherit('CmpWindowScrollBar', 'PmenuThumb', {
     guibg = 'NONE',
     ctermbg = 'NONE',
   })
 end)
 _G.cmp.plugin.colorscheme()
 
-if vim.fn.hlexists('CmpItemAbbr') ~= 1 then
-  vim.cmd [[highlight default link CmpItemAbbr CmpItemAbbrDefault]]
-end
+vim.cmd [[
+  highlight default link CmpBorderedWindow CmpWindow
+  highlight default link CmpBorderedWindowScrollBar CmpWindowScrollBar
+  highlight default link CmpItemAbbr CmpItemAbbrDefault
+  highlight default link CmpItemAbbrDeprecated CmpItemAbbrDeprecatedDefault
+  highlight default link CmpItemAbbrMatch CmpItemAbbrMatchDefault
+  highlight default link CmpItemAbbrMatchFuzzy CmpItemAbbrMatchFuzzyDefault
+  highlight default link CmpItemKind CmpItemKindDefault
+  highlight default link CmpWindow NormalFloat
+  highlight default link CmpWindowBorder FloatBorder
+]]
 
-if vim.fn.hlexists('CmpItemAbbrDeprecated') ~= 1 then
-  vim.cmd [[highlight default link CmpItemAbbrDeprecated CmpItemAbbrDeprecatedDefault]]
-end
-
-if vim.fn.hlexists('CmpItemAbbrMatch') ~= 1 then
-  vim.cmd [[highlight default link CmpItemAbbrMatch CmpItemAbbrMatchDefault]]
-end
-
-if vim.fn.hlexists('CmpItemAbbrMatchFuzzy') ~= 1 then
-  vim.cmd [[highlight default link CmpItemAbbrMatchFuzzy CmpItemAbbrMatchFuzzyDefault]]
-end
-
-if vim.fn.hlexists('CmpItemKind') ~= 1 then
-  vim.cmd [[highlight default link CmpItemKind CmpItemKindDefault]]
-end
 for name in pairs(types.lsp.CompletionItemKind) do
   if type(name) == 'string' then
     local hi = ('CmpItemKind%s'):format(name)
@@ -122,10 +112,6 @@ for name in pairs(types.lsp.CompletionItemKind) do
       vim.cmd(([[highlight default link %s %sDefault]]):format(hi, hi))
     end
   end
-end
-
-if vim.fn.hlexists('CmpItemMenu') ~= 1 then
-  vim.cmd [[highlight default link CmpItemMenu CmpItemMenuDefault]]
 end
 
 vim.cmd [[command! CmpStatus lua require('cmp').status()]]

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -102,16 +102,23 @@ end)
 _G.cmp.plugin.colorscheme()
 
 vim.cmd [[
-  highlight default link CmpBorderedWindow NormalFloat
-  highlight default link CmpBorderedWindowScrollThumb CmpWindowScrollThumb
   highlight default link CmpItemAbbr CmpItemAbbrDefault
   highlight default link CmpItemAbbrDeprecated CmpItemAbbrDeprecatedDefault
   highlight default link CmpItemAbbrMatch CmpItemAbbrMatchDefault
   highlight default link CmpItemAbbrMatchFuzzy CmpItemAbbrMatchFuzzyDefault
   highlight default link CmpItemKind CmpItemKindDefault
   highlight default link CmpItemMenu CmpItemMenuDefault
-  highlight default link CmpWindow Pmenu
-  highlight default link CmpWindowBorder CmpWindow
+
+  highlight default link CmpCompletionWindow Pmenu
+  highlight default link CmpCompletionWindowBorder CmpWindowBorder
+  highlight default link CmpCompletionWindowBordered CmpCompletionWindow
+
+  highlight default link CmpDocumentationWindow NormalFloat
+  highlight default link CmpDocumentationWindowBorder CmpWindowBorder
+  highlight default link CmpDocumentationWindowBordered CmpDocumentationWindow
+
+  highlight default link CmpWindowBorder NormalFloat
+  highlight default link CmpWindowBorderedScrollThumb CmpWindowScrollThumb
 ]]
 
 for name in pairs(types.lsp.CompletionItemKind) do

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -103,7 +103,7 @@ _G.cmp.plugin.colorscheme()
 
 vim.cmd [[
   highlight default link CmpBorderedWindow CmpWindow
-  highlight default link CmpBorderedWindowScrollBar CmpWindowScrollBar
+  highlight default link CmpBorderedWindowScrollThumb CmpWindowScrollThumb
   highlight default link CmpItemAbbr CmpItemAbbrDefault
   highlight default link CmpItemAbbrDeprecated CmpItemAbbrDeprecatedDefault
   highlight default link CmpItemAbbrMatch CmpItemAbbrMatchDefault

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -89,6 +89,7 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
     guibg = 'NONE',
     ctermbg = 'NONE',
   })
+  highlight.inherit('CmpItemMenuThumb', 'PmenuThumb', {})
 end)
 _G.cmp.plugin.colorscheme()
 

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -8,7 +8,6 @@ local misc = require('cmp.utils.misc')
 local types = require('cmp.types')
 local config = require('cmp.config')
 local highlight = require('cmp.utils.highlight')
-local window = require('cmp.utils.window')
 
 -- TODO: https://github.com/neovim/neovim/pull/14661
 vim.cmd [[
@@ -91,14 +90,16 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
     end
   end
 
-  highlight.inherit('CmpWindowScrollBar', 'PmenuThumb', {
+  highlight.inherit('CmpWindowScrollBar', 'PmenuSbar', {
+    guifg = 'NONE',
+    ctermfg = 'NONE',
+  })
+  highlight.inherit('CmpWindowScrollThumb', 'PmenuThumb', {
     guibg = 'NONE',
     ctermbg = 'NONE',
   })
 end)
 _G.cmp.plugin.colorscheme()
-
-local border_height, border_width = window.get_border_dimensions({style=config.get().window.completion})
 
 vim.cmd [[
   highlight default link CmpBorderedWindow CmpWindow

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -90,11 +90,11 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
     end
   end
 
-  highlight.inherit('CmpCompletionScrollBar', 'PmenuSbar', {
+  highlight.inherit('CmpScrollBar', 'PmenuSbar', {
     guifg = 'NONE',
     ctermfg = 'NONE',
   })
-  highlight.inherit('CmpCompletionScrollThumb', 'PmenuThumb', {
+  highlight.inherit('CmpScrollThumb', 'PmenuThumb', {
     guibg = 'NONE',
     ctermbg = 'NONE',
   })
@@ -113,8 +113,6 @@ vim.cmd [[
   highlight default link CmpCompletionWindowBorder NormalFloat
   highlight default link CmpDocumentationWindow NormalFloat
   highlight default link CmpDocumentationWindowBorder CmpCompletionWindowBorder
-  highlight default link CmpDocumentationScrollThumb CmpCompletionScrollThumb
-  highlight default link CmpDocumentationScrollBar CmpCompletionScrollBar
 ]]
 
 for name in pairs(types.lsp.CompletionItemKind) do

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -81,6 +81,10 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
     guibg = 'NONE',
     ctermbg = 'NONE',
   })
+  highlight.inherit('CmpItemMenuDefault', 'Pmenu', {
+    guibg = 'NONE',
+    ctermbg = 'NONE',
+  })
   for name in pairs(types.lsp.CompletionItemKind) do
     if type(name) == 'string' then
       vim.cmd(([[highlight default link CmpItemKind%sDefault CmpItemKind]]):format(name))
@@ -96,7 +100,7 @@ _G.cmp.plugin.colorscheme()
 
 local border_height, border_width = window.get_border_dimensions({style=config.get().window.completion})
 
-vim.cmd([[
+vim.cmd [[
   highlight default link CmpBorderedWindow CmpWindow
   highlight default link CmpBorderedWindowScrollBar CmpWindowScrollBar
   highlight default link CmpItemAbbr CmpItemAbbrDefault
@@ -104,10 +108,10 @@ vim.cmd([[
   highlight default link CmpItemAbbrMatch CmpItemAbbrMatchDefault
   highlight default link CmpItemAbbrMatchFuzzy CmpItemAbbrMatchFuzzyDefault
   highlight default link CmpItemKind CmpItemKindDefault
+  highlight default link CmpItemMenu CmpItemMenuDefault
   highlight default link CmpWindow NormalFloat
   highlight default link CmpWindowBorder FloatBorder
-  highlight default link CmpItemMenu ]]..(math.max(border_height, border_width) > 0 and 'CmpBorderedWindow' or 'CmpWindow')
-)
+]]
 
 for name in pairs(types.lsp.CompletionItemKind) do
   if type(name) == 'string' then

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -89,7 +89,10 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
     guibg = 'NONE',
     ctermbg = 'NONE',
   })
-  highlight.inherit('CmpItemMenuThumb', 'PmenuThumb', {})
+  highlight.inherit('CmpItemMenuThumb', 'PmenuThumb', {
+    guibg = 'NONE',
+    ctermbg = 'NONE',
+  })
 end)
 _G.cmp.plugin.colorscheme()
 

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -8,6 +8,7 @@ local misc = require('cmp.utils.misc')
 local types = require('cmp.types')
 local config = require('cmp.config')
 local highlight = require('cmp.utils.highlight')
+local window = require('cmp.utils.window')
 
 -- TODO: https://github.com/neovim/neovim/pull/14661
 vim.cmd [[
@@ -93,7 +94,9 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
 end)
 _G.cmp.plugin.colorscheme()
 
-vim.cmd [[
+local border_height, border_width = window.get_border_dimensions({style=config.get().window.completion})
+
+vim.cmd([[
   highlight default link CmpBorderedWindow CmpWindow
   highlight default link CmpBorderedWindowScrollBar CmpWindowScrollBar
   highlight default link CmpItemAbbr CmpItemAbbrDefault
@@ -103,7 +106,8 @@ vim.cmd [[
   highlight default link CmpItemKind CmpItemKindDefault
   highlight default link CmpWindow NormalFloat
   highlight default link CmpWindowBorder FloatBorder
-]]
+  highlight default link CmpItemMenu ]]..(math.max(border_height, border_width) > 0 and 'CmpBorderedWindow' or 'CmpWindow')
+)
 
 for name in pairs(types.lsp.CompletionItemKind) do
   if type(name) == 'string' then

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -110,9 +110,13 @@ vim.cmd [[
   highlight default link CmpItemMenu CmpItemMenuDefault
 
   highlight default link CmpCompletionWindow Pmenu
-  highlight default link CmpCompletionWindowBorder NormalFloat
+  highlight default link CmpCompletionWindowBorder FloatBorder
+  highlight default link CmpCompletionWindowBordered CmpCompletionWindow
+  highlight default link CmpCompletionWindowPadding CmpCompletionWindow
   highlight default link CmpDocumentationWindow NormalFloat
   highlight default link CmpDocumentationWindowBorder CmpCompletionWindowBorder
+  highlight default link CmpDocumentationWindowBordered CmpDocumentationWindow
+  highlight default link CmpDocumentationWindowPadding CmpDocumentationWindow
 ]]
 
 for name in pairs(types.lsp.CompletionItemKind) do

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -102,7 +102,7 @@ end)
 _G.cmp.plugin.colorscheme()
 
 vim.cmd [[
-  highlight default link CmpBorderedWindow CmpWindow
+  highlight default link CmpBorderedWindow NormalFloat
   highlight default link CmpBorderedWindowScrollThumb CmpWindowScrollThumb
   highlight default link CmpItemAbbr CmpItemAbbrDefault
   highlight default link CmpItemAbbrDeprecated CmpItemAbbrDeprecatedDefault
@@ -110,7 +110,7 @@ vim.cmd [[
   highlight default link CmpItemAbbrMatchFuzzy CmpItemAbbrMatchFuzzyDefault
   highlight default link CmpItemKind CmpItemKindDefault
   highlight default link CmpItemMenu CmpItemMenuDefault
-  highlight default link CmpWindow NormalFloat
+  highlight default link CmpWindow Pmenu
   highlight default link CmpWindowBorder FloatBorder
 ]]
 

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -111,14 +111,11 @@ vim.cmd [[
 
   highlight default link CmpCompletionWindow Pmenu
   highlight default link CmpCompletionWindowBorder CmpWindowBorder
-  highlight default link CmpCompletionWindowBordered CmpCompletionWindow
 
   highlight default link CmpDocumentationWindow NormalFloat
   highlight default link CmpDocumentationWindowBorder CmpWindowBorder
-  highlight default link CmpDocumentationWindowBordered CmpDocumentationWindow
 
   highlight default link CmpWindowBorder NormalFloat
-  highlight default link CmpWindowBorderedScrollThumb CmpWindowScrollThumb
 ]]
 
 for name in pairs(types.lsp.CompletionItemKind) do


### PR DESCRIPTION
This PR is a followup to #224, adding support for custom borders in the completion menu:

![cap](https://user-images.githubusercontent.com/36409591/140399667-ab05c2b2-6e59-4e88-8336-7a55069364c8.png)

It can be added to any existing config like so:

```lua
cmp.setup {
  window = {
    completion = { -- rounded border; thin-style scrollbar
      border = 'rounded',
      scrollbar = '║',
    },
    documentation = { -- no border; native-style scrollbar
      border = nil,
      scrollbar = '',
      -- other options
    },
  },
  -- other options
}
```

Note: This implementation ~~may~~ also works for `cmdline`~~, though I don't have that in my config so I haven't been able to test it.~~

---

One change I want to highlight is the use of `FloatBorder` for the completion menu. `Pmenu` was being used, but this makes the borders look less like a floating window and more like a box within the existing `pum` window (compare closely with the above screenshot):

![cap](https://user-images.githubusercontent.com/36409591/140252624-0c699438-4c9c-4a6f-8bcf-7baed612206c.png)

I tried to leave comments with the logic behind all of the additions. Let me know if there are any questions or concerns.

---

~~The only bug persisting is this:~~

![cap](https://user-images.githubusercontent.com/36409591/140258797-26e8752c-ee09-4872-9baf-147a60875bf2.png)

~~It seems to have something to do with me not quite being able to tell when the pum menu will be rendered above, and when it is, pushing the rows up. I am working on a fix but any ideas are appreciated~~