### PR TITLE
Escape <Bar> when setting indentkeys

### DIFF
--- a/lua/cmp/utils/keymap.lua
+++ b/lua/cmp/utils/keymap.lua
@@ -79,7 +79,7 @@ keymap.autoindent = function()
   local keys = {}
   table.insert(keys, keymap.t('<Cmd>setlocal indentkeys+=!^F<CR>'))
   table.insert(keys, keymap.t('<C-f>'))
-  table.insert(keys, keymap.t('<Cmd>setlocal indentkeys=%s<CR>'):format(vim.bo.indentkeys))
+  table.insert(keys, keymap.t('<Cmd>setlocal indentkeys=%s<CR>'):format(vim.bo.indentkeys:gsub( '|', '\\|')))
   return table.concat(keys, '')
 end
 


### PR DESCRIPTION
In `keymap.autoindent`, `!^F` is added to `indentkeys`, then `<C-f>` is
fed.  In the end `indentkeys` is reset to its original value.

We need to escape any `|` in `indentkeys` when setting the option
because otherwise they are seen as the command separator.