### PR TITLE
Add linebreak option to cmp documentation window

### DIFF
--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -13,6 +13,7 @@ docs_view.new = function()
   self.window:option('conceallevel', 2)
   self.window:option('concealcursor', 'n')
   self.window:option('foldenable', false)
+  self.window:option('linebreak', true)
   self.window:option('scrolloff', 0)
   self.window:option('wrap', true)
   return self


### PR DESCRIPTION
Small PR that updates the documentation floating window to use the 'linebreak' option in Vim so that when text wraps, the whole word is moved to the next line if it's too long for the current line. In my opinion, it makes it much easier to read the docs 😃. You can see what I mean below.

Before this PR:
![Screen Shot 2021-11-07 at 12 36 09 AM](https://user-images.githubusercontent.com/37027883/140636588-c73dca91-c762-469f-b8ab-a411ad75b855.png)

After this PR:
![Screen Shot 2021-11-07 at 12 37 03 AM](https://user-images.githubusercontent.com/37027883/140636610-9bdacc66-d8d5-4c15-908e-d240d73baa51.png)

If you don't want to accept this change, I'd love if we could add a custom filetype for the Documentation window so that at least for myself, I can write an autocmd that sets the 'linebreak' option in my own config for the documentation window. I'd be happy to refactor this PR to do that if you'd prefer. Maybe there's already something in nvim-cmp that I can hook into that I am just not aware of instead of adding this new change, if so I'd love to hear about it!

Thanks for all of the AMAZING work you've done on this plugin hrsh7th. nvim-cmp is such a big boost to my productivity and enjoyment of writing code in Neovim :)