### PR TITLE
Automagically enable LSP completion in vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,13 @@ lua <<EOF
 
   -- Setup lspconfig.
   local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())
-  -- Replace <YOUR_LSP_SERVER> with each lsp server you've enabled.
-  require('lspconfig')['<YOUR_LSP_SERVER>'].setup {
-    capabilities = capabilities
-  }
+  -- Automagically enable each lsp server that's available
+  local lspconfig = require('lspconfig')
+  for key,server in pairs(lspconfig.available_servers()) do
+    lspconfig[server].setup {
+      capabilities = capabilities
+    }
+  end
 EOF
 ```
 


### PR DESCRIPTION
To make it easier for folks to add new servers, without needing to add
the configuration in their vimrc, too, we can instead use the
`lspconfig`'s `available_servers` method to list all servers, and
automagically apply our capabilities.
