### PR TITLE
Add documentation.delay option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,10 @@ If set to `false`, the documentation of each item will not be shown.
 Else, a table representing documentation configuration should be provided.
 The following are the possible options:
 
+#### documentation.delay (type: number)
+
+Delay in milliseconds before requesting documentation from the source.
+
 #### documentation.border (type: string[])
 
 Border characters used for documentation window.

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -31,6 +31,7 @@ return function()
     preselect = types.cmp.PreselectMode.Item,
 
     documentation = {
+      delay = 20,
       border = { '', '', '', ' ', '', '', '', ' ' },
       winhighlight = 'NormalFloat:NormalFloat,FloatBorder:NormalFloat',
       maxwidth = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -88,6 +88,7 @@ cmp.ItemField.Menu = 'menu'
 ---@field public get_trigger_characters fun(trigger_characters: string[]): string[]
 
 ---@class cmp.DocumentationConfig
+---@field public delay number
 ---@field public border string[]
 ---@field public winhighlight string
 ---@field public maxwidth number|nil

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -180,11 +180,15 @@ view._get_entries_view = function(self)
 
   if c.experimental.native_menu then
     self.native_entries_view.event:on('change', function()
+      self.on_entry_change.timeout = c.documentation.delay
+      self.on_entry_change.stop()
       self:on_entry_change()
     end)
     return self.native_entries_view
   else
     self.custom_entries_view.event:on('change', function()
+      self.on_entry_change.timeout = c.documentation.delay
+      self.on_entry_change.stop()
       self:on_entry_change()
     end)
     return self.custom_entries_view
@@ -221,7 +225,7 @@ view.on_entry_change = async.throttle(
       self.ghost_text_view:hide()
     end
   end),
-  20
+  config.get().documentation.delay
 )
 
 return view


### PR DESCRIPTION
This option can be used to reduce induced load on slow language servers
or just to delay the documentation popup.