### PR TITLE
Fix document about scrolling docs backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ lua <<EOF
       end,
     },
     mapping = {
-      ['<C-d>'] = cmp.mapping(cmp.mapping.scroll_docs(-4), { 'i', 'c' }),
+      ['<C-b>'] = cmp.mapping(cmp.mapping.scroll_docs(-4), { 'i', 'c' }),
       ['<C-f>'] = cmp.mapping(cmp.mapping.scroll_docs(4), { 'i', 'c' }),
       ['<C-Space>'] = cmp.mapping(cmp.mapping.complete(), { 'i', 'c' }),
       ['<C-y>'] = cmp.config.disable, -- Specify `cmp.config.disable` if you want to remove the default `<C-y>` mapping.
@@ -164,7 +164,7 @@ mapping = {
   ['<C-p>'] = cmp.mapping.select_prev_item({ behavior = cmp.SelectBehavior.Insert }),
   ['<Down>'] = cmp.mapping.select_next_item({ behavior = cmp.SelectBehavior.Select }),
   ['<Up>'] = cmp.mapping.select_prev_item({ behavior = cmp.SelectBehavior.Select }),
-  ['<C-d>'] = cmp.mapping.scroll_docs(-4),
+  ['<C-b>'] = cmp.mapping.scroll_docs(-4),
   ['<C-f>'] = cmp.mapping.scroll_docs(4),
   ['<C-Space>'] = cmp.mapping.complete(),
   ['<C-e>'] = cmp.mapping.close(),


### PR DESCRIPTION
A better key mapping, corresponding to `<C-f>`, for scrolling docs backwards is `<C-b>` because it is used for scrolling backwards in Vim (`:h CTRL-B`).

If you have purposely written `<C-d>`, close this PR. Thanks.