### PR TITLE
Fix possible nil argument to string.byte

### DIFF
--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -237,7 +237,7 @@ source.complete = function(self, ctx, callback)
   local before_char = string.sub(ctx.cursor_before_line, -1)
   if ctx:get_reason() == types.cmp.ContextReason.TriggerOnly then
     before_char = string.match(ctx.cursor_before_line, '(.)%s*$')
-    if not char.is_symbol(string.byte(before_char)) then
+    if not before_char or not char.is_symbol(string.byte(before_char)) then
       before_char = ''
     end
   end


### PR DESCRIPTION
This fixes the following error that occurred when trying to expand a `luasnip` choicenode snippet at the start of a line:
```lua
Error executing vim.schedule lua callback:
.../nvim/site/pack/packer/start/nvim-cmp/lua/cmp/source.lua:240:
bad argument #1 to 'byte' (string expected, got nil)
```