### PR TITLE
Fix duplicate doc tags

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -321,7 +321,7 @@ enabled~
   `boolean | fun(): boolean`
   You can control nvim-cmp should work or not via this option.
 
-                                                     *cmp-config.snippet.expand*
+                                                          *cmp-config.preselect*
 preselect~
   `cmp.PreselectMode`
 
@@ -381,11 +381,6 @@ sorting.comparators~
   `(fun(entry1: cmp.Entry, entry2: cmp.Entry): boolean | nil)[]`
   The function to customize the sorting behavior.
   You can use built-in comparators via `cmp.config.compare.*`.
-
-                                                  *cmp-config.formatting.fields*
-formatting.fields~
-  `cmp.ItemField[]`
-  The array of completion menu field to specify the order of them.
 
                                                             *cmp-config.sources*
 sources~


### PR DESCRIPTION
helptags were failing with an error:

```
Error detected while processing /home/perrin4869/dotfiles/home/.config/nvim/after/plugin/helptags.vim:
line    4:
E154: Duplicate tag "cmp-config.formatting.fields" in file /home/perrin4869/.local/share/nvim/site/pack/default/start/nvim-cmp/doc/cmp.txt
E154: Duplicate tag "cmp-config.snippet.expand" in file /home/perrin4869/.local/share/nvim/site/pack/default/start/nvim-cmp/doc/cmp.txt
```

This is the fix.
Thanks!