### PR TITLE
fix: default highlights overriding existing highlights

### DIFF
--- a/lua/cmp/utils/highlight.lua
+++ b/lua/cmp/utils/highlight.lua
@@ -10,7 +10,7 @@ highlight.keys = {
 }
 
 highlight.inherit = function(name, source, override)
-  local cmd = ('highlight! default %s'):format(name)
+  local cmd = ('highlight default %s'):format(name)
   for _, key in ipairs(highlight.keys) do
     if override[key] then
       cmd = cmd .. (' %s=%s'):format(key, override[key])

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -81,7 +81,7 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
   })
   for name in pairs(types.lsp.CompletionItemKind) do
     if type(name) == 'string' then
-      vim.cmd(([[highlight! default link CmpItemKind%sDefault CmpItemKindDefault]]):format(name))
+      vim.cmd(([[highlight default link CmpItemKind%sDefault CmpItemKindDefault]]):format(name))
     end
   end
   highlight.inherit('CmpItemMenuDefault', 'Pmenu', {
@@ -92,35 +92,35 @@ end)
 _G.cmp.plugin.colorscheme()
 
 if vim.fn.hlexists('CmpItemAbbr') ~= 1 then
-  vim.cmd [[highlight! default link CmpItemAbbr CmpItemAbbrDefault]]
+  vim.cmd [[highlight default link CmpItemAbbr CmpItemAbbrDefault]]
 end
 
 if vim.fn.hlexists('CmpItemAbbrDeprecated') ~= 1 then
-  vim.cmd [[highlight! default link CmpItemAbbrDeprecated CmpItemAbbrDeprecatedDefault]]
+  vim.cmd [[highlight default link CmpItemAbbrDeprecated CmpItemAbbrDeprecatedDefault]]
 end
 
 if vim.fn.hlexists('CmpItemAbbrMatch') ~= 1 then
-  vim.cmd [[highlight! default link CmpItemAbbrMatch CmpItemAbbrMatchDefault]]
+  vim.cmd [[highlight default link CmpItemAbbrMatch CmpItemAbbrMatchDefault]]
 end
 
 if vim.fn.hlexists('CmpItemAbbrMatchFuzzy') ~= 1 then
-  vim.cmd [[highlight! default link CmpItemAbbrMatchFuzzy CmpItemAbbrMatchFuzzyDefault]]
+  vim.cmd [[highlight default link CmpItemAbbrMatchFuzzy CmpItemAbbrMatchFuzzyDefault]]
 end
 
 if vim.fn.hlexists('CmpItemKind') ~= 1 then
-  vim.cmd [[highlight! default link CmpItemKind CmpItemKindDefault]]
+  vim.cmd [[highlight default link CmpItemKind CmpItemKindDefault]]
 end
 for name in pairs(types.lsp.CompletionItemKind) do
   if type(name) == 'string' then
     local hi = ('CmpItemKind%s'):format(name)
     if vim.fn.hlexists(hi) ~= 1 then
-      vim.cmd(([[highlight! default link %s %sDefault]]):format(hi, hi))
+      vim.cmd(([[highlight default link %s %sDefault]]):format(hi, hi))
     end
   end
 end
 
 if vim.fn.hlexists('CmpItemMenu') ~= 1 then
-  vim.cmd [[highlight! default link CmpItemMenu CmpItemMenuDefault]]
+  vim.cmd [[highlight default link CmpItemMenu CmpItemMenuDefault]]
 end
 
 vim.cmd [[command! CmpStatus lua require('cmp').status()]]


### PR DESCRIPTION
`highlight! default` overrides the existing highlight in order to set a default link. So any highlight group that exists before will be wiped over.

To fix this I have changed `highlight! default` to `highlight default`, which only sets the highlight group if it wasn't already defined.