### PR TITLE
Add ghost_visible()

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -65,6 +65,11 @@ cmp.visible = function()
   return cmp.core.view:visible() or vim.fn.pumvisible() == 1
 end
 
+---Return view ghost text is visible or not.
+cmp.ghost_visible = function()
+  return cmp.core.view:ghost_visible()
+end
+
 ---Get current selected entry or nil
 cmp.get_selected_entry = function()
   return cmp.core.view:get_selected_entry()

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -135,6 +135,10 @@ view.visible = function(self)
   return self:_get_entries_view():visible()
 end
 
+view.ghost_visible = function(self)
+  return self.ghost_text_view:visible()
+end
+
 ---Scroll documentation window if possible.
 ---@param delta number
 view.scroll_docs = function(self, delta)

--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -93,4 +93,11 @@ ghost_text_view.hide = function(self)
   end
 end
 
+ghost_text_view.visible = function(self)
+  if self.win and self.entry then
+    return true
+  end
+  return false
+end
+
 return ghost_text_view


### PR DESCRIPTION
This enables things like a super-tab that expands ghost text when possible:
```lua
    ['<Tab>'] = cmp.mapping(function(fallback)
      if cmp.ghost_visible() then
        cmp.confirm({ select = true })
      elseif cmp.visible() then
        cmp.select_next_item()
      elseif snip.expand_or_jumpable() then
        snip.expand_or_jump()
      elseif has_words_before() then
        cmp.complete()
      else
        fallback()
      end
    end, {"i", "s"}),
```