### PR TITLE
docs: clarify behavior of `select` in confirm mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ lua <<EOF
         i = cmp.mapping.abort(),
         c = cmp.mapping.close(),
       }),
+      -- Accept currently selected item. If none selected, `select` first item.
+      -- Set `select` to `false` to only confirm explicitly selected items.
       ['<CR>'] = cmp.mapping.confirm({ select = true }),
     },
     sources = cmp.config.sources({

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -96,6 +96,8 @@ NOTE:
           i = cmp.mapping.abort(),
           c = cmp.mapping.close(),
         }),
+        -- Accept currently selected item. If none selected, `select` first item.
+        -- Set `select` to `false` to only confirm explicitly selected items.
         ['<CR>'] = cmp.mapping.confirm({ select = true }),
       },
       sources = cmp.config.sources({


### PR DESCRIPTION
Relates to #557