### PR TITLE
Readme: improve readability of lua code block in setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Setup
 
 This example configuration uses `vim-plug` as the plugin manager and `vim-vsnip` as snippet plugin.
 
-```viml
+```lua
 call plug#begin(s:plug_dir)
 Plug 'neovim/nvim-lspconfig'
 Plug 'hrsh7th/cmp-nvim-lsp'


### PR DESCRIPTION
I just noticed this while reading the setup section.

Compare

<img src="https://user-images.githubusercontent.com/40792180/144997329-e236aeaa-176f-4dd9-9fc3-1b9d5cc22a32.png" width=50%> </img>

with

<img src="https://user-images.githubusercontent.com/40792180/144997419-6afa1d51-04a6-4c72-9caf-898f62dcbe85.png" width=50%> </img>

Especially the comments look nicer imo.