### PR TITLE
feat: make throttle time configurable

### DIFF
--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -120,6 +120,7 @@ return function()
     experimental = {
       native_menu = false,
       ghost_text = false,
+      throttle_time = 120,
     },
 
     sources = {},

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -14,7 +14,6 @@ local api = require('cmp.utils.api')
 local event = require('cmp.utils.event')
 
 local SOURCE_TIMEOUT = 500
-local THROTTLE_TIME = 120
 
 ---@class cmp.Core
 ---@field public suspending boolean
@@ -165,7 +164,7 @@ core.on_change = function(self, trigger_event)
       if vim.tbl_contains(config.get().completion.autocomplete or {}, trigger_event) then
         self:complete(ctx)
       else
-        self.filter.timeout = THROTTLE_TIME
+        self.filter.timeout = config.get().experimental.throttle_time
         self:filter()
       end
     else
@@ -246,7 +245,7 @@ core.complete = function(self, ctx, source_configs)
             end
           end
           if not self.view:get_active_entry() then
-            self.filter.timeout = self.view:visible() and THROTTLE_TIME or 0
+            self.filter.timeout = self.view:visible() and config.get().experimental.throttle_time or 0
             self:filter()
           end
         end
@@ -256,7 +255,7 @@ core.complete = function(self, ctx, source_configs)
   end
 
   if not self.view:get_active_entry() then
-    self.filter.timeout = THROTTLE_TIME
+    self.filter.timeout = config.get().experimental.throttle_time
     self:filter()
   end
 end
@@ -264,7 +263,7 @@ end
 ---Update completion menu
 core.filter = async.throttle(
   vim.schedule_wrap(function(self)
-    self.filter.timeout = THROTTLE_TIME
+    self.filter.timeout = config.get().experimental.throttle_time
 
     local ignore = false
     ignore = ignore or not api.is_suitable_mode()
@@ -302,7 +301,7 @@ core.filter = async.throttle(
       end
     end
   end),
-  THROTTLE_TIME
+  config.get().experimental.throttle_time
 )
 
 ---Confirm completion.


### PR DESCRIPTION
For me nvim-cmp feels a lot more snappy when lowering the throttle_time in core.lua. I do not notice an increase in flickering or something else on my device. As such, I think it makes sense to make this a configurable option.

Thanks for the work on this amazing plugin!