### PR TITLE
Correct vim doc reference for getcmdtype()

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -149,7 +149,7 @@ NOTE: You can call these functions in mapping via `<Cmd>lua require('cmp').compl
 
 *cmp.setup.cmdline* (cmdtype: string, config: cmp.ConfigSchema)
   Setup cmdline configuration to the specific cmdtype.
-  See |getcmetype()|
+  See |getcmdtype()|
   NOTE: nvim-cmp does not support the `=` cmdtype.
 
 *cmp.visible* ()


### PR DESCRIPTION
Pretty sure this is a typo.