### PR TITLE
Fix `vim.fn.complete` being constantly called by the `native_entries_view`

### DIFF
--- a/lua/cmp/view/native_entries_view.lua
+++ b/lua/cmp/view/native_entries_view.lua
@@ -77,7 +77,7 @@ native_entries_view.open = function(self, offset, entries)
 end
 
 native_entries_view.close = function(self)
-  if api.is_suitable_mode() then
+  if api.is_suitable_mode() and self:visible() then
     vim.fn.complete(1, {})
     vim.api.nvim_select_popupmenu_item(-1, false, true, {})
   end


### PR DESCRIPTION
Fixes #653