### PR TITLE
Use a default zindex of 50 for documentation

### DIFF
--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -90,7 +90,7 @@ docs_view.open = function(self, e, view)
     row = view.row,
     col = col,
     border = documentation.border,
-    zindex = documentation.zindex,
+    zindex = documentation.zindex or 50,
   })
   if left and self.window:has_scrollbar() then
     self.window.style.col = self.window.style.col - 1


### PR DESCRIPTION
Unless manually configured, the current default zindex for documentation is 1.

This limits the flexibility of other floating windows to have lower zindex, since 1 is the lowest.

This PR changes the default zindex to 50 for documentation floating windows, to match Neovim's default zindex for floating windows.

I see that the default of 1 is specified in [window.lua](https://github.com/hrsh7th/nvim-cmp/blob/9c07c2d1c5581b22f742b891cadd42a311c1cf96/lua/cmp/utils/window.lua#L89). If the idea of changing default documentation zindex is acceptable, that would seemingly be an alternative place to make the change, and have the benefit that it would apply for all floats, not just documentation.

I noticed this in an attempt to address an [issue](https://github.com/dstein64/nvim-scrollview/issues/60) for a scrollbar plugin I wrote.