### PR TITLE
Change cmp#ready to CmpReady and document autocmds better

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -325,8 +325,11 @@ Highlight                                                        *cmp-highlight*
 ==============================================================================
 Autocmd                                                            *cmp-autocmd*
 
-*cmp#ready*
-  Invoke after sourcing the `plugin/cmp.lua`
+You can create custom autocommands for certain nvim-cmp events by defining
+autocommands for the User event with the following patterns.
+
+*CmpReady*
+  Invoked when nvim-cmp gets sourced from `plugin/cmp.lua`.
 
 
 

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -126,7 +126,7 @@ end
 
 vim.cmd [[command! CmpStatus lua require('cmp').status()]]
 
-vim.cmd [[doautocmd <nomodeline> User cmp#ready]]
+vim.cmd [[doautocmd <nomodeline> User CmpReady]]
 
 if vim.on_key then
   vim.on_key(function(keys)


### PR DESCRIPTION
I was bored, so I browsed the codebase to learn more about how nvim-cmp works.

I changed `cmp#ready` to `CmpReady` because I was confused with the naming convention; I thought it was an autoloaded function. I think the naming convention for User event autocommand patterns is upper camel-case. I also added a description in the docs on how to use these autocommands.

Please feel free to disregard if you disagree with any of these changes.