### PR TITLE
Handle nvim_{buf_}get_keymap return no rhs due to 'callback' mapping

### DIFF
--- a/lua/cmp/utils/keymap.lua
+++ b/lua/cmp/utils/keymap.lua
@@ -17,7 +17,7 @@ keymap.normalize = function(keys)
   vim.api.nvim_set_keymap('t', '<Plug>(cmp.utils.keymap.normalize)', keys, {})
   for _, map in ipairs(vim.api.nvim_get_keymap('t')) do
     if keymap.equals(map.lhs, '<Plug>(cmp.utils.keymap.normalize)') then
-      return map.rhs
+      return map.rhs or ""
     end
   end
   return keys
@@ -122,7 +122,7 @@ keymap.get_mapping = function(mode, lhs)
     if keymap.equals(map.lhs, lhs) then
       return {
         lhs = map.lhs,
-        rhs = map.rhs,
+        rhs = map.rhs or "",
         expr = map.expr == 1,
         noremap = map.noremap == 1,
         script = map.script == 1,
@@ -137,7 +137,7 @@ keymap.get_mapping = function(mode, lhs)
     if keymap.equals(map.lhs, lhs) then
       return {
         lhs = map.lhs,
-        rhs = map.rhs,
+        rhs = map.rhs or "",
         expr = map.expr == 1,
         noremap = map.noremap == 1,
         script = map.script == 1,


### PR DESCRIPTION
This is the only issue I've run into when using the new `nvim_{buf_}set_keymap` functions added recently. Not sure if there is a cleaner way to fix it, but essentially we can no longer rely on the mappings having a `rhs` (as returned from `nvim_{buf_}get_keymap`) if they instead define a `callback` as part of the `opts` key.

These are the only place where I can see that this API function is used.

Fixes #699, original core _PR_ [here](https://github.com/neovim/neovim/commit/b411f436d3e2e8a902dbf879d00fc5ed0fc436d3)