### PR TITLE
Default CmpItemKind%name% to CmpItemKind

### DIFF
--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -82,7 +82,7 @@ misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
   })
   for name in pairs(types.lsp.CompletionItemKind) do
     if type(name) == 'string' then
-      vim.cmd(([[highlight default link CmpItemKind%sDefault CmpItemKindDefault]]):format(name))
+      vim.cmd(([[highlight default link CmpItemKind%sDefault CmpItemKind]]):format(name))
     end
   end
   highlight.inherit('CmpItemMenuDefault', 'Pmenu', {


### PR DESCRIPTION
Reading the doc it seemed I could set `CmpItemKind` to override all item kind. Am I missing something?