### PR TITLE
Fix docs to avoid "E20: Mark not set" error

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -592,7 +592,7 @@ How to setup on the specific buffer?~
 
 You can setup buffer specific configuration like this.
 >
-  autocmd FileType markdown * lua require('cmp').setup.buffer {
+  autocmd FileType markdown lua require('cmp').setup.buffer {
   \   sources = {
   \     { name = 'path' },
   \     { name = 'buffer' },


### PR DESCRIPTION
`autocmd` notation is invalid in the FAQ session.

The way it is set it generates an "E20: Mark not set" error when buffer of given filetype is opened.

This PR set correct `autocmd` notation.