### PR TITLE
Fix: close the view if cmp.enabled = false and the user types some text

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -309,12 +309,18 @@ end)
 autocmd.subscribe('TextChanged', function()
   if config.enabled() then
     cmp.core:on_change('TextChanged')
+  else
+    cmp.core:reset()
+    cmp.core.view:close()
   end
 end)
 
 autocmd.subscribe('CursorMoved', function()
   if config.enabled() then
     cmp.core:on_moved()
+  else
+    cmp.core:reset()
+    cmp.core.view:close()
   end
 end)
 


### PR DESCRIPTION
A scenario where this lead to unintended behaviour previously was the following:

If cmp.enabled was configured such that it disabled cmp when in a comment,
and the user typed `--` in a lua file (this starts a comment), the cmp window
would not close if further text is typed on that line (although cmp should be disabled).

---

I have the following in my config:
```lua
enabled = function()
  local in_prompt = vim.api.nvim_buf_get_option(0, "buftype") == "prompt"
  if in_prompt then
    return false
  end
  local context = require("cmp.config.context")
  return not(context.in_treesitter_capture("comment") == true or context.in_syntax_group("Comment"))
end,
```

To see what the issue is, have a look at the following GIF:
![cmp_bug_pre](https://user-images.githubusercontent.com/40792180/153393234-f9a291e1-4398-4fd5-9a12-ac7453c2b150.gif)

This PR should fix it:
![cmp_bug_post](https://user-images.githubusercontent.com/40792180/153393533-1b8a4fab-d4ac-498d-a758-2f9c30f96b7b.gif)

Let me know if there is a better way to fix this :)