### PR TITLE
Added `event_chars` property to `confirm_done event`

### DIFF
--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -119,6 +119,7 @@ core.on_keymap = function(self, keys, fallback)
     local is_printable = char.is_printable(string.byte(chars, 1))
     self:confirm(e, {
       behavior = is_printable and 'insert' or 'replace',
+      commit_chars = chars,
     }, function()
       local ctx = self:get_context()
       local word = e:get_word()
@@ -429,6 +430,7 @@ core.confirm = function(self, e, option, callback)
       release()
       self.event:emit('confirm_done', {
         entry = e,
+        commit_chars = option.commit_chars,
       })
       if callback then
         callback()

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -119,7 +119,7 @@ core.on_keymap = function(self, keys, fallback)
     local is_printable = char.is_printable(string.byte(chars, 1))
     self:confirm(e, {
       behavior = is_printable and 'insert' or 'replace',
-      commit_chars = chars,
+      commit_character = chars,
     }, function()
       local ctx = self:get_context()
       local word = e:get_word()
@@ -430,7 +430,7 @@ core.confirm = function(self, e, option, callback)
       release()
       self.event:emit('confirm_done', {
         entry = e,
-        commit_chars = option.commit_chars,
+        commit_character = option.commit_character,
       })
       if callback then
         callback()

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -38,6 +38,7 @@ cmp.ItemField.Menu = 'menu'
 
 ---@class cmp.ConfirmOption
 ---@field public behavior cmp.ConfirmBehavior
+---@field public commit_chars? string
 
 ---@class cmp.SelectOption
 ---@field public behavior cmp.SelectBehavior

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -38,7 +38,7 @@ cmp.ItemField.Menu = 'menu'
 
 ---@class cmp.ConfirmOption
 ---@field public behavior cmp.ConfirmBehavior
----@field public commit_chars? string
+---@field public commit_character? string
 
 ---@class cmp.SelectOption
 ---@field public behavior cmp.SelectBehavior


### PR DESCRIPTION
Currently it seems there is no way for someone listening to the
`confirm_done` event to know exactly what character was used to commit
the completion confirmation.

This commit adds a `event_chars` property to the `confirm_done` event.
Its value is just the `chars` variable form the `core.on_keymap`
function.

This should help resolving a double parentheses issue with nvim-autopairs (#780).