### PR TITLE
Make sure config is not nil

### DIFF
--- a/lua/cmp/config.lua
+++ b/lua/cmp/config.lua
@@ -157,6 +157,10 @@ end
 ---@param c cmp.ConfigSchema
 ---@return cmp.ConfigSchema
 config.normalize = function(c)
+
+  -- make sure c is not 'nil'
+  local c = c == nil and {} or c
+
   if c.mapping then
     local normalized = {}
     for k, v in pairs(c.mapping) do


### PR DESCRIPTION
This ensures that the config is at least `{}` and never `nil`.
Otherwise, calling `cmp.setup()` errors out.