### PR TITLE
use only the first filetype for formatting

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -411,9 +411,14 @@ entry.get_documentation = function(self)
 
   -- detail
   if misc.safe(item.detail) and item.detail ~= '' then
+    local ft = self.context.filetype
+    local dot_index = string.find(ft, "%.")
+    if dot_index ~= nil then
+        ft = string.sub(ft, 0, dot_index-1)
+    end
     table.insert(documents, {
       kind = types.lsp.MarkupKind.Markdown,
-      value = ('```%s\n%s\n```'):format(self.context.filetype, str.trim(item.detail)),
+      value = ('```%s\n%s\n```'):format(ft, str.trim(item.detail)),
     })
   end
 


### PR DESCRIPTION
This fix syntax highlighting when handling files with multiple-filetype.

![Screenshot 2022-03-27 at 2 57 00 PM](https://user-images.githubusercontent.com/197371/160270389-95447baa-cc76-4b22-8b1b-9bf3ce7242c5.png)

After fix

![Screenshot 2022-03-27 at 2 58 07 PM](https://user-images.githubusercontent.com/197371/160270417-e732af1a-2fcf-4d12-9e1f-ab770567af65.png)

If there is a better way to fix this, let me know :)