### PR TITLE
fix: stop popup buffers from staying in memory after they close

### DIFF
--- a/lua/cmp/utils/buffer.lua
+++ b/lua/cmp/utils/buffer.lua
@@ -21,7 +21,7 @@ buffer.ensure = function(name)
     created_new = true
     buf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_option(buf, 'buftype', 'nofile')
-    vim.api.nvim_buf_set_option(buf, 'bufhidden', 'hide')
+    vim.api.nvim_buf_set_option(buf, 'bufhidden', 'wipe')
     buffer.cache[name] = buf
   end
   return buf, created_new


### PR DESCRIPTION
I noticed that popup menu buffers stick around in the buffer list even after they are hidden, at least for a while. You can see them using `:ls!`. From the vim docs:

https://github.com/neovim/neovim/blob/1186f7dd96b054d6a653685089fc845a8f5d2f27/runtime/doc/windows.txt#L1274-L1282

This manifests in nvim-cmp's popups appearing in the buffer list in [Airline](https://github.com/vim-airline/vim-airline), and possibly other statusline plugins too.

![Screenshot_2022-04-10_22-31-42](https://user-images.githubusercontent.com/8149273/162671247-176b7229-135a-41f5-b22a-e49b7966ee5f.png)

Changing to 'wipe' deletes the buffer immediately after it is hidden deletes the scratch buffers immediately and prevents this, and doesn't seem to affect functionality.

https://github.com/neovim/neovim/blob/1186f7dd96b054d6a653685089fc845a8f5d2f27/runtime/doc/options.txt#L1068-L1070