### PR TITLE
Update README.md with reasonable defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ lua <<EOF
       -- documentation = cmp.config.window.bordered(),
     },
     mapping = cmp.mapping.preset.insert({
+      ['<C-p>'] = cmp.mapping.select_prev_item(),
+      ['<C-n>'] = cmp.mapping.select_next_item(),
       ['<C-b>'] = cmp.mapping.scroll_docs(-4),
       ['<C-f>'] = cmp.mapping.scroll_docs(4),
       ['<C-Space>'] = cmp.mapping.complete(),


### PR DESCRIPTION
As the default for traversing the Autocomplete list was recently removed, having these defaults as the recommended configuration for new users will greatly reduce redundant questions from these new users.