### PR TITLE
fix: use vim.treesitter.query instead of deprecated nvim-treesitter.t…

### DIFF
--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -175,7 +175,6 @@ compare.scopes = setmetatable({
     if ok then
       local win, buf = vim.api.nvim_get_current_win(), vim.api.nvim_get_current_buf()
       local cursor_row = vim.api.nvim_win_get_cursor(win)[1] - 1
-      local ts_utils = require('nvim-treesitter.ts_utils')
 
       -- Cursor scope.
       local cursor_scope = nil
@@ -205,7 +204,7 @@ compare.scopes = setmetatable({
         for _, definition in pairs(definitions) do
           if s <= definition.node:start() and definition.node:end_() <= e then
             if scope:id() == locals.containing_scope(definition.node, buf):id() then
-              local text = ts_utils.get_node_text(definition.node)[1]
+              local text = vim.treesitter.query.get_node_text(definition.node)[1]
               if not self.scopes_map[text] then
                 self.scopes_map[text] = depth
               end


### PR DESCRIPTION
…s_utils

Using vim.treesitter.query instead of deprecated nvim-treesitter.ts_query in https://github.com/nvim-treesitter/nvim-treesitter/commit/c3848e713a8272e524a7eabe9eb0897cf2d6932e

Fixes:
![image](https://user-images.githubusercontent.com/17691791/163973692-91625214-14fd-4d05-b388-2d30f89b3c8f.png)
