### PR TITLE
Implement nvim_create_user_command

### DIFF
--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -102,7 +102,9 @@ if vim.on_key then
   end, vim.api.nvim_create_namespace('cmp.plugin'))
 end
 
-vim.cmd([[command! CmpStatus lua require('cmp').status()]])
+vim.api.nvim_create_user_command('CmpStatus', function()
+  require('cmp').status()
+end, { desc = 'Check status of cmp sources' })
 
 vim.cmd([[doautocmd <nomodeline> User CmpReady]])
 


### PR DESCRIPTION
This moves the creation of the `:CmpStatus` command to the new `vim.api.nvim_create_user_command` API

This requires neovim 0.7 so it should be done along with #844 