### PR TITLE
fix: Fix stylua errors and install_stylua script

### DIFF
--- a/lua/cmp/config/mapping.lua
+++ b/lua/cmp/config/mapping.lua
@@ -1,7 +1,7 @@
 local types = require('cmp.types')
 local misc = require('cmp.utils.misc')
 local feedkeys = require('cmp.utils.feedkeys')
-local keymap   = require('cmp.utils.keymap')
+local keymap = require('cmp.utils.keymap')
 
 local mapping = setmetatable({}, {
   __call = function(_, invoke, modes)
@@ -39,7 +39,7 @@ mapping.preset.insert = function(override)
     },
     ['<C-e>'] = {
       i = mapping.abort(),
-    }
+    },
   })
 end
 
@@ -54,7 +54,7 @@ mapping.preset.cmdline = function(override)
         else
           feedkeys.call(keymap.t('<C-z>'), 'n')
         end
-      end
+      end,
     },
     ['<S-Tab>'] = {
       c = function()
@@ -64,7 +64,7 @@ mapping.preset.cmdline = function(override)
         else
           feedkeys.call(keymap.t('<C-z>'), 'n')
         end
-      end
+      end,
     },
     ['<C-n>'] = {
       c = function(fallback)
@@ -74,7 +74,7 @@ mapping.preset.cmdline = function(override)
         else
           fallback()
         end
-      end
+      end,
     },
     ['<C-p>'] = {
       c = function(fallback)
@@ -84,7 +84,7 @@ mapping.preset.cmdline = function(override)
         else
           fallback()
         end
-      end
+      end,
     },
     ['<C-e>'] = {
       c = mapping.close(),

--- a/lua/cmp/utils/misc.lua
+++ b/lua/cmp/utils/misc.lua
@@ -251,4 +251,3 @@ misc.redraw = setmetatable({
 })
 
 return misc
-

--- a/utils/install_stylua.sh
+++ b/utils/install_stylua.sh
@@ -4,8 +4,7 @@ set -eu pipefall
 
 declare -r INSTALL_DIR="$PWD/utils"
 declare -r RELEASE="0.10.0"
-declare -r OS="linux"
-# declare -r OS="$(uname -s)"
+declare -r OS=$([ "$(uname -s)" == "Darwin" ] && echo "macos" || echo "linux")
 declare -r FILENAME="stylua-$RELEASE-$OS"
 
 declare -a __deps=("curl" "unzip")


### PR DESCRIPTION
The CI/Actions has been broken for a while (we shouldn't be ignoring build errors) and this PR should fix the CI build errors due to stylua.

- Fix code style issues, suggested by stylua
- Update install_stylua.lua script so that it can run in macOS as well.
