### PR TITLE
Move highlights to nvim_set_hl lua API

### DIFF
--- a/lua/cmp/utils/highlight.lua
+++ b/lua/cmp/utils/highlight.lua
@@ -1,46 +1,30 @@
 local highlight = {}
 
 highlight.keys = {
-  'gui',
-  'guifg',
-  'guibg',
-  'cterm',
-  'ctermfg',
-  'ctermbg',
+  'fg',
+  'bg',
+  'bold',
+  'italic',
+  'reverse',
+  'standout',
+  'underline',
+  'undercurl',
+  'strikethrough',
 }
 
-highlight.inherit = function(name, source, override)
-  local cmd = ('highlight default %s'):format(name)
+highlight.inherit = function(name, source, settings)
   for _, key in ipairs(highlight.keys) do
-    if override[key] then
-      cmd = cmd .. (' %s=%s'):format(key, override[key])
-    else
-      local v = highlight.get(source, key)
-      v = v == '' and 'NONE' or v
-      cmd = cmd .. (' %s=%s'):format(key, v)
-    end
-  end
-  vim.cmd(cmd)
-end
-
-highlight.get = function(source, key)
-  if key == 'gui' or key == 'cterm' then
-    local ui = {}
-    for _, k in ipairs({ 'bold', 'italic', 'reverse', 'inverse', 'standout', 'underline', 'undercurl', 'strikethrough' }) do
-      if vim.fn.synIDattr(vim.fn.hlID(source), k, key) == 1 then
-        table.insert(ui, k)
+    if not settings[key] then
+      local v = vim.fn.synIDattr(vim.fn.hlID(source), key)
+      if key ~= 'fg' and key ~= 'bg' then
+        v = v == 1
+      end
+      if v then
+        settings[key] = v == '' and 'NONE' or v
       end
     end
-    return table.concat(ui, ',')
-  elseif key == 'guifg' then
-    return vim.fn.synIDattr(vim.fn.hlID(source), 'fg#', 'gui')
-  elseif key == 'guibg' then
-    return vim.fn.synIDattr(vim.fn.hlID(source), 'bg#', 'gui')
-  elseif key == 'ctermfg' then
-    return vim.fn.synIDattr(vim.fn.hlID(source), 'fg', 'term')
-  elseif key == 'ctermbg' then
-    return vim.fn.synIDattr(vim.fn.hlID(source), 'bg', 'term')
   end
+  vim.api.nvim_set_hl(0, name, settings)
 end
 
 return highlight

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -37,55 +37,32 @@ misc.set(_G, { 'cmp', 'plugin', 'cmdline', 'enter' }, function()
 end)
 
 misc.set(_G, { 'cmp', 'plugin', 'colorscheme' }, function()
-  highlight.inherit('CmpItemAbbrDefault', 'Pmenu', {
-    guibg = 'NONE',
-    ctermbg = 'NONE',
-  })
-  highlight.inherit('CmpItemAbbrDeprecatedDefault', 'Comment', {
-    gui = 'NONE',
-    guibg = 'NONE',
-    ctermbg = 'NONE',
-  })
-  highlight.inherit('CmpItemAbbrMatchDefault', 'Pmenu', {
-    gui = 'NONE',
-    guibg = 'NONE',
-    ctermbg = 'NONE',
-  })
-  highlight.inherit('CmpItemAbbrMatchFuzzyDefault', 'Pmenu', {
-    gui = 'NONE',
-    guibg = 'NONE',
-    ctermbg = 'NONE',
-  })
-  highlight.inherit('CmpItemKindDefault', 'Special', {
-    guibg = 'NONE',
-    ctermbg = 'NONE',
-  })
-  highlight.inherit('CmpItemMenuDefault', 'Pmenu', {
-    guibg = 'NONE',
-    ctermbg = 'NONE',
-  })
+  highlight.inherit('CmpItemAbbrDefault', 'Pmenu', { bg = 'NONE' })
+  highlight.inherit('CmpItemAbbrDeprecatedDefault', 'Comment', { bg = 'NONE' })
+  highlight.inherit('CmpItemAbbrMatchDefault', 'Pmenu', { bg = 'NONE' })
+  highlight.inherit('CmpItemAbbrMatchFuzzyDefault', 'Pmenu', { bg = 'NONE' })
+  highlight.inherit('CmpItemKindDefault', 'Special', { bg = 'NONE' })
+  highlight.inherit('CmpItemMenuDefault', 'Pmenu', { bg = 'NONE' })
   for name in pairs(types.lsp.CompletionItemKind) do
     if type(name) == 'string' then
-      vim.cmd(([[highlight default link CmpItemKind%sDefault CmpItemKind]]):format(name))
+      vim.api.nvim_set_hl(0, ('CmpItemKind%sDefault'):format(name), { link = 'CmpItemKind' })
     end
   end
 end)
 _G.cmp.plugin.colorscheme()
 
-vim.cmd([[
-  highlight default link CmpItemAbbr CmpItemAbbrDefault
-  highlight default link CmpItemAbbrDeprecated CmpItemAbbrDeprecatedDefault
-  highlight default link CmpItemAbbrMatch CmpItemAbbrMatchDefault
-  highlight default link CmpItemAbbrMatchFuzzy CmpItemAbbrMatchFuzzyDefault
-  highlight default link CmpItemKind CmpItemKindDefault
-  highlight default link CmpItemMenu CmpItemMenuDefault
-]])
+vim.api.nvim_set_hl(0, 'CmpItemAbbr', { link = 'CmpItemAbbrDefault' })
+vim.api.nvim_set_hl(0, 'CmpItemAbbrDeprecated', { link = 'CmpItemAbbrDeprecatedDefault' })
+vim.api.nvim_set_hl(0, 'CmpItemAbbrMatch', { link = 'CmpItemAbbrMatchDefault' })
+vim.api.nvim_set_hl(0, 'CmpItemAbbrMatchFuzzy', { link = 'CmpItemAbbrMatchFuzzyDefault' })
+vim.api.nvim_set_hl(0, 'CmpItemKind', { link = 'CmpItemKindDefault' })
+vim.api.nvim_set_hl(0, 'CmpItemMenu', { link = 'CmpItemMenuDefault' })
 
 for name in pairs(types.lsp.CompletionItemKind) do
   if type(name) == 'string' then
     local hi = ('CmpItemKind%s'):format(name)
     if vim.fn.hlexists(hi) ~= 1 then
-      vim.cmd(([[highlight default link %s %sDefault]]):format(hi, hi))
+      vim.api.nvim_set_hl(0, hi, { link = ('%sDefault'):format(hi) })
     end
   end
 end


### PR DESCRIPTION
This gives a first stab at simplifying the highlighting in `cmp` to use the new `vim.api.nvim_set_hl` lua API.

I did remove the `cterm` and `gui` specific highlights because the `vim.fn.synIDattr` and `vim.api.nvim_set_hl` commands default to the current mode of neovim (i.e. gui/cterm/term) so I don't think it is necessary that we set all of them, instead just get the current mode. To my knowledge this mode won't change in the middle of running neovim.

This requires neovim 0.7 so it should be done along with https://github.com/hrsh7th/nvim-cmp/pull/844