### PR TITLE
fix: don't show non-working configuration in deprecation suggestion

### DIFF
--- a/lua/cmp/config.lua
+++ b/lua/cmp/config.lua
@@ -197,7 +197,7 @@ config.normalize = function(c)
       { 'documentation', 'WarningMsg' },
       { ' is deprecated.\n', 'Normal' },
       { '[nvim-cmp] Please use ', 'Normal' },
-      { 'window.documentation= "native"', 'WarningMsg' },
+      { 'window.documentation = cmp.config.window.bordered()', 'WarningMsg' },
       { ' instead.', 'Normal' },
     }, true, {})
     c.window = c.window or {}


### PR DESCRIPTION
As reported here: https://github.com/hrsh7th/nvim-cmp/issues/936