### PR TITLE
fix: Invalid color settings passed to nvim_set_hl 

### DIFF
--- a/lua/cmp/utils/highlight.lua
+++ b/lua/cmp/utils/highlight.lua
@@ -20,7 +20,7 @@ highlight.inherit = function(name, source, settings)
         v = v == 1
       end
       if v then
-        settings[key] = v == '' and 'NONE' or v
+        settings[key] = v == '' or 'NONE' or v
       end
     end
   end

--- a/lua/cmp/utils/highlight.lua
+++ b/lua/cmp/utils/highlight.lua
@@ -20,7 +20,7 @@ highlight.inherit = function(name, source, settings)
         v = v == 1
       end
       if v then
-        settings[key] = v == '' or 'NONE' or v
+        settings[key] = v == '' or 'NONE' or '0'
       end
     end
   end


### PR DESCRIPTION
this is a fix to this issue:
https://github.com/hrsh7th/nvim-cmp/issues/961
Not sure if it's the correct fix, but from what we (the members of the @theprimeagen discord server @navigationhazard and @mvargasmoran) seem to think it's correct