### PR TITLE
add events: view_opened and view_closed

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -223,9 +223,9 @@ NOTE: `<Cmd>lua require('cmp').complete()<CR>` can be used to call these functio
   - `complete_done`: emit after current completion is done.
   - `confirm_done`: emit after confirmation is done.
   - `view_opened`: emit after opening a new completion window. Called with a table holding a key
-    named `window`, poining to the completion window implementation.
+    named `window`, pointing to the completion window implementation.
   - `view_closed`: emit after closing pum is closed. Called with a table holding a key
-    named `window`, poining to the completion window implementation.
+    named `window`, pointing to the completion window implementation.
 
 ==============================================================================
 Mapping                                                            *cmp-mapping*

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -222,10 +222,10 @@ NOTE: `<Cmd>lua require('cmp').complete()<CR>` can be used to call these functio
 
   - `complete_done`: emit after current completion is done.
   - `confirm_done`: emit after confirmation is done.
-  - `view_opened`: emit after opening a new completion window. Called with a table holding a key
-    named `window`, pointing to the completion window implementation.
-  - `view_closed`: emit after closing pum is closed. Called with a table holding a key
-    named `window`, pointing to the completion window implementation.
+  - `menu_opened`: emit after opening a new completion menu. Called with a table holding a key
+    named `window`, pointing to the completion menu implementation.
+  - `menu_closed`: emit after completion menu is closed. Called with a table holding a key
+    named `window`, pointing to the completion menu implementation.
 
 ==============================================================================
 Mapping                                                            *cmp-mapping*

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -222,6 +222,10 @@ NOTE: `<Cmd>lua require('cmp').complete()<CR>` can be used to call these functio
 
   - `complete_done`: emit after current completion is done.
   - `confirm_done`: emit after confirmation is done.
+  - `view_opened`: emit after opening a new completion window. Called with a table holding a key
+    named `window`, poining to the completion window implementation.
+  - `view_closed`: emit after closing pum is closed. Called with a table holding a key
+    named `window`, poining to the completion window implementation.
 
 ==============================================================================
 Mapping                                                            *cmp-mapping*

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -36,9 +36,11 @@ core.new = function()
   self.view.event:on('keymap', function(...)
     self:on_keymap(...)
   end)
-  self.view.event:on('complete_done', function(evt)
-    self.event:emit('complete_done', evt)
-  end)
+  for _, event_name in ipairs({ 'complete_done', 'view_opened', 'view_closed' }) do
+    self.view.event:on(event_name, function(evt)
+      self.event:emit(event_name, evt)
+    end)
+  end
   return self
 end
 

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -36,7 +36,7 @@ core.new = function()
   self.view.event:on('keymap', function(...)
     self:on_keymap(...)
   end)
-  for _, event_name in ipairs({ 'complete_done', 'view_opened', 'view_closed' }) do
+  for _, event_name in ipairs({ 'complete_done', 'menu_opened', 'menu_closed' }) do
     self.view.event:on(event_name, function(evt)
       self.event:emit(event_name, evt)
     end)

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -108,6 +108,9 @@ view.open = function(self, ctx, sources)
     -- open
     if #entries > 0 then
       self:_get_entries_view():open(offset, entries)
+      self.event:emit('view_opened', {
+        window = self:_get_entries_view(),
+      })
       break
     end
   end
@@ -128,6 +131,9 @@ view.close = function(self)
   self:_get_entries_view():close()
   self.docs_view:close()
   self.ghost_text_view:hide()
+  self.event:emit('view_closed', {
+    window = self:_get_entries_view(),
+  })
 end
 
 ---Abort menu
@@ -135,6 +141,9 @@ view.abort = function(self)
   self:_get_entries_view():abort()
   self.docs_view:close()
   self.ghost_text_view:hide()
+  self.event:emit('view_closed', {
+    window = self:_get_entries_view(),
+  })
 end
 
 ---Return the view is visible or not.

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -108,7 +108,7 @@ view.open = function(self, ctx, sources)
     -- open
     if #entries > 0 then
       self:_get_entries_view():open(offset, entries)
-      self.event:emit('view_opened', {
+      self.event:emit('menu_opened', {
         window = self:_get_entries_view(),
       })
       break
@@ -131,7 +131,7 @@ view.close = function(self)
   self:_get_entries_view():close()
   self.docs_view:close()
   self.ghost_text_view:hide()
-  self.event:emit('view_closed', {
+  self.event:emit('menu_closed', {
     window = self:_get_entries_view(),
   })
 end
@@ -141,7 +141,7 @@ view.abort = function(self)
   self:_get_entries_view():abort()
   self.docs_view:close()
   self.ghost_text_view:hide()
-  self.event:emit('view_closed', {
+  self.event:emit('menu_closed', {
     window = self:_get_entries_view(),
   })
 end


### PR DESCRIPTION
Add more events.

This allows the following behaviour (notice the up/down arrow pointing to the direction of the menu (top_down or bottom_up):

![Peek 2022-05-04 15-49](https://user-images.githubusercontent.com/4946827/166684462-5ed71780-1e5e-49df-9aba-a67c4b54ce25.gif)


Here is the code needed to implement it, assuming you are using the `custom` view, and setting `selection_order` to `near_cursor`:

```lua
local ns_id = vim.api.nvim_create_namespace('arrows')
local function remove_marks()
    local all = vim.api.nvim_buf_get_extmarks(0, ns_id, 0, -1, {})
    for _, mark in ipairs(all) do
      vim.api.nvim_buf_del_extmark(0, ns_id, mark[1])
    end
end

cmp.event:on('view_closed',
  function()
    remove_marks()
  end
)

cmp.event:on('view_opened',
  function(evt)
    if vim.api.nvim_get_mode().mode:sub(1, 1) == 'c' then
      return
    end
    local character
    local cursor = vim.api.nvim_win_get_cursor(0)
    local row = cursor[1] - 1
    local col = cursor[2]

    remove_marks()

    if evt.window.bottom_up then
      character = "↑"
    else
      character = "↓"
    end
    local opts = {
      id = 1,
      virt_text = {{character, "IncSearch"}},
      virt_text_pos = 'overlay',
      priority = 10005,
    }

    vim.api.nvim_buf_set_extmark(0, ns_id, row, col, opts)
  end
)


```