### PR TITLE
feat: Custom item kinds

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -269,10 +269,13 @@ entry.get_vim_item = function(self, suggest_offset)
       end
     end
 
+    local cmp_opts = self:get_completion_item().cmp or {}
+
     local vim_item = {
       word = word,
       abbr = abbr,
-      kind = types.lsp.CompletionItemKind[self:get_kind()] or types.lsp.CompletionItemKind[1],
+      kind = cmp_opts.kind_text or types.lsp.CompletionItemKind[self:get_kind()] or types.lsp.CompletionItemKind[1],
+      kind_hl_group = cmp_opts.kind_hl_group,
       menu = menu,
       dup = self:get_completion_item().dup or 1,
     }

--- a/lua/cmp/types/lsp.lua
+++ b/lua/cmp/types/lsp.lua
@@ -170,6 +170,10 @@ lsp.CompletionItemKind = vim.tbl_add_reverse_lookup(lsp.CompletionItemKind)
 ---@field public detail string|nil
 ---@field public description string|nil
 
+---@class lsp.Cmp
+---@field public kind_text string
+---@field public kind_hl_group string
+
 ---@class lsp.CompletionItem
 ---@field public label string
 ---@field public labelDetails lsp.CompletionItemLabelDetails|nil
@@ -189,6 +193,7 @@ lsp.CompletionItemKind = vim.tbl_add_reverse_lookup(lsp.CompletionItemKind)
 ---@field public commitCharacters string[]|nil
 ---@field public command lsp.Command|nil
 ---@field public data any|nil
+---@field public cmp lsp.Cmp|nil
 ---
 ---TODO: Should send the issue for upstream?
 ---@field public word string|nil


### PR DESCRIPTION
Fixes #985 among others

This PR allows sources to return custom completion item kinds by returning a string instead of a int in the kind field. Currently, if you have a source which does not fit into the categories of a normal snippet or lsp kind there is no way to add an additional field. This fixes that. Here is an example in my copilot plugin:
```
source.format_completions = function(_, params, completions)
  return {
    label = label,
    kind = "Copilot",
    ...
  }
end
```

The benefits to this implementation (besides being 2 lines of code) are that highlight groups will be automatically added, for instance:
`vim.api.nvim_set_hl(0, CmpItemKindCopilot, '#A5BA93')`

Since cmp doesn't read config for formatting until immediately after determining type, this is by far the easiest way of making everything work in a non-invasive manner.

lspkind users will also be happy to know that I tested adding a custom group to it, and it works fine there as well:
```
require('lspkind').init({
  symbol_map = {
    Copilot = "[ﯙ]",
  },
})
```

I looked at a lot of different ways of doing this, but any method based on adding another entry and passing `kind = 26` for instance, resulted in hardcoding or overcomplication. 
