### PR TITLE
fix: only scroll docs if docs view is visible

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -172,7 +172,7 @@ end)
 
 ---Scrolling documentation window if possible
 cmp.scroll_docs = cmp.sync(function(delta)
-  if cmp.core.view:visible() then
+  if cmp.core.view.docs_view:visible() then
     cmp.core.view:scroll_docs(delta)
     return true
   else


### PR DESCRIPTION
I ran into some issues with indenting/unindenting code via `<C-d>/<C-t>` when the completion menu was open but no docs window visible.

I was also a bit surprised to see that when indenting/unindenting code it also opens the completion menu, which feels like a potential separate issue?