### PR TITLE
feat: add ability to send docs popup to a preview window

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -174,6 +174,9 @@ NOTE: `<Cmd>lua require('cmp').complete()<CR>` can be used to call these functio
 *cmp.select_prev_item* (option: { behavior = cmp.SelectBehavior })*
   Select previous item.
 
+*cmp.open_docs_preview*
+  Opens the docs window (if visible) in a preview window.
+
 *cmp.scroll_docs* (delta: number)
   Scroll docs if visible.
 
@@ -292,6 +295,9 @@ You can also use built-in mapping helpers.
 
   *cmp.mapping.select_prev_item* (option: { behavior = cmp.SelectBehavior })
     Same as |cmp.select_prev_item|.
+
+  *cmp.mapping.open_docs_preview*
+    Same as |cmp.open_docs_preview|.
 
   *cmp.mapping.scroll_docs* (delta: number)
     Same as |cmp.scroll_docs|.

--- a/lua/cmp/config/mapping.lua
+++ b/lua/cmp/config/mapping.lua
@@ -138,6 +138,15 @@ mapping.scroll_docs = function(delta)
   end
 end
 
+--Opens the docs window (if visible) in a preview window
+mapping.open_docs_preview = function()
+  return function(fallback)
+    if not require('cmp').open_docs_preview() then
+      fallback()
+    end
+  end
+end
+
 ---Select next completion item.
 mapping.select_next_item = function(option)
   return function(fallback)

--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -170,6 +170,16 @@ cmp.select_prev_item = cmp.sync(function(option)
   return false
 end)
 
+--Opens the docs window (if visible) in a preview window
+cmp.open_docs_preview = cmp.sync(function()
+  if cmp.core.view.docs_view:visible() then
+    cmp.core.view.docs_view:send_to_preview_window()
+    return true
+  else
+    return false
+  end
+end)
+
 ---Scrolling documentation window if possible
 cmp.scroll_docs = cmp.sync(function(delta)
   if cmp.core.view:visible() then

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -1,5 +1,6 @@
 local window = require('cmp.utils.window')
 local config = require('cmp.config')
+local buffer = require('cmp.utils.buffer')
 
 ---@class cmp.DocsView
 ---@field public window cmp.Window
@@ -157,6 +158,8 @@ docs_view.send_to_preview_window = function(self)
   vim.cmd([[stopinsert]])
   local pwin = get_preview_window()
   vim.api.nvim_win_set_buf(pwin, self.window:get_buffer())
+  buffer.cache[self.window.name] = nil -- release buffer cache as it's now managed manually by the user
+  self.window:close()
 end
 
 return docs_view

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -16,6 +16,12 @@ docs_view.new = function()
   self.window:option('linebreak', true)
   self.window:option('scrolloff', 0)
   self.window:option('wrap', true)
+  self.window:buffer_option('modifiable', false)
+  self.window:buffer_option('undolevels', -1)
+  self.window:buffer_option('buflisted', false)
+  self.window:buffer_option('buftype', 'nofile')
+  self.window:buffer_option('bufhidden', 'wipe')
+  self.window:buffer_option('swapfile', false)
   return self
 end
 
@@ -47,12 +53,14 @@ docs_view.open = function(self, e, view)
     self.entry = e
     vim.api.nvim_buf_call(self.window:get_buffer(), function()
       vim.cmd([[syntax clear]])
-      vim.api.nvim_buf_set_lines(self.window:get_buffer(), 0, -1, false, {})
+      vim.api.nvim_buf_set_option(0, 'modifiable', true)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {})
+      vim.lsp.util.stylize_markdown(0, documents, {
+        max_width = max_width,
+        max_height = documentation.max_height,
+      })
+      vim.api.nvim_buf_set_option(0, 'modifiable', false)
     end)
-    vim.lsp.util.stylize_markdown(self.window:get_buffer(), documents, {
-      max_width = max_width,
-      max_height = documentation.max_height,
-    })
   end
 
   -- Calculate window size.
@@ -131,6 +139,24 @@ end
 
 docs_view.visible = function(self)
   return self.window:visible()
+end
+
+docs_view.send_to_preview_window = function(self)
+  local function get_preview_window()
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(vim.api.nvim_get_current_tabpage())) do
+      if vim.api.nvim_win_get_option(win, 'previewwindow') then
+        return win
+      end
+    end
+    vim.cmd([[new]])
+    local pwin = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_option(pwin, 'previewwindow', true)
+    vim.api.nvim_win_set_height(pwin, vim.api.nvim_get_option('previewheight'))
+    return pwin
+  end
+  vim.cmd([[stopinsert]])
+  local pwin = get_preview_window()
+  vim.api.nvim_win_set_buf(pwin, self.window:get_buffer())
 end
 
 return docs_view

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -146,17 +146,19 @@ docs_view.send_to_preview_window = function(self)
   local function get_preview_window()
     for _, win in ipairs(vim.api.nvim_tabpage_list_wins(vim.api.nvim_get_current_tabpage())) do
       if vim.api.nvim_win_get_option(win, 'previewwindow') then
-        return win
+        return win, false
       end
     end
     vim.cmd([[new]])
     local pwin = vim.api.nvim_get_current_win()
     vim.api.nvim_win_set_option(pwin, 'previewwindow', true)
     vim.api.nvim_win_set_height(pwin, vim.api.nvim_get_option('previewheight'))
-    return pwin
+    return pwin, true
   end
-  vim.cmd([[stopinsert]])
-  local pwin = get_preview_window()
+  local pwin, new_window = get_preview_window()
+  if new_window then
+    vim.cmd([[stopinsert]])
+  end
   vim.api.nvim_win_set_buf(pwin, self.window:get_buffer())
   buffer.cache[self.window.name] = nil -- release buffer cache as it's now managed manually by the user
   self.window:close()


### PR DESCRIPTION
My searching might have been really bad, but I couldn't find any discussions around a feature like this. Apologies for jumping straight to implementation but the source code was very well written and easy to get into so I couldn't help myself :).

Demo: https://asciinema.org/a/sJWBBt3lQKs6NFyf3HdlqNCsU

---

So the idea behind this is to give users the ability to interact with the docs contents in more lasting contexts than just a popup window that closes itself, by providing the ability to send it to a new preview window (or overwrite the contents of any existing preview window). What do you think?