### PR TITLE
Add mapping for navigation via Ctrl-n and Ctrl-p

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ lua <<EOF
       -- documentation = cmp.config.window.bordered(),
     },
     mapping = cmp.mapping.preset.insert({
+      ['<C-n>'] = cmp.mapping(cmp.mapping.select_next_item(), {'i','c'}),
+      ['<C-p>'] = cmp.mapping(cmp.mapping.select_prev_item(), {'i','c'}),
       ['<C-b>'] = cmp.mapping.scroll_docs(-4),
       ['<C-f>'] = cmp.mapping.scroll_docs(4),
       ['<C-Space>'] = cmp.mapping.complete(),


### PR DESCRIPTION
Because of breaking changes there is no default mapping for navigation in menu, without them you cannot use cmp with config presented in README.md