### PR TITLE
fix: nvim_create_user_command to nvim_add_user_command

### DIFF
--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -52,7 +52,7 @@ if vim.on_key then
   end, vim.api.nvim_create_namespace('cmp.plugin'))
 end
 
-vim.api.nvim_create_user_command('CmpStatus', function()
+vim.api.nvim_add_user_command('CmpStatus', function()
   require('cmp').status()
 end, { desc = 'Check status of cmp sources' })
 


### PR DESCRIPTION
`vim.api.nvim_add_user_command` seems to be the working definition according to NeoVim v0.7.0 docs. 

`vim.api.nvim_create_user_command` throws an E5113 error for referencing a nil value.