### PR TITLE
Fix type comment for cmp.ContextReason

### DIFF
--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -12,7 +12,7 @@ cmp.SelectBehavior = {
   Select = 'select',
 }
 
----@alias cmp.ContextReason 'auto' | 'manual' 'triggerOnly' | 'none'
+---@alias cmp.ContextReason 'auto' | 'manual' | 'triggerOnly' | 'none'
 cmp.ContextReason = {
   Auto = 'auto',
   Manual = 'manual',


### PR DESCRIPTION
Side note, where is this documented? I see sumneko warning me about not providing an argument to cmp.mapping.complete(), but I don't know what the options object even does.