### PR TITLE
feat: add rockspec

### DIFF
--- a/nvim-cmp-scm-1.rockspec
+++ b/nvim-cmp-scm-1.rockspec
@@ -1,0 +1,37 @@
+local MODREV, SPECREV = "scm", "-1"
+rockspec_format = "3.0"
+package = "nvim-cmp"
+version = MODREV .. SPECREV
+
+description = {
+    summary = "A completion plugin for neovim",
+    labels = { "neovim" },
+    detailed = [[
+    A completion engine plugin for neovim written in Lua. Completion sources are installed from external repositories and "sourced".
+   ]],
+    homepage = "https://github.com/hrsh7th/nvim-cmp",
+    license = "MIT",
+}
+
+dependencies = {
+    "lua >= 5.1, < 5.4",
+}
+
+source = {
+    url = "http://github.com/hrsh7th/nvim-cmp/archive/v" .. MODREV .. ".zip",
+    dir = "nvim-cmp-" .. MODREV,
+}
+
+if MODREV == "scm" then
+    source = {
+        url = "git://github.com/hrsh7th/nvim-cmp",
+    }
+end
+
+build = {
+    type = "builtin",
+}
+copy_directories = {
+    'autoload',
+    'plugin',
+}


### PR DESCRIPTION
so that other plugins can mark nvim-cmp as a dependency

Some justification there https://teto.github.io/posts/2022-06-22-neovim-plugin-luarocks-2.html
