### PR TITLE
fix: matched highlighting dissapearing

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -380,7 +380,7 @@ entry.match = function(self, input, matching_config)
     end
 
     if self:get_filter_text() ~= self:get_completion_item().label then
-      _, matches = matcher.match(input, self:get_completion_item().label, { self:get_word() })
+      _, matches = matcher.match(input, self:get_completion_item().label, { synonyms = { self:get_word() } })
     end
 
     return { score = score, matches = matches }


### PR DESCRIPTION
Fixes #1030 
After looking at the input ```matcher.match``` got from the reproduction steps in the bug report, it looks like the signature of a function call was forgotten to be updated in c073501