### PR TITLE
feat: add `filter` option to sources

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -546,6 +546,38 @@ sources[n].group_index~
       })
     }
 <
+
+                                             *cmp-config.sources[n].entry_filter*
+sources[n].entry_filter~
+  `function`
+  A source-specific entry filter, with the following function signature:
+>
+  --- @param entry cmp.Entry
+  --- @param ctx cmp.Context
+  --- @return boolean
+  function(entry, ctx) end
+<
+
+  Returning `true` will keep the entry, while returning `false` will remove it.
+
+  This can be used to hide certain entries from a given source. For instance, you
+  could hide all entries with kind `Text` from the `nvim_lsp` filter using the
+  following source definition:
+>
+  {
+    name = 'nvim_lsp',
+    entry_filter = function(entry, ctx)
+      local kind = require('cmp.types').lsp.CompletionItemKind[entry:get_kind()]
+
+      if kind == 'Text' then return false end
+
+      return true
+    end
+  }
+<
+  Using the `ctx` parameter, you can further customize the behaviour of the
+  source.
+
                                                                *cmp-config.view*
 view~
   `{ entries: cmp.EntriesConfig|string }`

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -552,10 +552,7 @@ sources[n].entry_filter~
   `function`
   A source-specific entry filter, with the following function signature:
 >
-  --- @param entry cmp.Entry
-  --- @param ctx cmp.Context
-  --- @return boolean
-  function(entry, ctx) end
+  function(entry: cmp.Entry, ctx: cmp.Context): boolean
 <
 
   Returning `true` will keep the entry, while returning `false` will remove it.
@@ -567,9 +564,7 @@ sources[n].entry_filter~
   {
     name = 'nvim_lsp',
     entry_filter = function(entry, ctx)
-      local kind = require('cmp.types').lsp.CompletionItemKind[entry:get_kind()]
-
-      return kind ~= 'Text'
+      return require('cmp.types').lsp.CompletionItemKind[entry:get_kind()] ~= 'Text'
     end
   }
 <

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -569,9 +569,7 @@ sources[n].entry_filter~
     entry_filter = function(entry, ctx)
       local kind = require('cmp.types').lsp.CompletionItemKind[entry:get_kind()]
 
-      if kind == 'Text' then return false end
-
-      return true
+      return kind ~= 'Text'
     end
   }
 <

--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -101,6 +101,8 @@ source.get_entries = function(self, ctx)
     return self.entries
   end)()
 
+  local entry_filter = self:get_entry_filter()
+
   local inputs = {}
   local entries = {}
   for _, e in ipairs(target_entries) do
@@ -115,7 +117,10 @@ source.get_entries = function(self, ctx)
     if e.score >= 1 then
       e.matches = match.matches
       e.exact = e:get_filter_text() == inputs[o] or e:get_word() == inputs[o]
-      table.insert(entries, e)
+
+      if entry_filter(e, ctx) then
+        table.insert(entries, e)
+      end
     end
   end
   self.cache:set({ 'get_entries', self.revision, ctx.cursor_before_line }, entries)
@@ -230,6 +235,16 @@ source.get_keyword_length = function(self)
     return c.keyword_length
   end
   return config.get().completion.keyword_length or 1
+end
+
+---Get filter
+--@return function
+source.get_entry_filter = function(self)
+  local c = self:get_source_config()
+  if c.entry_filter then
+    return c.entry_filter
+  end
+  return function(_, _) return true end
 end
 
 ---Invoke completion

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -152,7 +152,7 @@ cmp.ItemField = {
 ---@field public keyword_length integer|nil
 ---@field public max_item_count integer|nil
 ---@field public group_index integer|nil
----@field public entry_filter function|nil
+---@field public entry_filter nil|function(entry: cmp.Entry, ctx: cmp.Context): boolean
 
 ---@class cmp.ViewConfig
 ---@field public entries cmp.EntriesConfig

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -152,6 +152,7 @@ cmp.ItemField = {
 ---@field public keyword_length integer|nil
 ---@field public max_item_count integer|nil
 ---@field public group_index integer|nil
+---@field public entry_filter function|nil
 
 ---@class cmp.ViewConfig
 ---@field public entries cmp.EntriesConfig


### PR DESCRIPTION
This allows the user to specify a `filter` function for each source.

Solves:
https://github.com/hrsh7th/nvim-cmp/issues/1036
https://github.com/hrsh7th/nvim-cmp/issues/1041
https://github.com/hrsh7th/nvim-cmp/issues/806

@hrsh7th do you see any problems with this implementation or approach in general?

An example (Updated):
```lua
-- don't show entries with kind "Text" from the "nvim_lsp" source
sources = {
{
  name = "nvim_lsp",
  entry_filter = function(entry, ctx)
    local kind = types.lsp.CompletionItemKind[entry:get_kind()]

    if kind == "Text" then return false end
    return true
  },
}
```

By utilizing the `ctx` parameter, the user can also ignore certain
entries in certain contexts.

Notes:
- <s>The name `filter` might not be entirely clear; what does returning `true` or `false` actually result in? Ideas?</s> Update: Changed name to `entry_filter`, and swapped true/false, making it function more like traditional filter functions.
- Documentation has to be added.
- <s>Specs have to be added.</s> There doesn't seem to be a precedence for testing other configuration options, not sure it's entirely necessary either.