### PR TITLE
Fix native_entries_view.info width and col calculations

### DIFF
--- a/lua/cmp/view/native_entries_view.lua
+++ b/lua/cmp/view/native_entries_view.lua
@@ -101,10 +101,10 @@ native_entries_view.info = function(self)
   if self:visible() then
     local info = vim.fn.pum_getpos()
     return {
-      width = info.width + (info.scrollable and 1 or 0),
+      width = info.width + (info.scrollbar and 1 or 0) + (info.col == 0 and 0 or 1),
       height = info.height,
       row = info.row,
-      col = info.col,
+      col = info.col == 0 and 0 or info.col - 1,
     }
   end
 end


### PR DESCRIPTION
The dictionary returned by `pum_getpos()` uses `scrollbar` not
`scrollable` to indicate whether the scrollbar is visible or not.

In addition, the padding on the left side of the popup menu isn't
included in the output of `pum_getpos()`, meaning that both `col` and
`width` (as understood by nvim-cmp) are off by one when the cursor isn't
at column `0`.

These two issues were causing the documentation window and popup menu to
overlap.