### PR TITLE
fix entry appearing for identical text

### DIFF
--- a/lua/cmp/matcher.lua
+++ b/lua/cmp/matcher.lua
@@ -88,8 +88,8 @@ matcher.match = function(input, word, option)
     return matcher.PREFIX_FACTOR + matcher.NOT_FUZZY_FACTOR, {}
   end
 
-  -- Ignore if input is long than word
-  if #input > #word then
+  -- Ignore if input is identical to or longer than word
+  if input == word or #input > #word then
     return 0, {}
   end
 


### PR DESCRIPTION
Fixes zbirenbaum/copilot-cmp#15

The formatting required for copilot text completions causes cmp to sometimes have an entry remain in the completion menu after it is accepted leading to some sizable problems as can be seen in the above issue.

Debugging matcher shows the input and word parameters are identical, so I believe the core of this issue is actually a bug elsewhere in the source with label being prioritized over filterText. Tracking down where that might be occurring if it even is, is quite difficult, so a simple equivalency check alongside the existing length check suffices.