### PR TITLE
Fix completion menu appearance when directly below virtual text lines

### DIFF
--- a/lua/cmp/utils/api.lua
+++ b/lua/cmp/utils/api.lua
@@ -57,9 +57,7 @@ api.get_screen_cursor = function()
     local cursor = api.get_cursor()
     return { cursor[1], cursor[2] + 1 }
   end
-  local cursor = api.get_cursor()
-  local pos = vim.fn.screenpos(0, cursor[1], cursor[2] + 1)
-  return { pos.row, pos.col - 1 }
+  return { vim.fn.winline(), vim.fn.wincol() - 1 }
 end
 
 api.get_cursor_before_line = function()

--- a/lua/cmp/utils/api.lua
+++ b/lua/cmp/utils/api.lua
@@ -57,7 +57,16 @@ api.get_screen_cursor = function()
     local cursor = api.get_cursor()
     return { cursor[1], cursor[2] + 1 }
   end
-  return { vim.fn.winline(), vim.fn.wincol() - 1 }
+  local cursor = api.get_cursor()
+  local pos = vim.fn.screenpos(0, cursor[1], cursor[2] + 1)
+  -- account for vim.fn.screenpos bug with virtual lines
+  local pos_after
+  if cursor[1] + 1 > vim.api.nvim_buf_line_count(0) then
+    pos_after = pos.row + 1
+  else
+    pos_after = vim.fn.screenpos(0, cursor[1] + 1, cursor[2] + 1).row
+  end
+  return { pos.row + (pos_after - pos.row - 1), pos.col - 1 }
 end
 
 api.get_cursor_before_line = function()


### PR DESCRIPTION
The current implementation of `api.get_screen_cursor` does not work when completion is started right below a line of virtual text (when the entire line is virtual text). The returned window row is off by one, resulting in the completion menu hiding the current row. See the following:

![b4](https://user-images.githubusercontent.com/4946827/180954004-0abb93c9-ec91-4602-8753-a41fd6b4b7e8.gif)

The fix is to use `vim.fn.winline` and `vim.fn.wincol` directly.
This is after the fix:

![after](https://user-images.githubusercontent.com/4946827/180954146-81da13d4-21af-4689-b97d-41f720dbdc6f.gif)
