### PR TITLE
Use `cmp.config.sources` in minimum vimrc

### DIFF
--- a/utils/vimrc.vim
+++ b/utils/vimrc.vim
@@ -36,10 +36,10 @@ cmp.setup {
     ['<CR>'] = cmp.mapping.confirm({ select = true })
   },
 
-  sources = {
+  sources = cmp.config.sources({
     { name = "nvim_lsp" },
     { name = "buffer" },
-  },
+  }),
 }
 EOF
 


### PR DESCRIPTION
Fixes #1104