### PR TITLE
add docs view filetype

### DIFF
--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -16,6 +16,7 @@ docs_view.new = function()
   self.window:option('linebreak', true)
   self.window:option('scrolloff', 0)
   self.window:option('wrap', true)
+  self.window:buffer_option("filetype", "cmp_documentation")
   return self
 end
 


### PR DESCRIPTION
As you can see, I have added file types for docs-view.

This will be more friendly to some plugins, such as: [nvim-colorizer.lua](https://github.com/norcalli/nvim-colorizer.lua)

When there is no file type, no color is displayed:

![](https://images-1302522496.cos.ap-nanjing.myqcloud.com/img/20220806134357.png)

With the file type:

![](https://images-1302522496.cos.ap-nanjing.myqcloud.com/img/20220806134303.png)