### PR TITLE
fix(plugin): overriding colorschemes

### DIFF
--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -26,15 +26,15 @@ for kind in pairs(types.lsp.CompletionItemKind) do
 end
 
 autocmd.subscribe('ColorScheme', function()
-  highlight.inherit('CmpItemAbbrDefault', 'Pmenu', { bg = 'NONE', default = false })
-  highlight.inherit('CmpItemAbbrDeprecatedDefault', 'Comment', { bg = 'NONE', default = false })
-  highlight.inherit('CmpItemAbbrMatchDefault', 'Pmenu', { bg = 'NONE', default = false })
-  highlight.inherit('CmpItemAbbrMatchFuzzyDefault', 'Pmenu', { bg = 'NONE', default = false })
-  highlight.inherit('CmpItemKindDefault', 'Special', { bg = 'NONE', default = false })
-  highlight.inherit('CmpItemMenuDefault', 'Pmenu', { bg = 'NONE', default = false })
+  highlight.inherit('CmpItemAbbrDefault', 'Pmenu', { bg = 'NONE', default = true })
+  highlight.inherit('CmpItemAbbrDeprecatedDefault', 'Comment', { bg = 'NONE', default = true })
+  highlight.inherit('CmpItemAbbrMatchDefault', 'Pmenu', { bg = 'NONE', default = true })
+  highlight.inherit('CmpItemAbbrMatchFuzzyDefault', 'Pmenu', { bg = 'NONE', default = true })
+  highlight.inherit('CmpItemKindDefault', 'Special', { bg = 'NONE', default = true })
+  highlight.inherit('CmpItemMenuDefault', 'Pmenu', { bg = 'NONE', default = true })
   for name in pairs(types.lsp.CompletionItemKind) do
     if type(name) == 'string' then
-      vim.api.nvim_set_hl(0, ('CmpItemKind%sDefault'):format(name), { link = 'CmpItemKind', default = false })
+      vim.api.nvim_set_hl(0, ('CmpItemKind%sDefault'):format(name), { link = 'CmpItemKind', default = true })
     end
   end
 end)


### PR DESCRIPTION
Commit 8ce0832a5c409644fa06f34337b74f11aaa871c7 via #972 broke my colorscheme and other colorschemes which provide nvim-cmp highlights (e.g. linking `CmpItemKindText` to `Text` doesn't work). Plugins in general should definitely use `default = true` to maintain compatability with colorschemes, otherwise they will clobber the groups set by the colorscheme (which is what is happening now).

I looked at #972, and it seems like that issue can be fixed by delaying the setup of highlight groups until they are first needed (e.g. when rendering the popup menu), which would give that user time to setup their highlight groups _and_ still adhere to `default = true`. It seems setting everything up in `plugin/cmp.lua` doesn't guarantee the user's colorscheme is fully configured.