### PR TITLE
fix(entry/get_replace_range): handle TextEdit.range

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -333,8 +333,12 @@ end
 entry.get_replace_range = function(self)
   return self.cache:ensure({ 'get_replace_range', self.resolved_completion_item and 1 or 0 }, function()
     local replace_range
-    if misc.safe(self:get_completion_item().textEdit) and misc.safe(self:get_completion_item().textEdit.replace) then
-      replace_range = self:get_completion_item().textEdit.replace
+    if misc.safe(self:get_completion_item().textEdit) then
+      if misc.safe(self:get_completion_item().textEdit.replace) then
+        replace_range = self:get_completion_item().textEdit.replace
+      else
+        replace_range = self:get_completion_item().textEdit.range
+      end
     else
       replace_range = {
         start = {


### PR DESCRIPTION
fixes cmp.mapping.confirm when ConfirmBehavior is set to Replace

----

Some servers send a `TextEdit` in the following form
```
{
  newText = '"javascript.suggest.names": ${1:true}',
  range = {
    end = {
      character = 0,
      line = 2
    },
    start = {
      character = 0,
      line = 2
    }
  }
}
```
Before/after:

https://user-images.githubusercontent.com/109605931/185707880-4819cc3e-1408-4748-940d-845f22a27073.mp4

I've seen this behavior on cssls/html/jsonls/gopls.

See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit and https://github.com/LunarVim/LunarVim/issues/2876#issuecomment-1204393574.

Repro:

<details>

vimrc.vim
```vimscript
if has('vim_starting')
  set encoding=utf-8
endif
scriptencoding utf-8

if &compatible
  set nocompatible
endif

let s:plug_dir = expand('/tmp/plugged/vim-plug')
if !filereadable(s:plug_dir .. '/plug.vim')
  execute printf('!curl -fLo %s/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim', s:plug_dir)
end

execute 'set runtimepath+=' . s:plug_dir
call plug#begin(s:plug_dir)
Plug 'hrsh7th/nvim-cmp'
Plug 'hrsh7th/cmp-buffer'
Plug 'hrsh7th/cmp-nvim-lsp'
Plug 'hrsh7th/vim-vsnip'
Plug 'neovim/nvim-lspconfig'
call plug#end()
PlugInstall | quit

" Setup global configuration. More on configuration below.
lua << EOF
local cmp = require "cmp"
cmp.setup {
  snippet = {
    expand = function(args)
      vim.fn["vsnip#anonymous"](args.body)
    end,
  },

  mapping = cmp.mapping.preset.insert{
    ["<CR>"] = cmp.mapping.confirm({ select = true, behavior = cmp.ConfirmBehavior.Replace }),
    ["<C-space>"] = cmp.mapping(function()
      cmp.complete(cmp.ContextReason.Manual)
    end),
  },

  sources = cmp.config.sources({
    { name = "nvim_lsp" },
  }),
}
EOF

lua << EOF
local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())

require'lspconfig'.jsonls.setup {
  capabilities = capabilities,
}
EOF
```

`tsserver.json`
```json
{
"$schema": "https://raw.githubusercontent.com/tamago324/nlsp-settings.nvim/main/schemas/_generated/tsserver.json",
}
```

</details>