### PR TITLE
Fix the complete in insert mode

### DIFF
--- a/lua/cmp/view/native_entries_view.lua
+++ b/lua/cmp/view/native_entries_view.lua
@@ -77,7 +77,10 @@ native_entries_view.open = function(self, offset, entries)
 end
 
 native_entries_view.close = function(self)
-  if api.is_insert_mode() and self:visible() then
+  if api.is_suitable_mode() and self:visible() then
+		if vim.api.nvim_get_mode()["mode"] == "i" then
+      vim.fn.complete(1, {})
+    end
     vim.api.nvim_select_popupmenu_item(-1, false, true, {})
   end
   self.offset = -1


### PR DESCRIPTION
Fixes the complete in the command line of neovim

Without it:

![image](https://user-images.githubusercontent.com/14362650/185749087-c91a2e04-526e-43e9-81d3-6d906df9666f.png)

With this:

![image](https://user-images.githubusercontent.com/14362650/185749201-61f9c5e2-8434-46a1-b2e1-c2d27731bd09.png)
