### PR TITLE
Fix ConfirmBehavior.Replace

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -333,12 +333,9 @@ end
 entry.get_replace_range = function(self)
   return self.cache:ensure({ 'get_replace_range', self.resolved_completion_item and 1 or 0 }, function()
     local replace_range
-    if misc.safe(self:get_completion_item().textEdit) then
-      if misc.safe(self:get_completion_item().textEdit.replace) then
+    if misc.safe(self:get_completion_item().textEdit) and
+        misc.safe(self:get_completion_item().textEdit.replace) then
         replace_range = self:get_completion_item().textEdit.replace
-      else
-        replace_range = self:get_completion_item().textEdit.range
-      end
     else
       replace_range = {
         start = {


### PR DESCRIPTION
This reverts breaking change in 27bc575.

Before this change confirm() with ConfirmBehavior.Replace behaved as
expected:

abcd|<C-n><CR>
abcdefg|

Presently confirm() with ConfirmBehavior.Replace is inserting the entire
suggestion after the cursor:

abcd|<C-n><CR>
abcdabcdefg|