### PR TITLE
Fix grammar mistake: "setup" -> "set up"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ call plug#end()
 set completeopt=menu,menuone,noselect
 
 lua <<EOF
-  -- Setup nvim-cmp.
+  -- Set up nvim-cmp.
   local cmp = require'cmp'
 
   cmp.setup({
@@ -120,7 +120,7 @@ lua <<EOF
     })
   })
 
-  -- Setup lspconfig.
+  -- Set up lspconfig.
   local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())
   -- Replace <YOUR_LSP_SERVER> with each lsp server you've enabled.
   require('lspconfig')['<YOUR_LSP_SERVER>'].setup {


### PR DESCRIPTION
The use of "setup" in "Setup nvim-cmp" and "Setup lspconfig" is incorrect because "setup" is a noun while "set up" is a verb. "Set up" is correct.