### PR TITLE
Add incsearch_redraw_keys settings

### DIFF
--- a/lua/cmp/utils/misc.lua
+++ b/lua/cmp/utils/misc.lua
@@ -226,12 +226,13 @@ misc.redraw = setmetatable({
   doing = false,
   force = false,
   -- We use `<Up><Down>` to redraw the screen. (Previously, We use <C-r><ESC>. it will remove the unmatches search history.)
-  termcode = vim.api.nvim_replace_termcodes('<Up><Down>', true, true, true),
+  incsearch_redraw_keys = '<Up><Down>',
 }, {
   __call = function(self, force)
+    local termcode = vim.api.nvim_replace_termcodes(self.incsearch_redraw_keys, true, true, true)
     if vim.tbl_contains({ '/', '?' }, vim.fn.getcmdtype()) then
       if vim.o.incsearch then
-        return vim.api.nvim_feedkeys(self.termcode, 'in', true)
+        return vim.api.nvim_feedkeys(termcode, 'in', true)
       end
     end
 


### PR DESCRIPTION
When using incsearch with cmp-cmdline, the completion window display may be corrupted.

By default, it uses `<Up><Down>`, but you can re-render it by using `<C-r><Esc>` or `<C-r><BS>`.
However, using `<C-r>` breaks the history going back with `<Up>` and `<Down>`.

Therefore, a configuration item has been added to allow the user to change the key to be sent.

https://user-images.githubusercontent.com/5423775/187353553-2e3ec752-3a52-43fc-9781-2663905a53aa.mp4

