### PR TITLE
`README.md`: use buffer source for `/` and `?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,15 @@ lua <<EOF
     })
   })
 
-  -- Use buffer source for `/` (if you enabled `native_menu`, this won't work anymore).
-  cmp.setup.cmdline('/', {
-    mapping = cmp.mapping.preset.cmdline(),
-    sources = {
-      { name = 'buffer' }
-    }
-  })
+  -- Use buffer source for `/` and `?` (if you enabled `native_menu`, this won't work anymore).
+  for _,v in pairs({ '/', '?' })
+    cmp.setup.cmdline(v, {
+      mapping = cmp.mapping.preset.cmdline(),
+      sources = {
+        { name = 'buffer' }
+      }
+    })
+  end
 
   -- Use cmdline & path source for ':' (if you enabled `native_menu`, this won't work anymore).
   cmp.setup.cmdline(':', {


### PR DESCRIPTION
Since we can use both `/` and `?` for searching in Neovim, it makes more sense to use the buffer source in both of them instead of just `/`. Since putting `{ '/', '?' }` instead of `'/'` does not work, I put it in a `for` loop.