### PR TITLE
`setup.cmdline`: support using a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,12 @@ lua <<EOF
   })
 
   -- Use buffer source for `/` and `?` (if you enabled `native_menu`, this won't work anymore).
-  for _,v in pairs({ '/', '?' }) do
-    cmp.setup.cmdline(v, {
-      mapping = cmp.mapping.preset.cmdline(),
-      sources = {
-        { name = 'buffer' }
-      }
-    })
-  end
+  cmp.setup.cmdline({ '/', '?' }, {
+    mapping = cmp.mapping.preset.cmdline(),
+    sources = {
+      { name = 'buffer' }
+    }
+  })
 
   -- Use cmdline & path source for ':' (if you enabled `native_menu`, this won't work anymore).
   cmp.setup.cmdline(':', {

--- a/lua/cmp/config.lua
+++ b/lua/cmp/config.lua
@@ -57,10 +57,12 @@ end
 ---Set configuration for cmdline
 ---@param c cmp.ConfigSchema
 ---@param cmdtype string
-config.set_cmdline = function(c, cmdtype)
-  local revision = (config.cmdline[cmdtype] or {}).revision or 1
-  config.cmdline[cmdtype] = c or {}
-  config.cmdline[cmdtype].revision = revision + 1
+config.set_cmdline = function(c, cmdtypes)
+  for _, cmdtype in ipairs(type(cmdtypes) == 'table' and cmdtypes or { cmdtypes }) do
+    local revision = (config.cmdline[cmdtype] or {}).revision or 1
+    config.cmdline[cmdtype] = c or {}
+    config.cmdline[cmdtype].revision = revision + 1
+  end
 end
 
 ---Set configuration as oneshot completion.


### PR DESCRIPTION
I made the `cmd.setup.cmdline` function support using a string or a table as the first argument. Since it is recommended to have the same configuration for both `/` and `?`, this makes a lot of sense so we do not have to use a `for` loop. I also changed the README since we do not need the `for` loop anymore.