### PR TITLE
Update type annotations for setup.cmdline

### DIFF
--- a/lua/cmp/config.lua
+++ b/lua/cmp/config.lua
@@ -56,7 +56,7 @@ end
 
 ---Set configuration for cmdline
 ---@param c cmp.ConfigSchema
----@param cmdtype string
+---@param cmdtypes string|string[]
 config.set_cmdline = function(c, cmdtypes)
   for _, cmdtype in ipairs(type(cmdtypes) == 'table' and cmdtypes or { cmdtypes }) do
     local revision = (config.cmdline[cmdtype] or {}).revision or 1

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -61,7 +61,7 @@ cmp.ItemField = {
 ---@field public __call fun(c: cmp.ConfigSchema)
 ---@field public buffer fun(c: cmp.ConfigSchema)
 ---@field public global fun(c: cmp.ConfigSchema)
----@field public cmdline fun(type: string, c: cmp.ConfigSchema)
+---@field public cmdline fun(type: string|string[], c: cmp.ConfigSchema)
 ---@field public filetype fun(type: string|string[], c: cmp.ConfigSchema)
 
 ---@class cmp.SourceApiParams: cmp.SourceConfig


### PR DESCRIPTION
Updated type annotations as `setup.cmdline` now accepts string[] by #1193.