### PR TITLE
Fixed conflicts with ultisnip and copilot in cmp

### DIFF
--- a/lua/cmp/utils/autocmd.lua
+++ b/lua/cmp/utils/autocmd.lua
@@ -46,6 +46,11 @@ autocmd.emit = function(event)
   debug.log(string.format('>>> %s', event))
   autocmd.events[event] = autocmd.events[event] or {}
   for _, callback in ipairs(autocmd.events[event]) do
+    local ok, err = pcall(callback)
+    if not ok then
+      debug.log(err)
+      return
+    end
     callback()
   end
 end


### PR DESCRIPTION
Previusly i present problems with copilot and ultisnipts in this awasome plugin cmp, the complicts appears when declare variables  with "_" so i added lines code to validate execute the callbacks to get autocompletation code suggestion

![image](https://user-images.githubusercontent.com/55772887/194777789-67265dac-3dae-42c9-89d1-71acb2c4387b.png)

now

![image](https://user-images.githubusercontent.com/55772887/194779314-468f49c9-4067-43b5-82b9-f3bbf3b065ce.png)
