### PR TITLE
fix(context): compatibility with nvim<0.8

### DIFF
--- a/lua/cmp/config/context.lua
+++ b/lua/cmp/config/context.lua
@@ -33,9 +33,13 @@ context.in_treesitter_capture = function(capture)
     col = col - 1
   end
 
+  local get_captures_at_pos = -- See neovim/neovim#20331
+    require('vim.treesitter').get_captures_at_pos -- for neovim >= 0.8
+    or require('vim.treesitter').get_captures_at_position -- for neovim < 0.8
+
   local captures_at_cursor = vim.tbl_map(function(x)
     return x.capture
-  end, require('vim.treesitter').get_captures_at_pos(buf, row, col))
+  end, get_captures_at_pos(buf, row, col))
 
   if vim.tbl_isempty(captures_at_cursor) then
     return false


### PR DESCRIPTION
`get_captures_at_position` has been renamed to `get_captures_at_pos`: neovim/neovim#20331. Fallback to `get_captures_at_position` in case `get_captures_at_pos` is `nil`.

_See comment by @smjonas in https://github.com/hrsh7th/nvim-cmp/issues/1211#issuecomment-1273592539_