### PR TITLE
Fix undefined new() error in example source

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -783,7 +783,7 @@ Here is an example on how to create a custom source:
   end
 
   ---Register your source to nvim-cmp.
-  require('cmp').register_source('month', source.new())
+  require('cmp').register_source('month', source)
 <
 ==============================================================================
 FAQ                                                                    *cmp-faq*


### PR DESCRIPTION
Ran into a bug in the help file showing an example source. There was a stray `source.new()` call that threw errors. This PR might save somebody in the future a bit of head-scratching.