### PR TITLE
fix: Fix entry.match when there is custom format callback

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -377,7 +377,8 @@ entry.match = function(self, input, matching_config)
     }
 
     local score, matches, _
-    score, matches = matcher.match(input, self:get_filter_text(), option)
+    local vim_item = self:get_vim_item(self:get_offset())
+    score, matches = matcher.match(input, vim_item.abbr, option)
 
     -- Support the language server that doesn't respect VSCode's behaviors.
     if score == 0 then
@@ -389,13 +390,13 @@ entry.match = function(self, input, matching_config)
           accept = accept or string.match(prefix, '^[^%a]+$')
           accept = accept or string.find(self:get_completion_item().textEdit.newText, prefix, 1, true)
           if accept then
-            score, matches = matcher.match(input, prefix .. self:get_filter_text(), option)
+            score, matches = matcher.match(input, prefix .. vim_item.abbr, option)
           end
         end
       end
     end
 
-    if self:get_filter_text() ~= self:get_completion_item().label then
+    if vim_item.abbr == self:get_filter_text() and vim_item.abbr ~= self:get_completion_item().label then
       _, matches = matcher.match(input, self:get_completion_item().label, { synonyms = { self:get_word() } })
     end
 


### PR DESCRIPTION
This Pull Request fixes #1248 

# Changes
- Fixed highlighting logic inside the `entry.match()` function when there is a custom callback function for abbr formattng.

# Pictures that describe the issue
![image](https://user-images.githubusercontent.com/45588457/196617816-3b272c45-12d3-47d9-8edf-ca8b86eed37f.png)

# After solved the issue
<img width="450" alt="image" src="https://user-images.githubusercontent.com/45588457/196617921-f25fe36b-358b-4c5f-bd7d-ae29c0b5c9c0.png">

