### PR TITLE
Use `default_capabilities()` in doc and util

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -126,7 +126,7 @@ A recommended configuration can be found below.
     })
 
     -- Setup lspconfig.
-    local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())
+    local capabilities = require('cmp_nvim_lsp').default_capabilities()
     require('lspconfig')[%YOUR_LSP_SERVER%].setup {
       capabilities = capabilities
     }

--- a/utils/vimrc.vim
+++ b/utils/vimrc.vim
@@ -44,7 +44,7 @@ cmp.setup {
 EOF
 
 lua << EOF
-local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())
+local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
 require'lspconfig'.cssls.setup {
   capabilities = capabilities,


### PR DESCRIPTION
Commit 0b6654d3de257669b9b3b2a5cb557d5d813f2229 changed the `README.md` to use `default_capabilities()` instead of `update_capabilities()`. This commit replicates that change to `doc/cmp.txt` and `utils/vimrc.vim` for consistency.