### PR TITLE
Fix replace_keycodes has expr traceback

### DIFF
--- a/lua/cmp/utils/keymap.lua
+++ b/lua/cmp/utils/keymap.lua
@@ -137,7 +137,7 @@ keymap.fallback = function(bufnr, mode, map)
         script = map.script,
         nowait = map.nowait,
         silent = map.silent and mode ~= 'c',
-        replace_keycodes = map.replace_keycodes,
+        replace_keycodes = map.replace_keycodes == 1,
       })
       vim.api.nvim_feedkeys(keymap.t(fallback_lhs), 'im', true)
     elseif map.callback then
@@ -172,7 +172,7 @@ keymap.solve = function(bufnr, mode, map)
       script = true,
       nowait = map.nowait,
       silent = map.silent and mode ~= 'c',
-      replace_keycodes = map.replace_keycodes,
+      replace_keycodes = map.replace_keycodes == 1,
     })
     return { keys = keymap.t(recursive) .. string.gsub(rhs, '^' .. vim.pesc(lhs), ''), mode = 'im' }
   end


### PR DESCRIPTION
Fixes the following traceback:
    E5108: Error executing lua: ...site/pack/packer/start/nvim-cmp/lua/cmp/utils/keymap.lua:250: "replace_keycodes" requires "expr"
    stack traceback:
            [C]: in function 'nvim_set_keymap'
            ...site/pack/packer/start/nvim-cmp/lua/cmp/utils/keymap.lua:250: in function 'set_map'
            ...site/pack/packer/start/nvim-cmp/lua/cmp/utils/keymap.lua:170: in function 'solve'
            ...site/pack/packer/start/nvim-cmp/lua/cmp/utils/keymap.lua:133: in function <...site/pack/packer/start/nvim-cmp/lua/cmp/utils/keymap.lua:132>

Happens by simple pressing tab in insert mode on an empty file supported by a LSP.

Regression since 53bd5749011c0830d54d9b22a37259651d5916df