### PR TITLE
feat: disable `showbreak` for documentation window

### DIFF
--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -15,6 +15,7 @@ docs_view.new = function()
   self.window:option('foldenable', false)
   self.window:option('linebreak', true)
   self.window:option('scrolloff', 0)
+  self.window:option('showbreak', 'NONE')
   self.window:option('wrap', true)
   self.window:buffer_option('filetype', 'cmp_docs')
   return self


### PR DESCRIPTION
Although I have `showbreak` set for normal editing I would rather not see that in documentation. RFC.

Setting to `NONE` as per `:h showbreak`:

```
	A window-local value overrules a global value.  If the global value is
	set and you want no value in the current window use NONE:  
		:setlocal showbreak=NONE
```