### PR TITLE
Fix select_next_item and select_prev_item 

### DIFF
--- a/lua/cmp/view/native_entries_view.lua
+++ b/lua/cmp/view/native_entries_view.lua
@@ -122,9 +122,9 @@ native_entries_view.select_next_item = function(self, option)
   end
   if self:visible() then
     if (option.behavior or types.cmp.SelectBehavior.Insert) == types.cmp.SelectBehavior.Insert then
-      feedkeys.call(keymap.t(string.format('%s<C-n>', option.count), 'n', callback))
+      feedkeys.call(keymap.t(string.rep('<C-n>', option.count)), 'n', callback)
     else
-      feedkeys.call(keymap.t(string.format('%s<Down>', option.count)), 'n', callback)
+      feedkeys.call(keymap.t(string.rep('<Down>', option.count)), 'n', callback)
     end
   end
 end
@@ -135,9 +135,9 @@ native_entries_view.select_prev_item = function(self, option)
   end
   if self:visible() then
     if (option.behavior or types.cmp.SelectBehavior.Insert) == types.cmp.SelectBehavior.Insert then
-      feedkeys.call(keymap.t(string.format('%s<C-p>', option.count), 'n', callback))
+      feedkeys.call(keymap.t(string.rep('<C-p>', option.count)), 'n', callback)
     else
-      feedkeys.call(keymap.t(string.format('%s<Up>', option.count)), 'n', callback)
+      feedkeys.call(keymap.t(string.rep('<Up>', option.count)), 'n', callback)
     end
   end
 end


### PR DESCRIPTION
This fixes a bug with select_next_item and select_prev_item methods in native_entries_view. 

The error:
```lua
E5108: Error executing lua: ...site/pack/packer/opt/nvim-cmp/lua/cmp/utils/feedkeys.lua:10: bad argument #1 to 'match' (string expected, got nil)
stack traceback:
        [C]: in function 'match'
        ...site/pack/packer/opt/nvim-cmp/lua/cmp/utils/feedkeys.lua:10: in function 'call'
        ...packer/opt/nvim-cmp/lua/cmp/view/native_entries_view.lua:125: in function 'select_next_item'
        ...hare/nvim/site/pack/packer/opt/nvim-cmp/lua/cmp/view.lua:164: in function 'select_next_item'
        ...hare/nvim/site/pack/packer/opt/nvim-cmp/lua/cmp/init.lua:138: in function 'select_next_item'
        /home/zahid/.config/nvim/lua/plugins/cmp-plugin/init.lua:62: in function 'on_keymap'
        ...hare/nvim/site/pack/packer/opt/nvim-cmp/lua/cmp/core.lua:145: in function 'callback'
        ...m/site/pack/packer/opt/nvim-cmp/lua/cmp/utils/keymap.lua:118: in function <...m/site/pack/packer/opt/nvim-cmp/lua/cmp/utils/keymap.lua:112>
```