### PR TITLE
fix: type annotation for enabled field in ConfigSchema

### DIFF
--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -79,7 +79,7 @@ cmp.ItemField = {
 
 ---@class cmp.ConfigSchema
 ---@field private revision integer
----@field public enabled fun():boolean|boolean
+---@field public enabled boolean | fun(): boolean
 ---@field public performance cmp.PerformanceConfig
 ---@field public preselect cmp.PreselectMode
 ---@field public completion cmp.CompletionConfig


### PR DESCRIPTION
I was using it with https://github.com/sumneko/lua-language-server, and it was giving me a type error with `enabled = true`, probably because it parsed the type as `fun(): (boolean|boolean)`, which is equivalent to `fun(): boolean`
changing it to `boolean | fun(): boolean` fixes it for me