### PR TITLE
feat: added hide_scrollbar option to window.completition ( #1087)

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -630,6 +630,11 @@ window.completion.side_padding~
   `number`
   The ammount of padding to add on the completion window's sides
 
+                                     *cmp-config.window.completion.hide_scrollbar*
+window.completion.hide_scrollbar~
+  `boolean`
+  Wether the scrollbar should be hidden even if there are more items that fit
+
                                      *cmp-config.window.documentation.max_width*
 window.documentation.max_width~
   `number`

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -95,6 +95,7 @@ return function()
         scrolloff = 0,
         col_offset = 0,
         side_padding = 1,
+        hide_scrollbar = false,
       },
       documentation = {
         max_height = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),

--- a/lua/cmp/config/window.lua
+++ b/lua/cmp/config/window.lua
@@ -9,6 +9,7 @@ window.bordered = function(opts)
     scrolloff = opts.scrolloff or 0,
     col_offset = opts.col_offset or 0,
     side_padding = opts.side_padding or 1,
+    hide_scrollbar = opts.hide_scrollbar or false,
   }
 end
 

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -117,6 +117,7 @@ cmp.ItemField = {
 ---@field public max_width integer|nil
 ---@field public max_height integer|nil
 ---@field public scrolloff integer|nil
+---@field public hide_scrollbar boolean|false
 
 ---@class cmp.ConfirmationConfig
 ---@field public default_behavior cmp.ConfirmBehavior

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -1,6 +1,7 @@
 local misc = require('cmp.utils.misc')
 local buffer = require('cmp.utils.buffer')
 local api = require('cmp.utils.api')
+local config = require('cmp.config')
 
 ---@class cmp.WindowStyle
 ---@field public relative string
@@ -126,7 +127,8 @@ end
 ---Update
 window.update = function(self)
   local info = self:info()
-  if info.scrollable then
+  local hide_scrollbar = config.get().window.completion.hide_scrollbar
+  if info.scrollable and not hide_scrollbar then
     -- Draw the background of the scrollbar
 
     if not info.border_info.visible then


### PR DESCRIPTION
Added configuration option to disable competition scrollbar.

Inspiration: [https://github.com/hrsh7th/nvim-cmp/issues/1087#issuecomment-1193701228](https://github.com/hrsh7th/nvim-cmp/issues/1087#issuecomment-1193701228)

Issue: [https://github.com/hrsh7th/nvim-cmp/issues/1087](https://github.com/hrsh7th/nvim-cmp/issues/1087)

Before:
![image](https://user-images.githubusercontent.com/83361786/202150918-f3b08b3e-bbae-4c68-85ce-0badc36d12d9.png)

After:
![image](https://user-images.githubusercontent.com/83361786/202151243-7082671e-708e-47b0-add5-a627a6546d3d.png)

Please let me know if I missed anything.