### PR TITLE
feat: `enabled` for sources

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -540,6 +540,11 @@ sources[n].max_item_count~
   `number`
   The source-specific item count.
 
+                                          *cmp-config.sources[n].enabled*
+sources[n].enabled~
+  `boolean | fun(ctx: cmp.Source.context): boolean`
+  Whether this source should be enabled.
+
                                              *cmp-config.sources[n].group_index*
 sources[n].group_index~
   `number`

--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -80,11 +80,28 @@ source.get_fetching_time = function(self)
   return 100 * 1000 -- return pseudo time if source isn't fetching.
 end
 
+---Return whether this source is enabled
+---@return boolean
+source.enabled = function(self)
+  local _e = self:get_source_config().enabled
+  if type(_e) == 'boolean' then
+    return _e
+  elseif type(_e) == 'function' then
+    return _e(self.context)
+  else
+    return true
+  end
+end
+
 ---Return filtered entries
 ---@param ctx cmp.Context
 ---@return cmp.Entry[]
 source.get_entries = function(self, ctx)
   if self.offset == -1 then
+    return {}
+  end
+
+  if not self:enabled() then
     return {}
   end
 

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -148,6 +148,7 @@ cmp.ItemField = {
 
 ---@class cmp.SourceConfig
 ---@field public name string
+---@field public enabled nil|boolean|function(ctx: cmp.Source.context): boolean
 ---@field public option table|nil
 ---@field public priority integer|nil
 ---@field public trigger_characters string[]|nil


### PR DESCRIPTION
This PR adds `enabled` for individual sources.

This option can be used to toggle source based on context/conditions (https://github.com/hrsh7th/nvim-cmp/issues/806). I wanted `dictionary` to be enabled only in comments and, I was able to achieve that by

```lua
enabled = function (ctx)
    return context.in_treesitter_capture('comment')
end
```