### PR TITLE
Docs: Use tree-sitter language injection

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -44,7 +44,7 @@ A recommended configuration can be found below.
     1. You must provide a `snippet.expand` function.
     2. `cmp.setup.cmdline` won't work if you use the `native` completion menu.
     3. You can disable the `default` options by specifying `cmp.config.disable` value.
->
+>vim
   call plug#begin(s:plug_dir)
   Plug 'neovim/nvim-lspconfig'
   Plug 'hrsh7th/cmp-nvim-lsp'
@@ -182,7 +182,7 @@ NOTE: `<Cmd>lua require('cmp').complete()<CR>` can be used to call these functio
   Invoke completion.
 
   The following configuration defines a key mapping to show completion only for vsnip snippets.
->
+>lua
   cmp.setup {
     mapping = {
       ['<C-s>'] = cmp.mapping.complete({
@@ -194,14 +194,14 @@ NOTE: `<Cmd>lua require('cmp').complete()<CR>` can be used to call these functio
       })
     }
   }
-< >
+< >vim
   inoremap <C-S> <Cmd>lua require('cmp').complete({ config = { sources = { { name = 'vsnip' } } } })<CR>
 <
   NOTE: `config` in that case means a temporary setting, but `config.mapping` remains permanent.
 
 *cmp.complete_common_string* ()
   Complete common string (similar to shell completion behavior).
->
+>lua
   cmp.setup {
     mapping = {
       ['<C-l>'] = cmp.mapping(function(fallback)
@@ -239,7 +239,7 @@ The `fallback` function can be used to call an existing mapping.
 For example, typical pair-wise plugins automatically define mappings for `<CR>` and `(`.
 Nvim-cmp will overwrite it if you provide a mapping. To call the existing mapping,
 you would need to invoke the `fallback` function.
->
+>lua
   cmp.setup {
     mapping = {
       ['<CR>'] = function(fallback)
@@ -251,7 +251,7 @@ you would need to invoke the `fallback` function.
       end
     }
   }
-< >
+< >lua
   cmp.setup {
     mapping = {
       ['<Tab>'] = function(fallback)
@@ -266,7 +266,7 @@ you would need to invoke the `fallback` function.
 <
 
 It is possible to specify the modes the mapping should be active in (`i` = insert mode, `c` = command mode, `s` = select mode):
->
+>lua
   cmp.setup {
     mapping = {
       ['<CR>'] = cmp.mapping(your_mapping_function, { 'i', 'c' })
@@ -274,7 +274,7 @@ It is possible to specify the modes the mapping should be active in (`i` = inser
   }
 <
 You can also specify different mappings for different modes by passing a table:
->
+>lua
   cmp.setup {
     mapping = {
       ['<CR>'] = cmp.mapping({
@@ -350,7 +350,7 @@ NOTE: `kind` is a symbol after each completion option.
 *CmpItemKind%KIND_NAME%*
   Highlight group for the kind of the field for a specific `lsp.CompletionItemKind`.
   If you only want to overwrite the `method` kind's highlight group, you can do this:
->
+>vim
     highlight CmpItemKindMethod guibg=NONE guifg=Orange
 <
 *CmpItemMenu*
@@ -490,7 +490,7 @@ sorting.priority_weight~
   Each item's original priority (given by its corresponding source) will be
   increased by `#sources - (source_index - 1)` and multiplied by `priority_weight`.
   That is, the final priority is calculated by the following formula:
->
+>lua
   final_score = orig_score + ((#sources - (source_index - 1)) * sorting.priority_weight)
 <
                                                 *cmp-config.sorting.comparators*
@@ -547,7 +547,7 @@ sources[n].group_index~
 
   For instance, you can set the `buffer`'s source `group_index` to a larger number
   if you don't want to see `buffer` source items while `nvim-lsp` source is available:
->
+>lua
     cmp.setup {
       sources = {
         { name = 'nvim_lsp', group_index = 1 },
@@ -556,7 +556,7 @@ sources[n].group_index~
     }
 <
   You can also achieve this by using the built-in configuration helper like this:
->
+>lua
     cmp.setup {
       sources = cmp.config.sources({
         { name = 'nvim_lsp' },
@@ -579,7 +579,7 @@ sources[n].entry_filter~
   This can be used to hide certain entries from a given source. For instance, you
   could hide all entries with kind `Text` from the `nvim_lsp` filter using the
   following source definition:
->
+>lua
   {
     name = 'nvim_lsp',
     entry_filter = function(entry, ctx)
@@ -662,7 +662,7 @@ cmp.config.compare~
 cmp.config.context~
 
   The `cmp.config.context` can be used for context-aware completion toggling.
->
+>lua
     cmp.setup {
       enabled = function()
         -- disable completion if the cursor is `Comment` syntax group.
@@ -688,7 +688,7 @@ cmp.config.sources~
     You can specify multiple source arrays. The sources are grouped in the
     order you specify, and the groups are displayed as a fallback, like chain
     completion.
->
+>lua
     cmp.setup {
       sources = cmp.config.sources({
         { name = 'nvim_lsp' },
@@ -702,7 +702,7 @@ cmp.config.window~
   *cmp.config.window.bordered* (option)
     Make the completion window `bordered`.
     The option is described in `cmp.ConfigSchema`.
->
+>lua
     cmp.setup {
       window = {
         completion = cmp.config.window.bordered(),
@@ -725,7 +725,7 @@ NOTE:
   and if you publish it on GitHub, add the `nvim-cmp` topic so users can find it more easily.
 
 Here is an example on how to create a custom source:
->
+>lua
   local source = {}
 
   ---Return whether this source is available in the current context or not (optional).
@@ -807,7 +807,7 @@ How to disable the preselect feature? ~
   The LSP spec defines the `preselect` feature for completion.
 
   You can disable the `preselect` feature like this:
->
+>lua
   cmp.setup {
     preselect = cmp.PreselectMode.None
   }
@@ -816,7 +816,7 @@ How to disable the preselect feature? ~
 How to disable commitCharacters?~
 
   You can disable the commitCharacters feature (which is defined in LSP spec):
->
+>lua
   cmp.setup {
     confirmation = {
       get_commit_characters = function(commit_characters)
@@ -831,7 +831,7 @@ How to disable auto-completion?~
 How to use nvim-cmp as omnifunc?~
 
   You can disable auto-completion like this:
->
+>lua
   cmp.setup {
     ...
     completion = {
@@ -841,7 +841,7 @@ How to use nvim-cmp as omnifunc?~
   }
 <
   Then you will need to invoke completion manually.
->
+>vim
   inoremap <C-x><C-o> <Cmd>lua require('cmp').complete()<CR>
 <
 
@@ -849,7 +849,7 @@ How to disable nvim-cmp for a specific buffer?~
 How to setup nvim-cmp for a specific buffer?~
 
   You can setup buffer-specific configuration like this:
->
+>lua
   cmp.setup.filetype({ 'markdown', 'help' }, {
     sources = {
       { name = 'path' },
@@ -861,7 +861,7 @@ How to setup nvim-cmp for a specific buffer?~
 How to disable the documentation window?~
 
   Simply use the following config:
->
+>lua
   cmp.setup.filetype({ 'markdown', 'help' }, {
     window = {
       documentation = cmp.config.disable
@@ -881,12 +881,12 @@ How to integrate with copilot.vim?~
   Therefore, you should manage those plugins by yourself.
 
   Fortunately, the copilot.vim has a feature that disables the fallback mechanism.
->
+>vim
   let g:copilot_no_tab_map = v:true
   imap <expr> <Plug>(vimrc:copilot-dummy-map) copilot#Accept("\<Tab>")
 <
   You can manage copilot.vim's accept feature inside nvim-cmp's key-mapping function:
->
+>lua
   cmp.setup {
     mapping = {
       ['<C-g>'] = cmp.mapping(function(fallback)


### PR DESCRIPTION
nvim-treesitter supports language injection in help docs.

![image](https://user-images.githubusercontent.com/60453380/207758857-3cc49e90-6890-4ee1-a159-9b5d6df1e8b1.png)

see:
    https://github.com/nvim-treesitter/nvim-treesitter/pull/3846