### PR TITLE
fix(api): get_screen_pos

### DIFF
--- a/lua/cmp/utils/api.lua
+++ b/lua/cmp/utils/api.lua
@@ -55,7 +55,7 @@ end
 api.get_screen_cursor = function()
   if api.is_cmdline_mode() then
     local cursor = api.get_cursor()
-    return { cursor[1], cursor[2] + 1 }
+    return { cursor[1], vim.fn.strdisplaywidth(string.sub(vim.fn.getcmdline(), 1, cursor[2] + 1)) }
   end
   local cursor = api.get_cursor()
   local pos = vim.fn.screenpos(0, cursor[1], cursor[2] + 1)

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -153,9 +153,8 @@ custom_entries_view.open = function(self, offset, entries)
   height = math.min(height, #self.entries)
 
   local pos = api.get_screen_cursor()
-  local cursor = api.get_cursor()
   local cursor_before_line = api.get_cursor_before_line()
-  local delta = vim.fn.strdisplaywidth(cursor_before_line:sub(-cursor[2])) + 1 - self.offset
+  local delta = vim.fn.strdisplaywidth(cursor_before_line:sub(self.offset))
   local row, col = pos[1], pos[2] - delta - 1
 
   local border_info = window.get_border_info({ style = completion })


### PR DESCRIPTION
Consider multibyte characters when calculating screen_cursor in cmdline.
