### PR TITLE
Hide snippets from autocomplete popup

### DIFF
--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -29,6 +29,7 @@ return function()
       expand = function(_)
         error('snippet engine is not configured.')
       end,
+      hide_snippets = false,
     },
 
     completion = {

--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -105,6 +105,7 @@ source.get_entries = function(self, ctx)
   local inputs = {}
   local entries = {}
   local matching_config = self:get_matching_config()
+  local hide_snippets = config.get().snippet.hide_snippets
   for _, e in ipairs(target_entries) do
     local o = e:get_offset()
     if not inputs[o] then
@@ -118,7 +119,12 @@ source.get_entries = function(self, ctx)
       e.matches = match.matches
       e.exact = e:get_filter_text() == inputs[o] or e:get_word() == inputs[o]
 
-      if entry_filter(e, ctx) then
+      local show_entry = true
+      if hide_snippets then
+        show_entry = e:get_kind() ~= types.lsp.CompletionItemKind.Snippet
+      end
+
+      if show_entry and entry_filter(e, ctx) then
         table.insert(entries, e)
       end
     end

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -139,6 +139,7 @@ cmp.ItemField = {
 
 ---@class cmp.SnippetConfig
 ---@field public expand fun(args: cmp.SnippetExpansionParams)
+---@field public hide_snippets boolean
 
 ---@class cmp.ExperimentalConfig
 ---@field public ghost_text cmp.GhostTextConfig|false


### PR DESCRIPTION
This commit allows snippets to be hidden from the autocomplete popup by setting hide_snippets to true in the configuration.

Note: The solution was inspired from the following discussion #759