### PR TITLE
Round up width/height for windows

### DIFF
--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -7,8 +7,8 @@ local config = require('cmp.config')
 ---@field public relative string
 ---@field public row integer
 ---@field public col integer
----@field public width integer
----@field public height integer
+---@field public width integer|float
+---@field public height integer|float
 ---@field public border string|string[]|nil
 ---@field public zindex integer|nil
 
@@ -86,6 +86,11 @@ window.set_style = function(self, style)
   end
 
   self.style.zindex = self.style.zindex or 1
+
+  --- GUI clients are allowed to return fractional bounds, but we need integer
+  --- bounds to open the window
+  self.style.width = math.ceil(self.style.width)
+  self.style.height = math.ceil(self.style.height)
 end
 
 ---Return buffer id.


### PR DESCRIPTION
Ever since neovim introduced the nvim_ui_pum_set_bounds() call, GUI clients have gained the ability to inform neovim of the current bounds of an external popup menu provided by ext_popupmenu.

Since external popup menus are allowed to be any size in pixels which may or may not line up cleanly on the grid, nvim allows for fractional coordinates to be reported. This also will mean that in the event of this, we'll end up with a cmp.WindowStyle with a float value for width/height - which is incompatible with vim.api.nvim_open_win() and will cause us to hit errors with GUI clients using this API call. An example:

```
Error executing vim.schedule lua callback: /home/lyudess/.vim/bundle/nvim-cmp/lua/cmp/utils/window.lua:115: 'width' key must be a positive Integer
stack traceback:
	[C]: in function 'nvim_win_set_config'
	/home/lyudess/.vim/bundle/nvim-cmp/lua/cmp/utils/window.lua:115: in function 'open'
	.../lyudess/.vim/bundle/nvim-cmp/lua/cmp/view/docs_view.lua:102: in function 'open'
	/home/lyudess/.vim/bundle/nvim-cmp/lua/cmp/view.lua:238: in function 'callback'
	/home/lyudess/.vim/bundle/nvim-cmp/lua/cmp/utils/async.lua:109: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

So, fix this by simply rounding up the width/height.