### PR TITLE
Add `override` option

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,2 +1,3 @@
 globals = { 'vim', 'describe', 'it', 'before_each', 'after_each', 'assert', 'async' }
 max_line_length = false
+ignore = { '311', '431', '432' }

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -515,20 +515,26 @@ sources[n].option~
   `table`
   Any specific options defined by the source itself.
 
+                                                *cmp-config.sources[n].override*
+sources[n].override~
+  `cmp.SourceOverrideConfig`
+  A table that sets up functions to override the behavior of the custom source.
+  Implemented as the following type definitions.
+  (For advanced users.)
+>lua
+  ---@class cmp.SourceOverrideConfig
+  ---@field public is_available? fun(is_available: fun(): boolean): boolean
+  ---@field public get_trigger_characters? fun(params: cmp.SourceApiParams, get_trigger_characters: (fun(params: cmp.SourceApiParams): string[])): string[]
+  ---@field public get_keyword_pattern? fun(params: cmp.SourceApiParams, get_keyword_pattern: fun(params: cmp.SourceApiParams): string): string
+  ---@field public complete fun(params: cmp.SourceCompletionApiParams, callback: fun(response: lsp.CompletionResponse), complete: fun(params: cmp.SourceCompletionApiParams, callback: fun(response: lsp.CompletionResponse)))
+  ---@field public resolve fun(completion_item: lsp.CompletionItem, callback: fun(completion_item: lsp.CompletionItem), resolve: fun(completion_item: lsp.CompletionItem, callback: fun(completion_item: lsp.CompletionItem)))
+  ---@field public execute fun(completion_item: lsp.CompletionItem, callback: fun(), execute: fun(completion_item: lsp.CompletionItem, callback: fun()))
+<
+
                                           *cmp-config.sources[n].keyword_length*
 sources[n].keyword_length~
   `number`
   The source-specific keyword length to trigger auto completion.
-
-                                         *cmp-config.sources[n].keyword_pattern*
-sources[n].keyword_pattern~
-  `string`
-  The source-specific keyword pattern.
-
-                                      *cmp-config.sources[n].trigger_characters*
-sources[n].trigger_characters~
-  `string[]`
-  A source-specific keyword pattern.
 
                                                 *cmp-config.sources[n].priority*
 sources[n].priority~
@@ -592,9 +598,8 @@ sources[n].entry_filter~
 
                                                                *cmp-config.view*
 view~
-  `{ entries: cmp.EntriesConfig|string }`
+  `{ entries: cmp.CustomEntriesConfig|NativeEntriesConfig|cmp.WildmenuEntriesConfig|string }`
   The view class used to customize nvim-cmp's appearance.
-  Currently available configuration options are:
 
                            *cmp-config.window.{completion,documentation}.border*
 window.{completion,documentation}.border~
@@ -789,7 +794,7 @@ Here is an example on how to create a custom source:
 
   ---Executed after the item was selected.
   ---@param completion_item lsp.CompletionItem
-  ---@param callback fun(completion_item: lsp.CompletionItem|nil)
+  ---@param callback fun()
   function source:execute(completion_item, callback)
     callback(completion_item)
   end

--- a/lua/cmp/config.lua
+++ b/lua/cmp/config.lua
@@ -190,8 +190,12 @@ config.normalize = function(c)
   -- Notice experimental.native_menu.
   if c.experimental and c.experimental.native_menu then
     echo({
-      '[nvim-cmp] ', { 'experimental.native_menu', 'WarningMsg' }, ' is deprecated.\n',
-      '[nvim-cmp] Please use ', { 'view.entries = "native"', 'WarningMsg' }, ' instead.',
+      '[nvim-cmp] ',
+      { 'experimental.native_menu', 'WarningMsg' },
+      ' is deprecated.\n',
+      '[nvim-cmp] Please use ',
+      { 'view.entries = "native"', 'WarningMsg' },
+      ' instead.',
     })
 
     c.view = c.view or {}
@@ -201,8 +205,12 @@ config.normalize = function(c)
   -- Notice documentation.
   if c.documentation ~= nil then
     echo({
-      '[nvim-cmp] ', { 'documentation', 'WarningMsg' }, ' is deprecated.\n',
-      '[nvim-cmp] Please use ', { 'window.documentation = cmp.config.window.bordered()', 'WarningMsg' }, ' instead.'
+      '[nvim-cmp] ',
+      { 'documentation', 'WarningMsg' },
+      ' is deprecated.\n',
+      '[nvim-cmp] Please use ',
+      { 'window.documentation = cmp.config.window.bordered()', 'WarningMsg' },
+      ' instead.',
     })
     c.window = c.window or {}
     c.window.documentation = c.documentation
@@ -211,14 +219,17 @@ config.normalize = function(c)
   -- Notice sources.[n].opts
   if c.sources then
     for _, s in ipairs(c.sources) do
-
       -- rename: opts -> option
       if s.opts and not s.option then
         s.option = s.opts
         s.opts = nil
         echo({
-          '[nvim-cmp] ', { 'sources[number].opts', 'WarningMsg' }, ' is deprecated.\n',
-          '[nvim-cmp] Please use ', { 'sources[number].option', 'WarningMsg' }, ' instead.',
+          '[nvim-cmp] ',
+          { 'sources[number].opts', 'WarningMsg' },
+          ' is deprecated.\n',
+          '[nvim-cmp] Please use ',
+          { 'sources[number].option', 'WarningMsg' },
+          ' instead.',
         })
       end
       s.option = s.option or {}
@@ -226,8 +237,12 @@ config.normalize = function(c)
       -- deprecated: trigger_characters
       if s.trigger_characters then
         echo({
-          '[nvim-cmp] ', { 'sources[number].trigger_characters', 'WarningMsg' }, ' is deprecated.\n',
-          '[nvim-cmp] Please use ', { 'sources[number].orverride.get_trigger_characters', 'WarningMsg' }, ' instead.'
+          '[nvim-cmp] ',
+          { 'sources[number].trigger_characters', 'WarningMsg' },
+          ' is deprecated.\n',
+          '[nvim-cmp] Please use ',
+          { 'sources[number].orverride.get_trigger_characters', 'WarningMsg' },
+          ' instead.',
         })
         if not s.override or s.override.get_trigger_characters then
           s.override = s.override or {}
@@ -240,8 +255,12 @@ config.normalize = function(c)
       -- deprecated: keyword_pattern
       if s.keyword_pattern then
         echo({
-          '[nvim-cmp] ', { 'sources[number].keyword_pattern', 'WarningMsg' }, ' is deprecated.\n',
-          '[nvim-cmp] Please use ', { 'sources[number].orverride.get_keyword_pattern', 'WarningMsg' }, ' instead.'
+          '[nvim-cmp] ',
+          { 'sources[number].keyword_pattern', 'WarningMsg' },
+          ' is deprecated.\n',
+          '[nvim-cmp] Please use ',
+          { 'sources[number].orverride.get_keyword_pattern', 'WarningMsg' },
+          ' instead.',
         })
         if not s.override or s.override.get_keyword_pattern then
           s.override = s.override or {}

--- a/lua/cmp/config.lua
+++ b/lua/cmp/config.lua
@@ -234,6 +234,8 @@ config.normalize = function(c)
       end
       s.option = s.option or {}
 
+      s.override = s.override or {}
+
       -- deprecated: trigger_characters
       if s.trigger_characters then
         echo({
@@ -244,8 +246,7 @@ config.normalize = function(c)
           { 'sources[number].orverride.get_trigger_characters', 'WarningMsg' },
           ' instead.',
         })
-        if not s.override or s.override.get_trigger_characters then
-          s.override = s.override or {}
+        if not s.override.get_trigger_characters then
           s.override.get_trigger_characters = function()
             return s.trigger_characters
           end
@@ -262,7 +263,7 @@ config.normalize = function(c)
           { 'sources[number].orverride.get_keyword_pattern', 'WarningMsg' },
           ' instead.',
         })
-        if not s.override or s.override.get_keyword_pattern then
+        if not s.override.get_keyword_pattern then
           s.override = s.override or {}
           s.override.get_keyword_pattern = function()
             return s.keyword_pattern

--- a/lua/cmp/init_spec.lua
+++ b/lua/cmp/init_spec.lua
@@ -81,7 +81,7 @@ describe('cmp', function()
       end,
       resolve = function(_, callback)
         callback({ label = 'override:resolved' })
-      end
+      end,
     })
     Keymap.spec(Async.async(function()
       Keymap.send('io', 'ni'):await()
@@ -104,7 +104,7 @@ describe('cmp', function()
       execute = function(_, callback)
         vim.api.nvim_set_current_line('ok')
         callback()
-      end
+      end,
     })
     Keymap.spec(Async.async(function()
       Keymap.send('io', 'ni'):await()
@@ -116,5 +116,4 @@ describe('cmp', function()
       assert.equals('ok', vim.api.nvim_get_current_line())
     end))
   end)
-
 end)

--- a/lua/cmp/init_spec.lua
+++ b/lua/cmp/init_spec.lua
@@ -1,0 +1,120 @@
+local async = require('cmp.utils.async')
+local core = require('cmp.core')
+local spec = require('cmp.utils.spec')
+local types = require('cmp.types')
+local config = require('cmp.config')
+local source = require('cmp.source')
+local Async = require('cmp.kit.Async')
+local Keymap = require('cmp.kit.Vim.Keymap')
+
+describe('cmp', function()
+  before_each(spec.before)
+
+  local function setup(override)
+    local c = core.new()
+    local s = source.new('spec', {
+      complete = function(_, _, callback)
+        callback({})
+      end,
+    })
+    c:register_source(s)
+    config.set_buffer({
+      sources = {
+        {
+          name = 'spec',
+          override = override,
+        },
+      },
+    }, vim.api.nvim_get_current_buf())
+    c:prepare()
+    return c
+  end
+
+  it('should work source[n].override.is_available', function()
+    local c = setup({
+      complete = function(_, callback)
+        callback({
+          { label = 'ok!' },
+        })
+      end,
+      is_available = function(_)
+        return vim.api.nvim_get_current_line() == 'ok'
+      end,
+    })
+    Keymap.spec(Async.async(function()
+      -- o
+      Keymap.send('io', 'ni'):await()
+      c:complete(c:get_context({ reason = types.cmp.ContextReason.Manual }))
+      vim.wait(200)
+      assert.equals(0, #c.view:get_entries())
+
+      -- ok
+      Keymap.send('k', 'ni'):await()
+      c:complete(c:get_context({ reason = types.cmp.ContextReason.Manual }))
+      vim.wait(200)
+      assert.equals(1, #c.view:get_entries())
+    end))
+  end)
+
+  it('should work source[n].override.complete', function()
+    local c = setup({
+      complete = function(_, callback)
+        callback({
+          { label = 'override' },
+        })
+      end,
+    })
+    Keymap.spec(Async.async(function()
+      Keymap.send('io', 'ni'):await()
+      c:complete(c:get_context({ reason = types.cmp.ContextReason.Manual }))
+      vim.wait(200)
+      assert.equals('override', c.view:get_entries()[1]:get_completion_item().label)
+    end))
+  end)
+
+  it('should work source[n].override.resolve', function()
+    local c = setup({
+      complete = function(_, callback)
+        callback({
+          { label = 'override' },
+        })
+      end,
+      resolve = function(_, callback)
+        callback({ label = 'override:resolved' })
+      end
+    })
+    Keymap.spec(Async.async(function()
+      Keymap.send('io', 'ni'):await()
+      c:complete(c:get_context({ reason = types.cmp.ContextReason.Manual }))
+      vim.wait(200)
+      async.sync(function(done)
+        c.view:get_entries()[1]:resolve(done)
+      end, 1000)
+      assert.equals('override:resolved', c.view:get_entries()[1]:get_completion_item().label)
+    end))
+  end)
+
+  it('should work source[n].override.resolve', function()
+    local c = setup({
+      complete = function(_, callback)
+        callback({
+          { label = 'override' },
+        })
+      end,
+      execute = function(_, callback)
+        vim.api.nvim_set_current_line('ok')
+        callback()
+      end
+    })
+    Keymap.spec(Async.async(function()
+      Keymap.send('io', 'ni'):await()
+      c:complete(c:get_context({ reason = types.cmp.ContextReason.Manual }))
+      vim.wait(200)
+      async.sync(function(done)
+        c.view:get_entries()[1]:execute(done)
+      end, 1000)
+      assert.equals('ok', vim.api.nvim_get_current_line())
+    end))
+  end)
+
+end)

--- a/lua/cmp/init_spec.lua
+++ b/lua/cmp/init_spec.lua
@@ -89,7 +89,7 @@ describe('cmp', function()
         })
       end,
     }, {
-      trigger_characters = { 'v' }
+      trigger_characters = { 'v' },
     })
     ---@diagnostic disable-next-line: undefined-field
     assert.are.same(vim.tbl_values(c.sources)[1]:get_trigger_characters(), { 'v' })

--- a/lua/cmp/kit/App/Cache.lua
+++ b/lua/cmp/kit/App/Cache.lua
@@ -1,0 +1,70 @@
+---Create cache key.
+---@private
+---@param key string[]|string
+---@return string
+local function _key(key)
+  if type(key) == 'table' then
+    return table.concat(key, ':')
+  end
+  return key
+end
+
+---@class cmp.kit.App.Cache
+---@field private keys table<string, boolean>
+---@field private entries table<string, any>
+local Cache = {}
+Cache.__index = Cache
+
+---Create new cache instance.
+function Cache.new()
+  local self = setmetatable({}, Cache)
+  self.keys = {}
+  self.entries = {}
+  return self
+end
+
+---Get cache entry.
+---@param key string[]|string
+---@return any
+function Cache:get(key)
+  return self.entries[_key(key)]
+end
+
+---Set cache entry.
+---@param key string[]|string
+---@param val any
+function Cache:set(key, val)
+  key = _key(key)
+  self.keys[key] = true
+  self.entries[key] = val
+end
+
+---Delete cache entry.
+---@param key string[]|string
+function Cache:del(key)
+  key = _key(key)
+  self.keys[key] = nil
+  self.entries[key] = nil
+end
+
+---Return this cache has the key entry or not.
+---@param key string[]|string
+---@return boolean
+function Cache:has(key)
+  key = _key(key)
+  return not not self.keys[key]
+end
+
+---Ensure cache entry.
+---@generic T
+---@param key string[]|string
+---@param callback function(): T
+---@return T
+function Cache:ensure(key, callback)
+  if not self:has(key) then
+    self:set(key, callback())
+  end
+  return self:get(key)
+end
+
+return Cache

--- a/lua/cmp/kit/App/Config.lua
+++ b/lua/cmp/kit/App/Config.lua
@@ -1,0 +1,96 @@
+local kit = require('cmp.kit')
+local Cache = require('cmp.kit.App.Cache')
+
+---@alias cmp.kit.App.Config.SchemaInternal cmp.kit.App.Config.Schema|{ revision: integer }
+
+---@class cmp.kit.App.Config
+---@field private cache cmp.kit.App.Cache
+---@field private default cmp.kit.App.Config.SchemaInternal
+---@field private _global cmp.kit.App.Config.SchemaInternal
+---@field private _filetype table<string, cmp.kit.App.Config.SchemaInternal>
+---@field private _buffer table<integer, cmp.kit.App.Config.SchemaInternal>
+local Config = {}
+Config.__index = Config
+
+---Create new config instance.
+---@param default? cmp.kit.App.Config.Schema
+function Config.new(default)
+  local self = setmetatable({}, Config)
+  self.cache = Cache.new()
+  self.default = default or {}
+  self._global = {}
+  self._filetype = {}
+  self._buffer = {}
+  return self
+end
+
+---Update global config.
+---@param config cmp.kit.App.Config.Schema
+function Config:global(config)
+  local revision = (self._global.revision or 1) + 1
+  self._global = config or {}
+  self._global.revision = revision
+end
+
+---Update filetype config.
+---@param filetypes string|string[]
+---@param config cmp.kit.App.Config.Schema
+function Config:filetype(filetypes, config)
+  for _, filetype in ipairs(kit.to_array(filetypes)) do
+    local revision = ((self._filetype[filetype] or {}).revision or 1) + 1
+    self._filetype[filetype] = config or {}
+    self._filetype[filetype].revision = revision
+  end
+end
+
+---Update filetype config.
+---@param bufnr integer
+---@param config cmp.kit.App.Config.Schema
+function Config:buffer(bufnr, config)
+  bufnr = bufnr == 0 and vim.api.nvim_get_current_buf() or bufnr
+  local revision = ((self._buffer[bufnr] or {}).revision or 1) + 1
+  self._buffer[bufnr] = config or {}
+  self._buffer[bufnr].revision = revision
+end
+
+---Get current configuration.
+---@return cmp.kit.App.Config.Schema
+function Config:get()
+  local filetype = vim.api.nvim_buf_get_option(0, 'filetype')
+  local bufnr = vim.api.nvim_get_current_buf()
+  return self.cache:ensure({
+    tostring(self._global.revision or 0),
+    tostring((self._buffer[bufnr] or {}).revision or 0),
+    tostring((self._filetype[filetype] or {}).revision or 0),
+  }, function()
+    local config = self.default
+    config = kit.merge(self._global, config)
+    config = kit.merge(self._filetype[filetype] or {}, config)
+    config = kit.merge(self._buffer[bufnr] or {}, config)
+    config.revision = nil
+    return config
+  end)
+end
+
+---Create setup interface.
+---@return fun(config: cmp.kit.App.Config.Schema)|{ filetype: fun(filetypes: string|string[], config: cmp.kit.App.Config.Schema), buffer: fun(bufnr: integer, config: cmp.kit.App.Config.Schema) }
+function Config:create_setup_interface()
+  return setmetatable({}, {
+    ---@param config cmp.kit.App.Config.Schema
+    __call = function(_, config)
+      self:global(config)
+    end,
+    ---@param filetypes string|string[]
+    ---@param config cmp.kit.App.Config.Schema
+    filetype = function(_, filetypes, config)
+      self:filetype(filetypes, config)
+    end,
+    ---@param bufnr integer
+    ---@param config cmp.kit.App.Config.Schema
+    buffer = function(_, bufnr, config)
+      self:buffer(bufnr, config)
+    end,
+  })
+end
+
+return Config

--- a/lua/cmp/kit/App/Config.lua
+++ b/lua/cmp/kit/App/Config.lua
@@ -4,8 +4,8 @@ local Cache = require('cmp.kit.App.Cache')
 ---@alias cmp.kit.App.Config.SchemaInternal cmp.kit.App.Config.Schema|{ revision: integer }
 
 ---@class cmp.kit.App.Config
----@field private cache cmp.kit.App.Cache
----@field private default cmp.kit.App.Config.SchemaInternal
+---@field private _cache cmp.kit.App.Cache
+---@field private _default cmp.kit.App.Config.SchemaInternal
 ---@field private _global cmp.kit.App.Config.SchemaInternal
 ---@field private _filetype table<string, cmp.kit.App.Config.SchemaInternal>
 ---@field private _buffer table<integer, cmp.kit.App.Config.SchemaInternal>
@@ -16,12 +16,18 @@ Config.__index = Config
 ---@param default? cmp.kit.App.Config.Schema
 function Config.new(default)
   local self = setmetatable({}, Config)
-  self.cache = Cache.new()
-  self.default = default or {}
+  self._cache = Cache.new()
+  self._default = default or {}
   self._global = {}
   self._filetype = {}
   self._buffer = {}
   return self
+end
+
+---Set default configuration.
+---@param default cmp.kit.App.Config.Schema
+function Config:default(default)
+  self._default = default
 end
 
 ---Update global config.
@@ -58,12 +64,12 @@ end
 function Config:get()
   local filetype = vim.api.nvim_buf_get_option(0, 'filetype')
   local bufnr = vim.api.nvim_get_current_buf()
-  return self.cache:ensure({
+  return self._cache:ensure({
     tostring(self._global.revision or 0),
     tostring((self._buffer[bufnr] or {}).revision or 0),
     tostring((self._filetype[filetype] or {}).revision or 0),
   }, function()
-    local config = self.default
+    local config = self._default
     config = kit.merge(self._global, config)
     config = kit.merge(self._filetype[filetype] or {}, config)
     config = kit.merge(self._buffer[bufnr] or {}, config)

--- a/lua/cmp/kit/App/Event.lua
+++ b/lua/cmp/kit/App/Event.lua
@@ -42,8 +42,10 @@ function Event:off(name, listener)
     self._events[name] = nil
   else
     for i = #self._events[name], 1, -1 do
-      table.remove(self._events[name], i)
-      break
+      if self._events[name][i] == listener then
+        table.remove(self._events[name], i)
+        break
+      end
     end
   end
 end

--- a/lua/cmp/kit/App/Event.lua
+++ b/lua/cmp/kit/App/Event.lua
@@ -1,0 +1,75 @@
+---@class cmp.kit.App.Event
+---@field private _events table<string, table>
+local Event = {}
+Event.__index = Event
+
+---Create new Event.
+function Event.new()
+  local self = setmetatable({}, Event)
+  self._events = {}
+  return self
+end
+
+---Register listener.
+---@param name string
+---@param listener function
+---@return function
+function Event:on(name, listener)
+  self._events[name] = self._events[name] or {}
+  table.insert(self._events[name], listener)
+  return function()
+    self:off(name, listener)
+  end
+end
+
+---Register once listener.
+---@param name string
+---@param listener function
+function Event:once(name, listener)
+  local off
+  off = self:on(name, function(...)
+    listener(...)
+    off()
+  end)
+end
+
+---Off specified listener from event.
+---@param name string
+---@param listener function
+function Event:off(name, listener)
+  self._events[name] = self._events[name] or {}
+  if not listener then
+    self._events[name] = nil
+  else
+    for i = #self._events[name], 1, -1 do
+      table.remove(self._events[name], i)
+      break
+    end
+  end
+end
+
+---Return if the listener is registered.
+---@param name string
+---@param listener? function
+---@return boolean
+function Event:has(name, listener)
+  self._events[name] = self._events[name] or {}
+  for _, v in ipairs(self._events[name]) do
+    if v == listener then
+      return true
+    end
+  end
+  return false
+end
+
+---Emit event.
+---@param name string
+---@vararg any
+function Event:emit(name, ...)
+  self._events[name] = self._events[name] or {}
+  for _, v in ipairs(self._events[name]) do
+    v(...)
+  end
+end
+
+return Event

--- a/lua/cmp/kit/Async/AsyncTask.lua
+++ b/lua/cmp/kit/Async/AsyncTask.lua
@@ -26,13 +26,17 @@ local function settle(task, status, value)
   if status == AsyncTask.Status.Rejected then
     if not task.chained and not task.synced then
       local timer = uv.new_timer()
-      timer:start(0, 0, kit.safe_schedule_wrap(function()
-        timer:stop()
-        timer:close()
-        if not task.chained and not task.synced then
-          AsyncTask.on_unhandled_rejection(value)
-        end
-      end))
+      timer:start(
+        0,
+        0,
+        kit.safe_schedule_wrap(function()
+          timer:stop()
+          timer:close()
+          if not task.chained and not task.synced then
+            AsyncTask.on_unhandled_rejection(value)
+          end
+        end)
+      )
     end
   end
 end

--- a/lua/cmp/kit/Async/AsyncTask.lua
+++ b/lua/cmp/kit/Async/AsyncTask.lua
@@ -1,0 +1,220 @@
+local uv = require('luv')
+local kit = require('cmp.kit')
+
+local is_thread = vim.is_thread()
+
+---@class cmp.kit.Async.AsyncTask
+---@field private value any
+---@field private status cmp.kit.Async.AsyncTask.Status
+---@field private synced boolean
+---@field private chained boolean
+---@field private children (fun(): any)[]
+local AsyncTask = {}
+AsyncTask.__index = AsyncTask
+
+---Settle the specified task.
+---@param task cmp.kit.Async.AsyncTask
+---@param status cmp.kit.Async.AsyncTask.Status
+---@param value any
+local function settle(task, status, value)
+  task.status = status
+  task.value = value
+  for _, c in ipairs(task.children) do
+    c()
+  end
+
+  if status == AsyncTask.Status.Rejected then
+    if not task.chained and not task.synced then
+      local timer = uv.new_timer()
+      timer:start(0, 0, kit.safe_schedule_wrap(function()
+        timer:stop()
+        timer:close()
+        if not task.chained and not task.synced then
+          AsyncTask.on_unhandled_rejection(value)
+        end
+      end))
+    end
+  end
+end
+
+---@enum cmp.kit.Async.AsyncTask.Status
+AsyncTask.Status = {
+  Pending = 0,
+  Fulfilled = 1,
+  Rejected = 2,
+}
+
+---Handle unhandled rejection.
+---@param err any
+function AsyncTask.on_unhandled_rejection(err)
+  error('AsyncTask.on_unhandled_rejection: ' .. tostring(err))
+end
+
+---Return the value is AsyncTask or not.
+---@param value any
+---@return boolean
+function AsyncTask.is(value)
+  return getmetatable(value) == AsyncTask
+end
+
+---Resolve all tasks.
+---@param tasks any[]
+---@return cmp.kit.Async.AsyncTask
+function AsyncTask.all(tasks)
+  return AsyncTask.new(function(resolve, reject)
+    local values = {}
+    local count = 0
+    for i, task in ipairs(tasks) do
+      task:dispatch(function(value)
+        values[i] = value
+        count = count + 1
+        if #tasks == count then
+          resolve(values)
+        end
+      end, reject)
+    end
+  end)
+end
+
+---Create resolved AsyncTask.
+---@param v any
+---@return cmp.kit.Async.AsyncTask
+function AsyncTask.resolve(v)
+  if AsyncTask.is(v) then
+    return v
+  end
+  return AsyncTask.new(function(resolve)
+    resolve(v)
+  end)
+end
+
+---Create new AsyncTask.
+---@NOET: The AsyncTask has similar interface to JavaScript Promise but the AsyncTask can be worked as synchronous.
+---@param v any
+---@return cmp.kit.Async.AsyncTask
+function AsyncTask.reject(v)
+  if AsyncTask.is(v) then
+    return v
+  end
+  return AsyncTask.new(function(_, reject)
+    reject(v)
+  end)
+end
+
+---Create new async task object.
+---@generic T
+---@param runner fun(resolve?: fun(value: T?), reject?: fun(err: any?))
+function AsyncTask.new(runner)
+  local self = setmetatable({}, AsyncTask)
+
+  self.value = nil
+  self.status = AsyncTask.Status.Pending
+  self.synced = false
+  self.chained = false
+  self.children = {}
+  local ok, err = pcall(runner, function(res)
+    if self.status == AsyncTask.Status.Pending then
+      settle(self, AsyncTask.Status.Fulfilled, res)
+    end
+  end, function(err)
+    if self.status == AsyncTask.Status.Pending then
+      settle(self, AsyncTask.Status.Rejected, err)
+    end
+  end)
+  if not ok then
+    settle(self, AsyncTask.Status.Rejected, err)
+  end
+  return self
+end
+
+---Sync async task.
+---@NOTE: This method uses `vim.wait` so that this can't wait the typeahead to be empty.
+---@param timeout? number
+---@return any
+function AsyncTask:sync(timeout)
+  self.synced = true
+
+  if is_thread then
+    while true do
+      if self.status ~= AsyncTask.Status.Pending then
+        break
+      end
+      uv.run('once')
+    end
+  else
+    vim.wait(timeout or 24 * 60 * 60 * 1000, function()
+      return self.status ~= AsyncTask.Status.Pending
+    end, 1, false)
+  end
+  if self.status == AsyncTask.Status.Rejected then
+    error(self.value, 2)
+  end
+  if self.status ~= AsyncTask.Status.Fulfilled then
+    error('AsyncTask:sync is timeout.', 2)
+  end
+  return self.value
+end
+
+---Await async task.
+---@param schedule? boolean
+---@return any
+function AsyncTask:await(schedule)
+  local Async = require('cmp.kit.Async')
+  local ok, res = pcall(Async.await, self)
+  if not ok then
+    error(res, 2)
+  end
+  if schedule then
+    Async.await(Async.schedule())
+  end
+  return res
+end
+
+---Register next step.
+---@param on_fulfilled fun(value: any): any
+function AsyncTask:next(on_fulfilled)
+  return self:dispatch(on_fulfilled, function(err)
+    error(err, 2)
+  end)
+end
+
+---Register catch step.
+---@param on_rejected fun(value: any): any
+---@return cmp.kit.Async.AsyncTask
+function AsyncTask:catch(on_rejected)
+  return self:dispatch(function(value)
+    return value
+  end, on_rejected)
+end
+
+---Dispatch task state.
+---@param on_fulfilled fun(value: any): any
+---@param on_rejected fun(err: any): any
+---@return cmp.kit.Async.AsyncTask
+function AsyncTask:dispatch(on_fulfilled, on_rejected)
+  self.chained = true
+
+  local function dispatch(resolve, reject)
+    local on_next = self.status == AsyncTask.Status.Fulfilled and on_fulfilled or on_rejected
+    local res = on_next(self.value)
+    if AsyncTask.is(res) then
+      res:dispatch(resolve, reject)
+    else
+      resolve(res)
+    end
+  end
+
+  if self.status == AsyncTask.Status.Pending then
+    return AsyncTask.new(function(resolve, reject)
+      table.insert(self.children, function()
+        local ok, err = pcall(dispatch, resolve, reject)
+        if not ok then
+          reject(err)
+        end
+      end)
+    end)
+  end
+  return AsyncTask.new(dispatch)
+end
+
+return AsyncTask

--- a/lua/cmp/kit/Async/init.lua
+++ b/lua/cmp/kit/Async/init.lua
@@ -1,0 +1,136 @@
+local AsyncTask = require('cmp.kit.Async.AsyncTask')
+
+local Async = {}
+
+---@type string<thread, integer>
+Async.___threads___ = {}
+
+---Run async function immediately.
+---@generic T: fun(...): cmp.kit.Async.AsyncTask
+---@param runner T
+---@param ... any
+---@return cmp.kit.Async.AsyncTask
+function Async.run(runner, ...)
+  return Async.async(runner)(...)
+end
+
+---Create async function.
+---@generic T: fun(...): cmp.kit.Async.AsyncTask
+---@param runner T
+---@return T
+function Async.async(runner)
+  return function(...)
+    local args = { ... }
+
+    local running = (coroutine.running())
+    if Async.___threads___[running] then
+      Async.___threads___[running] = Async.___threads___[running] + 1
+      if Async.___threads___[running] <= 1024 then
+        return AsyncTask.new(function(resolve, reject)
+          local v = runner(unpack(args))
+          if AsyncTask.is(v) then
+            v:dispatch(resolve, reject)
+          else
+            resolve(v)
+          end
+        end)
+      end
+    end
+
+    local thread = coroutine.create(runner)
+    return AsyncTask.new(function(resolve, reject)
+      Async.___threads___[thread] = 1
+
+      local function next_step(ok, v)
+        if coroutine.status(thread) == 'dead' then
+          Async.___threads___[thread] = nil
+          if AsyncTask.is(v) then
+            v:dispatch(resolve, reject)
+          else
+            if ok then
+              resolve(v)
+            else
+              reject(v)
+            end
+          end
+          return
+        end
+
+        v:dispatch(function(...)
+          next_step(coroutine.resume(thread, true, ...))
+        end, function(...)
+          next_step(coroutine.resume(thread, false, ...))
+        end)
+      end
+
+      next_step(coroutine.resume(thread, unpack(args)))
+    end)
+  end
+end
+
+---Await async task.
+---@param task cmp.kit.Async.AsyncTask
+---@return any
+function Async.await(task)
+  if not Async.___threads___[coroutine.running()] then
+    error('`Async.await` must be called in async context.')
+  end
+  if not AsyncTask.is(task) then
+    error('`Async.await` must be called with AsyncTask.')
+  end
+
+  local ok, res = coroutine.yield(task)
+  if not ok then
+    error(res, 2)
+  end
+  return res
+end
+
+---Create vim.schedule task.
+---@return cmp.kit.Async.AsyncTask
+function Async.schedule()
+  return AsyncTask.new(function(resolve)
+    vim.schedule(resolve)
+  end)
+end
+
+---Create vim.defer_fn task.
+---@param timeout integer
+---@return cmp.kit.Async.AsyncTask
+function Async.timeout(timeout)
+  return AsyncTask.new(function(resolve)
+    vim.defer_fn(resolve, timeout)
+  end)
+end
+
+---Create async function from callback function.
+---@generic T: ...
+---@param runner fun(...: T)
+---@param option? { schedule?: boolean, callback?: integer }
+---@return fun(...: T): cmp.kit.Async.AsyncTask
+function Async.promisify(runner, option)
+  option = option or {}
+  option.schedule = not vim.is_thread() and (option.schedule or false)
+  option.callback = option.callback or nil
+  return function(...)
+    local args = { ... }
+    return AsyncTask.new(function(resolve, reject)
+      local max = #args + 1
+      local pos = math.min(option.callback or max, max)
+      table.insert(args, pos, function(err, ...)
+        if option.schedule and vim.in_fast_event() then
+          resolve = vim.schedule_wrap(resolve)
+          reject = vim.schedule_wrap(reject)
+        end
+        if err then
+          reject(err)
+        else
+          resolve(...)
+        end
+      end)
+      runner(unpack(args))
+    end)
+  end
+end
+
+return Async

--- a/lua/cmp/kit/IO/init.lua
+++ b/lua/cmp/kit/IO/init.lua
@@ -1,0 +1,448 @@
+local uv = require('luv')
+local Async = require('cmp.kit.Async')
+
+local is_windows = uv.os_uname().sysname:lower() == 'windows'
+
+---@see https://github.com/luvit/luvit/blob/master/deps/fs.lua
+local IO = {}
+
+---@class cmp.kit.IO.UV.Stat
+---@field public dev integer
+---@field public mode integer
+---@field public nlink integer
+---@field public uid integer
+---@field public gid integer
+---@field public rdev integer
+---@field public ino integer
+---@field public size integer
+---@field public blksize integer
+---@field public blocks integer
+---@field public flags integer
+---@field public gen integer
+---@field public atime { sec: integer, nsec: integer }
+---@field public mtime { sec: integer, nsec: integer }
+---@field public ctime { sec: integer, nsec: integer }
+---@field public birthtime { sec: integer, nsec: integer }
+---@field public type string
+
+---@enum cmp.kit.IO.UV.AccessMode
+IO.AccessMode = {
+  r = 'r',
+  rs = 'rs',
+  sr = 'sr',
+  ['r+'] = 'r+',
+  ['rs+'] = 'rs+',
+  ['sr+'] = 'sr+',
+  w = 'w',
+  wx = 'wx',
+  xw = 'xw',
+  ['w+'] = 'w+',
+  ['wx+'] = 'wx+',
+  ['xw+'] = 'xw+',
+  a = 'a',
+  ax = 'ax',
+  xa = 'xa',
+  ['a+'] = 'a+',
+  ['ax+'] = 'ax+',
+  ['xa+'] = 'xa+',
+}
+
+---@enum cmp.kit.IO.WalkStatus
+IO.WalkStatus = {
+  SkipDir = 1,
+  Break = 2,
+}
+
+---@type fun(path: string): cmp.kit.Async.AsyncTask
+IO.fs_stat = Async.promisify(uv.fs_stat)
+
+---@type fun(path: string): cmp.kit.Async.AsyncTask
+IO.fs_unlink = Async.promisify(uv.fs_unlink)
+
+---@type fun(path: string): cmp.kit.Async.AsyncTask
+IO.fs_rmdir = Async.promisify(uv.fs_rmdir)
+
+---@type fun(path: string, mode: integer): cmp.kit.Async.AsyncTask
+IO.fs_mkdir = Async.promisify(uv.fs_mkdir)
+
+---@type fun(from: string, to: string, option?: { excl?: boolean, ficlone?: boolean, ficlone_force?: boolean }): cmp.kit.Async.AsyncTask
+IO.fs_copyfile = Async.promisify(uv.fs_copyfile)
+
+---@type fun(path: string, flags: cmp.kit.IO.UV.AccessMode, mode: integer): cmp.kit.Async.AsyncTask
+IO.fs_open = Async.promisify(uv.fs_open)
+
+---@type fun(fd: userdata): cmp.kit.Async.AsyncTask
+IO.fs_close = Async.promisify(uv.fs_close)
+
+---@type fun(fd: userdata, chunk_size: integer, offset?: integer): cmp.kit.Async.AsyncTask
+IO.fs_read = Async.promisify(uv.fs_read)
+
+---@type fun(fd: userdata, content: string, offset?: integer): cmp.kit.Async.AsyncTask
+IO.fs_write = Async.promisify(uv.fs_write)
+
+---@type fun(fd: userdata, offset: integer): cmp.kit.Async.AsyncTask
+IO.fs_ftruncate = Async.promisify(uv.fs_ftruncate)
+
+---@type fun(path: string, chunk_size?: integer): cmp.kit.Async.AsyncTask
+IO.fs_opendir = Async.promisify(uv.fs_opendir, { callback = 2 })
+
+---@type fun(fd: userdata): cmp.kit.Async.AsyncTask
+IO.fs_closedir = Async.promisify(uv.fs_closedir)
+
+---@type fun(fd: userdata): cmp.kit.Async.AsyncTask
+IO.fs_readdir = Async.promisify(uv.fs_readdir)
+
+---@type fun(path: string): cmp.kit.Async.AsyncTask
+IO.fs_scandir = Async.promisify(uv.fs_scandir)
+
+---@type fun(path: string): cmp.kit.Async.AsyncTask
+IO.fs_realpath = Async.promisify(uv.fs_realpath)
+
+---Return if the path is directory.
+---@param path string
+---@return cmp.kit.Async.AsyncTask
+function IO.is_directory(path)
+  path = IO.normalize(path)
+  return Async.run(function()
+    return IO.fs_stat(path):catch(function()
+      return {}
+    end):await().type == 'directory'
+  end)
+end
+
+---Read file.
+---@param path string
+---@param chunk_size? integer
+---@return cmp.kit.Async.AsyncTask
+function IO.read_file(path, chunk_size)
+  chunk_size = chunk_size or 1024
+  return Async.run(function()
+    local stat = IO.fs_stat(path):await()
+    local fd = IO.fs_open(path, IO.AccessMode.r, tonumber('755', 8)):await()
+    local ok, res = pcall(function()
+      local chunks = {}
+      local offset = 0
+      while offset < stat.size do
+        local chunk = IO.fs_read(fd, math.min(chunk_size, stat.size - offset), offset):await()
+        if not chunk then
+          break
+        end
+        table.insert(chunks, chunk)
+        offset = offset + #chunk
+      end
+      return table.concat(chunks, ''):sub(1, stat.size - 1) -- remove EOF.
+    end)
+    IO.fs_close(fd):await()
+    if not ok then
+      error(res)
+    end
+    return res
+  end)
+end
+
+---Write file.
+---@param path string
+---@param content string
+---@param chunk_size? integer
+function IO.write_file(path, content, chunk_size)
+  chunk_size = chunk_size or 1024
+  content = content .. '\n' -- add EOF.
+  return Async.run(function()
+    local fd = IO.fs_open(path, IO.AccessMode.w, tonumber('755', 8)):await()
+    local ok, err = pcall(function()
+      local offset = 0
+      while offset < #content do
+        local chunk = content:sub(offset + 1, offset + chunk_size)
+        offset = offset + IO.fs_write(fd, chunk, offset):await()
+      end
+      IO.fs_ftruncate(fd, offset):await()
+    end)
+    IO.fs_close(fd):await()
+    if not ok then
+      error(err)
+    end
+  end)
+end
+
+---Create directory.
+---@param path string
+---@param mode integer
+---@param option? { recursive?: boolean }
+function IO.mkdir(path, mode, option)
+  path = IO.normalize(path)
+  option = option or {}
+  option.recursive = option.recursive or false
+  return Async.run(function()
+    if not option.recursive then
+      IO.fs_mkdir(path, mode):await()
+    else
+      local not_exists = {}
+      local current = path
+      while current ~= '/' do
+        local stat = IO.fs_stat(current):catch(function() end):await()
+        if stat then
+          break
+        end
+        table.insert(not_exists, 1, current)
+        current = IO.dirname(current)
+      end
+      for _, dir in ipairs(not_exists) do
+        IO.fs_mkdir(dir, mode):await()
+      end
+    end
+  end)
+end
+
+---Remove file or directory.
+---@param start_path string
+---@param option? { recursive?: boolean }
+function IO.rm(start_path, option)
+  start_path = IO.normalize(start_path)
+  option = option or {}
+  option.recursive = option.recursive or false
+  return Async.run(function()
+    local stat = IO.fs_stat(start_path):await()
+    if stat.type == 'directory' then
+      local children = IO.scandir(start_path):await()
+      if not option.recursive and #children > 0 then
+        error(('IO.rm: `%s` is a directory and not empty.'):format(start_path))
+      end
+      IO.walk(start_path, function(err, entry)
+        if err then
+          error('IO.rm: ' .. tostring(err))
+        end
+        if entry.type == 'directory' then
+          IO.fs_rmdir(entry.path):await()
+        else
+          IO.fs_unlink(entry.path):await()
+        end
+      end, { postorder = true }):await()
+    else
+      IO.fs_unlink(start_path):await()
+    end
+  end)
+end
+
+---Copy file or directory.
+---@param from any
+---@param to any
+---@param option? { recursive?: boolean }
+---@return cmp.kit.Async.AsyncTask
+function IO.cp(from, to, option)
+  from = IO.normalize(from)
+  to = IO.normalize(to)
+  option = option or {}
+  option.recursive = option.recursive or false
+  return Async.run(function()
+    local stat = IO.fs_stat(from):await()
+    if stat.type == 'directory' then
+      if not option.recursive then
+        error(('IO.cp: `%s` is a directory.'):format(from))
+      end
+      IO.walk(from, function(err, entry)
+        if err then
+          error('IO.cp: ' .. tostring(err))
+        end
+        local new_path = entry.path:gsub(vim.pesc(from), to)
+        if entry.type == 'directory' then
+          IO.mkdir(new_path, tonumber(stat.mode, 10), { recursive = true }):await()
+        else
+          IO.fs_copyfile(entry.path, new_path):await()
+        end
+      end):await()
+    else
+      IO.fs_copyfile(from, to):await()
+    end
+  end)
+end
+
+---Walk directory entries recursively.
+---@param start_path string
+---@param callback fun(err: string|nil, entry: { path: string, type: string }): cmp.kit.IO.WalkStatus?
+---@param option? { postorder?: boolean }
+function IO.walk(start_path, callback, option)
+  start_path = IO.normalize(start_path)
+  option = option or {}
+  option.postorder = option.postorder or false
+  return Async.run(function()
+    local function walk_pre(dir)
+      local ok, iter_entries = pcall(function()
+        return IO.iter_scandir(dir.path):await()
+      end)
+      if not ok then
+        return callback(iter_entries, dir)
+      end
+      local status = callback(nil, dir)
+      if status == IO.WalkStatus.SkipDir then
+        return
+      elseif status == IO.WalkStatus.Break then
+        return status
+      end
+      for entry in iter_entries do
+        if entry.type == 'directory' then
+          if walk_pre(entry) == IO.WalkStatus.Break then
+            return IO.WalkStatus.Break
+          end
+        else
+          if callback(nil, entry) == IO.WalkStatus.Break then
+            return IO.WalkStatus.Break
+          end
+        end
+      end
+    end
+
+    local function walk_post(dir)
+      local ok, iter_entries = pcall(function()
+        return IO.iter_scandir(dir.path):await()
+      end)
+      if not ok then
+        return callback(iter_entries, dir)
+      end
+      for entry in iter_entries do
+        if entry.type == 'directory' then
+          if walk_post(entry) == IO.WalkStatus.Break then
+            return IO.WalkStatus.Break
+          end
+        else
+          if callback(nil, entry) == IO.WalkStatus.Break then
+            return IO.WalkStatus.Break
+          end
+        end
+      end
+      return callback(nil, dir)
+    end
+
+    if not IO.is_directory(start_path) then
+      error(('IO.walk: `%s` is not a directory.'):format(start_path))
+    end
+    if option.postorder then
+      walk_post({ path = start_path, type = 'directory' })
+    else
+      walk_pre({ path = start_path, type = 'directory' })
+    end
+  end)
+end
+
+---Scan directory entries.
+---@param path string
+---@return cmp.kit.Async.AsyncTask
+function IO.scandir(path)
+  path = IO.normalize(path)
+  return Async.run(function()
+    local fd = IO.fs_scandir(path):await()
+    local entries = {}
+    while true do
+      local name, type = uv.fs_scandir_next(fd)
+      if not name then
+        break
+      end
+      table.insert(entries, {
+        type = type,
+        path = IO.join(path, name),
+      })
+    end
+    return entries
+  end)
+end
+
+---Scan directory entries.
+---@param path any
+---@return cmp.kit.Async.AsyncTask
+function IO.iter_scandir(path)
+  path = IO.normalize(path)
+  return Async.run(function()
+    local fd = IO.fs_scandir(path):await()
+    return function()
+      local name, type = uv.fs_scandir_next(fd)
+      if name then
+        return {
+          type = type,
+          path = IO.join(path, name),
+        }
+      end
+    end
+  end)
+end
+
+---Return normalized path.
+---@param path string
+---@return string
+function IO.normalize(path)
+  if is_windows then
+    path = path:gsub('\\', '/')
+  end
+
+  -- remove trailing slash.
+  if path:sub(-1) == '/' then
+    path = path:sub(1, -2)
+  end
+
+  -- skip if the path already absolute.
+  if IO.is_absolute(path) then
+    return path
+  end
+
+  -- homedir.
+  if path:sub(1, 1) == '~' then
+    path = IO.join(uv.os_homedir(), path:sub(2))
+  end
+
+  -- absolute.
+  if path:sub(1, 1) == '/' then
+    return path:sub(-1) == '/' and path:sub(1, -2) or path
+  end
+
+  -- resolve relative path.
+  local up = uv.cwd()
+  up = up:sub(-1) == '/' and up:sub(1, -2) or up
+  while true do
+    if path:sub(1, 3) == '../' then
+      path = path:sub(4)
+      up = IO.dirname(up)
+    elseif path:sub(1, 2) == './' then
+      path = path:sub(3)
+    else
+      break
+    end
+  end
+  return IO.join(up, path)
+end
+
+---Join the paths.
+---@param base string
+---@param path string
+---@return string
+function IO.join(base, path)
+  if base:sub(-1) == '/' then
+    base = base:sub(1, -2)
+  end
+  return base .. '/' .. path
+end
+
+---Return the path of the current working directory.
+---@param path string
+---@return string
+function IO.dirname(path)
+  if path:sub(-1) == '/' then
+    path = path:sub(1, -2)
+  end
+  return (path:gsub('/[^/]+$', ''))
+end
+
+if is_windows then
+  ---Return the path is absolute or not.
+  ---@param path string
+  ---@return boolean
+  function IO.is_absolute(path)
+    return path:sub(1, 1) == '/' or path:match('^%a://')
+  end
+else
+  ---Return the path is absolute or not.
+  ---@param path string
+  ---@return boolean
+  function IO.is_absolute(path)
+    return path:sub(1, 1) == '/'
+  end
+end
+
+return IO

--- a/lua/cmp/kit/LSP/Client.lua
+++ b/lua/cmp/kit/LSP/Client.lua
@@ -1,0 +1,1300 @@
+local LSP = require('cmp.kit.LSP')
+local AsyncTask = require('cmp.kit.Async.AsyncTask')
+
+---@class cmp.kit.LSP.Client
+---@field public client table
+local Client = {}
+Client.__index = Client
+
+---Create LSP Client wrapper.
+---@param client table
+---@return cmp.kit.LSP.Client
+function Client.new(client)
+  local self = setmetatable({}, Client)
+  self.client = client
+  return self
+end
+
+---@param params cmp.kit.LSP.ImplementationParams
+function Client:textDocument_implementation(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/implementation', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.TypeDefinitionParams
+function Client:textDocument_typeDefinition(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/typeDefinition', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params nil
+function Client:workspace_workspaceFolders(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/workspaceFolders', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@class cmp.kit.LSP.IntersectionType01 : cmp.kit.LSP.ConfigurationParams, cmp.kit.LSP.PartialResultParams
+
+---@param params cmp.kit.LSP.IntersectionType01
+function Client:workspace_configuration(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/configuration', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DocumentColorParams
+function Client:textDocument_documentColor(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/documentColor', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.ColorPresentationParams
+function Client:textDocument_colorPresentation(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/colorPresentation', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.FoldingRangeParams
+function Client:textDocument_foldingRange(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/foldingRange', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DeclarationParams
+function Client:textDocument_declaration(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/declaration', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.SelectionRangeParams
+function Client:textDocument_selectionRange(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/selectionRange', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.WorkDoneProgressCreateParams
+function Client:window_workDoneProgress_create(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('window/workDoneProgress/create', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CallHierarchyPrepareParams
+function Client:textDocument_prepareCallHierarchy(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/prepareCallHierarchy', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CallHierarchyIncomingCallsParams
+function Client:callHierarchy_incomingCalls(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('callHierarchy/incomingCalls', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CallHierarchyOutgoingCallsParams
+function Client:callHierarchy_outgoingCalls(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('callHierarchy/outgoingCalls', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.SemanticTokensParams
+function Client:textDocument_semanticTokens_full(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/semanticTokens/full', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.SemanticTokensDeltaParams
+function Client:textDocument_semanticTokens_full_delta(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/semanticTokens/full/delta', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.SemanticTokensRangeParams
+function Client:textDocument_semanticTokens_range(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/semanticTokens/range', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params nil
+function Client:workspace_semanticTokens_refresh(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/semanticTokens/refresh', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.ShowDocumentParams
+function Client:window_showDocument(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('window/showDocument', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.LinkedEditingRangeParams
+function Client:textDocument_linkedEditingRange(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/linkedEditingRange', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CreateFilesParams
+function Client:workspace_willCreateFiles(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/willCreateFiles', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.RenameFilesParams
+function Client:workspace_willRenameFiles(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/willRenameFiles', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DeleteFilesParams
+function Client:workspace_willDeleteFiles(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/willDeleteFiles', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.MonikerParams
+function Client:textDocument_moniker(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/moniker', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.TypeHierarchyPrepareParams
+function Client:textDocument_prepareTypeHierarchy(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/prepareTypeHierarchy', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.TypeHierarchySupertypesParams
+function Client:typeHierarchy_supertypes(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('typeHierarchy/supertypes', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.TypeHierarchySubtypesParams
+function Client:typeHierarchy_subtypes(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('typeHierarchy/subtypes', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.InlineValueParams
+function Client:textDocument_inlineValue(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/inlineValue', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params nil
+function Client:workspace_inlineValue_refresh(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/inlineValue/refresh', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.InlayHintParams
+function Client:textDocument_inlayHint(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/inlayHint', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.InlayHint
+function Client:inlayHint_resolve(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('inlayHint/resolve', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params nil
+function Client:workspace_inlayHint_refresh(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/inlayHint/refresh', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DocumentDiagnosticParams
+function Client:textDocument_diagnostic(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/diagnostic', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.WorkspaceDiagnosticParams
+function Client:workspace_diagnostic(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/diagnostic', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params nil
+function Client:workspace_diagnostic_refresh(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/diagnostic/refresh', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.RegistrationParams
+function Client:client_registerCapability(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('client/registerCapability', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.UnregistrationParams
+function Client:client_unregisterCapability(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('client/unregisterCapability', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.InitializeParams
+function Client:initialize(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('initialize', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params nil
+function Client:shutdown(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('shutdown', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.ShowMessageRequestParams
+function Client:window_showMessageRequest(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('window/showMessageRequest', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.WillSaveTextDocumentParams
+function Client:textDocument_willSaveWaitUntil(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/willSaveWaitUntil', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CompletionParams
+function Client:textDocument_completion(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/completion', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CompletionItem
+function Client:completionItem_resolve(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('completionItem/resolve', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.HoverParams
+function Client:textDocument_hover(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/hover', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.SignatureHelpParams
+function Client:textDocument_signatureHelp(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/signatureHelp', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DefinitionParams
+function Client:textDocument_definition(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/definition', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.ReferenceParams
+function Client:textDocument_references(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/references', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DocumentHighlightParams
+function Client:textDocument_documentHighlight(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/documentHighlight', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DocumentSymbolParams
+function Client:textDocument_documentSymbol(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/documentSymbol', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CodeActionParams
+function Client:textDocument_codeAction(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/codeAction', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CodeAction
+function Client:codeAction_resolve(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('codeAction/resolve', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.WorkspaceSymbolParams
+function Client:workspace_symbol(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/symbol', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.WorkspaceSymbol
+function Client:workspaceSymbol_resolve(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspaceSymbol/resolve', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CodeLensParams
+function Client:textDocument_codeLens(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/codeLens', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.CodeLens
+function Client:codeLens_resolve(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('codeLens/resolve', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params nil
+function Client:workspace_codeLens_refresh(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/codeLens/refresh', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DocumentLinkParams
+function Client:textDocument_documentLink(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/documentLink', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DocumentLink
+function Client:documentLink_resolve(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('documentLink/resolve', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DocumentFormattingParams
+function Client:textDocument_formatting(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/formatting', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DocumentRangeFormattingParams
+function Client:textDocument_rangeFormatting(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/rangeFormatting', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.DocumentOnTypeFormattingParams
+function Client:textDocument_onTypeFormatting(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/onTypeFormatting', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.RenameParams
+function Client:textDocument_rename(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/rename', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.PrepareRenameParams
+function Client:textDocument_prepareRename(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('textDocument/prepareRename', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.ExecuteCommandParams
+function Client:workspace_executeCommand(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/executeCommand', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params cmp.kit.LSP.ApplyWorkspaceEditParams
+function Client:workspace_applyEdit(params)
+  local that, request_id, reject_ = self, nil, nil
+  local task = AsyncTask.new(function(resolve, reject)
+    request_id = self.client.request('workspace/applyEdit', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+    reject_ = reject
+  end)
+  function task.cancel()
+    that.client.cancel_request(request_id)
+    reject_(LSP.ErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+return Client

--- a/lua/cmp/kit/LSP/Position.lua
+++ b/lua/cmp/kit/LSP/Position.lua
@@ -1,0 +1,103 @@
+local LSP = require('cmp.kit.LSP')
+
+local Position = {}
+
+---Return the value is position or not.
+---@param v any
+---@return boolean
+function Position.is(v)
+  local is = true
+  is = is and (type(v) == 'table' and type(v.line) == 'number' and type(v.character) == 'number')
+  return is
+end
+
+---Create a cursor position.
+---@param encoding? cmp.kit.LSP.PositionEncodingKind
+function Position.cursor(encoding)
+  local r, c = unpack(vim.api.nvim_win_get_cursor(0))
+  local utf8 = { line = r - 1, character = c }
+  if encoding == LSP.PositionEncodingKind.UTF8 then
+    return utf8
+  else
+    local text = vim.api.nvim_get_current_line()
+    if encoding == LSP.PositionEncodingKind.UTF32 then
+      return Position.to(text, utf8, LSP.PositionEncodingKind.UTF8, LSP.PositionEncodingKind.UTF32)
+    end
+    return Position.to(text, utf8, LSP.PositionEncodingKind.UTF8, LSP.PositionEncodingKind.UTF16)
+  end
+end
+
+---Convert position to specified encoding from specified encoding.
+---@param text string
+---@param position cmp.kit.LSP.Position
+---@param from_encoding cmp.kit.LSP.PositionEncodingKind
+---@param to_encoding cmp.kit.LSP.PositionEncodingKind
+function Position.to(text, position, from_encoding, to_encoding)
+  if to_encoding == LSP.PositionEncodingKind.UTF8 then
+    return Position.to_utf8(text, position, from_encoding)
+  elseif to_encoding == LSP.PositionEncodingKind.UTF16 then
+    return Position.to_utf16(text, position, from_encoding)
+  elseif to_encoding == LSP.PositionEncodingKind.UTF32 then
+    return Position.to_utf32(text, position, from_encoding)
+  end
+  error('LSP.Position: Unsupported encoding: ' .. to_encoding)
+end
+
+---Convert position to utf8 from specified encoding.
+---@param text string
+---@param position cmp.kit.LSP.Position
+---@param from_encoding? cmp.kit.LSP.PositionEncodingKind
+---@return cmp.kit.LSP.Position
+function Position.to_utf8(text, position, from_encoding)
+  from_encoding = from_encoding or LSP.PositionEncodingKind.UTF16
+  if from_encoding == LSP.PositionEncodingKind.UTF8 then
+    return position
+  end
+  local ok, byteindex = pcall(function()
+    return vim.str_byteindex(text, position.character, from_encoding == LSP.PositionEncodingKind.UTF16)
+  end)
+  if ok then
+    position = { line = position.line, character = byteindex }
+  end
+  return position
+end
+
+---Convert position to utf16 from specified encoding.
+---@param text string
+---@param position cmp.kit.LSP.Position
+---@param from_encoding? cmp.kit.LSP.PositionEncodingKind
+---@return cmp.kit.LSP.Position
+function Position.to_utf16(text, position, from_encoding)
+  local utf8 = Position.to_utf8(text, position, from_encoding)
+  for index = utf8.character, 0, -1 do
+    local ok, utf16index = pcall(function()
+      return select(2, vim.str_utfindex(text, index))
+    end)
+    if ok then
+      position = { line = utf8.line, character = utf16index }
+      break
+    end
+  end
+  return position
+end
+
+---Convert position to utf32 from specified encoding.
+---@param text string
+---@param position cmp.kit.LSP.Position
+---@param from_encoding? cmp.kit.LSP.PositionEncodingKind
+---@return cmp.kit.LSP.Position
+function Position.to_utf32(text, position, from_encoding)
+  local utf8 = Position.to_utf8(text, position, from_encoding)
+  for index = utf8.character, 0, -1 do
+    local ok, utf32index = pcall(function()
+      return select(1, vim.str_utfindex(text, index))
+    end)
+    if ok then
+      position = { line = utf8.line, character = utf32index }
+      break
+    end
+  end
+  return position
+end
+
+return Position

--- a/lua/cmp/kit/LSP/Range.lua
+++ b/lua/cmp/kit/LSP/Range.lua
@@ -1,0 +1,55 @@
+local Position = require('cmp.kit.LSP.Position')
+
+local Range = {}
+
+---Return the value is range or not.
+---@param v any
+---@return boolean
+function Range.is(v)
+  return type(v) == 'table' and Position.is(v.start) and Position.is(v['end'])
+end
+
+---Return the range is empty or not.
+---@param range cmp.kit.LSP.Range
+---@return boolean
+function Range.empty(range)
+  return range.start.line == range['end'].line and range.start.character == range['end'].character
+end
+
+---Convert range to utf8 from specified encoding.
+---@param text_start string
+---@param range cmp.kit.LSP.Range
+---@param from_encoding? cmp.kit.LSP.PositionEncodingKind
+---@return cmp.kit.LSP.Range
+function Range.to_utf8(text_start, text_end, range, from_encoding)
+  return {
+    start = Position.to_utf8(text_start, range.start, from_encoding),
+    ['end'] = Position.to_utf8(text_end, range['end'], from_encoding),
+  }
+end
+
+---Convert range to utf16 from specified encoding.
+---@param text_start string
+---@param range cmp.kit.LSP.Range
+---@param from_encoding? cmp.kit.LSP.PositionEncodingKind
+---@return cmp.kit.LSP.Range
+function Range.to_utf16(text_start, text_end, range, from_encoding)
+  return {
+    start = Position.to_utf16(text_start, range.start, from_encoding),
+    ['end'] = Position.to_utf16(text_end, range['end'], from_encoding),
+  }
+end
+
+---Convert range to utf32 from specified encoding.
+---@param text_start string
+---@param range cmp.kit.LSP.Range
+---@param from_encoding? cmp.kit.LSP.PositionEncodingKind
+---@return cmp.kit.LSP.Range
+function Range.to_utf32(text_start, text_end, range, from_encoding)
+  return {
+    start = Position.to_utf32(text_start, range.start, from_encoding),
+    ['end'] = Position.to_utf32(text_end, range['end'], from_encoding),
+  }
+end
+
+return Range

--- a/lua/cmp/kit/LSP/init.lua
+++ b/lua/cmp/kit/LSP/init.lua
@@ -1,0 +1,1911 @@
+local LSP = {}
+
+---@enum cmp.kit.LSP.SemanticTokenTypes
+LSP.SemanticTokenTypes = {
+  namespace = 'namespace',
+  type = 'type',
+  class = 'class',
+  enum = 'enum',
+  interface = 'interface',
+  struct = 'struct',
+  typeParameter = 'typeParameter',
+  parameter = 'parameter',
+  variable = 'variable',
+  property = 'property',
+  enumMember = 'enumMember',
+  event = 'event',
+  ['function'] = 'function',
+  method = 'method',
+  macro = 'macro',
+  keyword = 'keyword',
+  modifier = 'modifier',
+  comment = 'comment',
+  string = 'string',
+  number = 'number',
+  regexp = 'regexp',
+  operator = 'operator',
+  decorator = 'decorator',
+}
+
+---@enum cmp.kit.LSP.SemanticTokenModifiers
+LSP.SemanticTokenModifiers = {
+  declaration = 'declaration',
+  definition = 'definition',
+  readonly = 'readonly',
+  static = 'static',
+  deprecated = 'deprecated',
+  abstract = 'abstract',
+  async = 'async',
+  modification = 'modification',
+  documentation = 'documentation',
+  defaultLibrary = 'defaultLibrary',
+}
+
+---@enum cmp.kit.LSP.DocumentDiagnosticReportKind
+LSP.DocumentDiagnosticReportKind = {
+  Full = 'full',
+  Unchanged = 'unchanged',
+}
+
+---@enum cmp.kit.LSP.ErrorCodes
+LSP.ErrorCodes = {
+  ParseError = -32700,
+  InvalidRequest = -32600,
+  MethodNotFound = -32601,
+  InvalidParams = -32602,
+  InternalError = -32603,
+  ServerNotInitialized = -32002,
+  UnknownErrorCode = -32001,
+}
+
+---@enum cmp.kit.LSP.LSPErrorCodes
+LSP.LSPErrorCodes = {
+  RequestFailed = -32803,
+  ServerCancelled = -32802,
+  ContentModified = -32801,
+  RequestCancelled = -32800,
+}
+
+---@enum cmp.kit.LSP.FoldingRangeKind
+LSP.FoldingRangeKind = {
+  Comment = 'comment',
+  Imports = 'imports',
+  Region = 'region',
+}
+
+---@enum cmp.kit.LSP.SymbolKind
+LSP.SymbolKind = {
+  File = 1,
+  Module = 2,
+  Namespace = 3,
+  Package = 4,
+  Class = 5,
+  Method = 6,
+  Property = 7,
+  Field = 8,
+  Constructor = 9,
+  Enum = 10,
+  Interface = 11,
+  Function = 12,
+  Variable = 13,
+  Constant = 14,
+  String = 15,
+  Number = 16,
+  Boolean = 17,
+  Array = 18,
+  Object = 19,
+  Key = 20,
+  Null = 21,
+  EnumMember = 22,
+  Struct = 23,
+  Event = 24,
+  Operator = 25,
+  TypeParameter = 26,
+}
+
+---@enum cmp.kit.LSP.SymbolTag
+LSP.SymbolTag = {
+  Deprecated = 1,
+}
+
+---@enum cmp.kit.LSP.UniquenessLevel
+LSP.UniquenessLevel = {
+  document = 'document',
+  project = 'project',
+  group = 'group',
+  scheme = 'scheme',
+  global = 'global',
+}
+
+---@enum cmp.kit.LSP.MonikerKind
+LSP.MonikerKind = {
+  import = 'import',
+  export = 'export',
+  ['local'] = 'local',
+}
+
+---@enum cmp.kit.LSP.InlayHintKind
+LSP.InlayHintKind = {
+  Type = 1,
+  Parameter = 2,
+}
+
+---@enum cmp.kit.LSP.MessageType
+LSP.MessageType = {
+  Error = 1,
+  Warning = 2,
+  Info = 3,
+  Log = 4,
+}
+
+---@enum cmp.kit.LSP.TextDocumentSyncKind
+LSP.TextDocumentSyncKind = {
+  None = 0,
+  Full = 1,
+  Incremental = 2,
+}
+
+---@enum cmp.kit.LSP.TextDocumentSaveReason
+LSP.TextDocumentSaveReason = {
+  Manual = 1,
+  AfterDelay = 2,
+  FocusOut = 3,
+}
+
+---@enum cmp.kit.LSP.CompletionItemKind
+LSP.CompletionItemKind = {
+  Text = 1,
+  Method = 2,
+  Function = 3,
+  Constructor = 4,
+  Field = 5,
+  Variable = 6,
+  Class = 7,
+  Interface = 8,
+  Module = 9,
+  Property = 10,
+  Unit = 11,
+  Value = 12,
+  Enum = 13,
+  Keyword = 14,
+  Snippet = 15,
+  Color = 16,
+  File = 17,
+  Reference = 18,
+  Folder = 19,
+  EnumMember = 20,
+  Constant = 21,
+  Struct = 22,
+  Event = 23,
+  Operator = 24,
+  TypeParameter = 25,
+}
+
+---@enum cmp.kit.LSP.CompletionItemTag
+LSP.CompletionItemTag = {
+  Deprecated = 1,
+}
+
+---@enum cmp.kit.LSP.InsertTextFormat
+LSP.InsertTextFormat = {
+  PlainText = 1,
+  Snippet = 2,
+}
+
+---@enum cmp.kit.LSP.InsertTextMode
+LSP.InsertTextMode = {
+  asIs = 1,
+  adjustIndentation = 2,
+}
+
+---@enum cmp.kit.LSP.DocumentHighlightKind
+LSP.DocumentHighlightKind = {
+  Text = 1,
+  Read = 2,
+  Write = 3,
+}
+
+---@enum cmp.kit.LSP.CodeActionKind
+LSP.CodeActionKind = {
+  Empty = '',
+  QuickFix = 'quickfix',
+  Refactor = 'refactor',
+  RefactorExtract = 'refactor.extract',
+  RefactorInline = 'refactor.inline',
+  RefactorRewrite = 'refactor.rewrite',
+  Source = 'source',
+  SourceOrganizeImports = 'source.organizeImports',
+  SourceFixAll = 'source.fixAll',
+}
+
+---@enum cmp.kit.LSP.TraceValues
+LSP.TraceValues = {
+  Off = 'off',
+  Messages = 'messages',
+  Verbose = 'verbose',
+}
+
+---@enum cmp.kit.LSP.MarkupKind
+LSP.MarkupKind = {
+  PlainText = 'plaintext',
+  Markdown = 'markdown',
+}
+
+---@enum cmp.kit.LSP.PositionEncodingKind
+LSP.PositionEncodingKind = {
+  UTF8 = 'utf-8',
+  UTF16 = 'utf-16',
+  UTF32 = 'utf-32',
+}
+
+---@enum cmp.kit.LSP.FileChangeType
+LSP.FileChangeType = {
+  Created = 1,
+  Changed = 2,
+  Deleted = 3,
+}
+
+---@enum cmp.kit.LSP.WatchKind
+LSP.WatchKind = {
+  Create = 1,
+  Change = 2,
+  Delete = 4,
+}
+
+---@enum cmp.kit.LSP.DiagnosticSeverity
+LSP.DiagnosticSeverity = {
+  Error = 1,
+  Warning = 2,
+  Information = 3,
+  Hint = 4,
+}
+
+---@enum cmp.kit.LSP.DiagnosticTag
+LSP.DiagnosticTag = {
+  Unnecessary = 1,
+  Deprecated = 2,
+}
+
+---@enum cmp.kit.LSP.CompletionTriggerKind
+LSP.CompletionTriggerKind = {
+  Invoked = 1,
+  TriggerCharacter = 2,
+  TriggerForIncompleteCompletions = 3,
+}
+
+---@enum cmp.kit.LSP.SignatureHelpTriggerKind
+LSP.SignatureHelpTriggerKind = {
+  Invoked = 1,
+  TriggerCharacter = 2,
+  ContentChange = 3,
+}
+
+---@enum cmp.kit.LSP.CodeActionTriggerKind
+LSP.CodeActionTriggerKind = {
+  Invoked = 1,
+  Automatic = 2,
+}
+
+---@enum cmp.kit.LSP.FileOperationPatternKind
+LSP.FileOperationPatternKind = {
+  file = 'file',
+  folder = 'folder',
+}
+
+---@enum cmp.kit.LSP.NotebookCellKind
+LSP.NotebookCellKind = {
+  Markup = 1,
+  Code = 2,
+}
+
+---@enum cmp.kit.LSP.ResourceOperationKind
+LSP.ResourceOperationKind = {
+  Create = 'create',
+  Rename = 'rename',
+  Delete = 'delete',
+}
+
+---@enum cmp.kit.LSP.FailureHandlingKind
+LSP.FailureHandlingKind = {
+  Abort = 'abort',
+  Transactional = 'transactional',
+  TextOnlyTransactional = 'textOnlyTransactional',
+  Undo = 'undo',
+}
+
+---@enum cmp.kit.LSP.PrepareSupportDefaultBehavior
+LSP.PrepareSupportDefaultBehavior = {
+  Identifier = 1,
+}
+
+---@enum cmp.kit.LSP.TokenFormat
+LSP.TokenFormat = {
+  Relative = 'relative',
+}
+
+---@class cmp.kit.LSP.ImplementationParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+
+---@class cmp.kit.LSP.Location
+---@field public uri string
+---@field public range cmp.kit.LSP.Range
+
+---@class cmp.kit.LSP.ImplementationRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.ImplementationOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.TypeDefinitionParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+
+---@class cmp.kit.LSP.TypeDefinitionRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.TypeDefinitionOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.WorkspaceFolder
+---@field public uri string The associated URI for this workspace folder.
+---@field public name string The name of the workspace folder. Used to refer to this<br>workspace folder in the user interface.
+
+---@class cmp.kit.LSP.DidChangeWorkspaceFoldersParams
+---@field public event cmp.kit.LSP.WorkspaceFoldersChangeEvent The actual workspace folder change event.
+
+---@class cmp.kit.LSP.ConfigurationParams
+---@field public items cmp.kit.LSP.ConfigurationItem[]
+
+---@class cmp.kit.LSP.PartialResultParams
+---@field public partialResultToken? cmp.kit.LSP.ProgressToken An optional token that a server can use to report partial results (e.g. streaming) to<br>the client.
+
+---@class cmp.kit.LSP.DocumentColorParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+
+---@class cmp.kit.LSP.ColorInformation
+---@field public range cmp.kit.LSP.Range The range in the document where this color appears.
+---@field public color cmp.kit.LSP.Color The actual color value for this color range.
+
+---@class cmp.kit.LSP.DocumentColorRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.DocumentColorOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.ColorPresentationParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+---@field public color cmp.kit.LSP.Color The color to request presentations for.
+---@field public range cmp.kit.LSP.Range The range where the color would be inserted. Serves as a context.
+
+---@class cmp.kit.LSP.ColorPresentation
+---@field public label string The label of this color presentation. It will be shown on the color<br>picker header. By default this is also the text that is inserted when selecting<br>this color presentation.
+---@field public textEdit? cmp.kit.LSP.TextEdit An [edit](#TextEdit) which is applied to a document when selecting<br>this presentation for the color.  When `falsy` the [label](#ColorPresentation.label)<br>is used.
+---@field public additionalTextEdits? cmp.kit.LSP.TextEdit[] An optional array of additional [text edits](#TextEdit) that are applied when<br>selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves.
+
+---@class cmp.kit.LSP.WorkDoneProgressOptions
+---@field public workDoneProgress? boolean
+
+---@class cmp.kit.LSP.TextDocumentRegistrationOptions
+---@field public documentSelector (cmp.kit.LSP.DocumentSelector | nil) A document selector to identify the scope of the registration. If set to null<br>the document selector provided on the client side will be used.
+
+---@class cmp.kit.LSP.FoldingRangeParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+
+---@class cmp.kit.LSP.FoldingRange
+---@field public startLine integer The zero-based start line of the range to fold. The folded area starts after the line's last character.<br>To be valid, the end must be zero or larger and smaller than the number of lines in the document.
+---@field public startCharacter? integer The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
+---@field public endLine integer The zero-based end line of the range to fold. The folded area ends with the line's last character.<br>To be valid, the end must be zero or larger and smaller than the number of lines in the document.
+---@field public endCharacter? integer The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
+---@field public kind? cmp.kit.LSP.FoldingRangeKind Describes the kind of the folding range such as `comment' or 'region'. The kind<br>is used to categorize folding ranges and used by commands like 'Fold all comments'.<br>See [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
+---@field public collapsedText? string The text that the client should show when the specified range is<br>collapsed. If not defined or not supported by the client, a default<br>will be chosen by the client.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.FoldingRangeRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.FoldingRangeOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.DeclarationParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+
+---@class cmp.kit.LSP.DeclarationRegistrationOptions : cmp.kit.LSP.DeclarationOptions, cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.SelectionRangeParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+---@field public positions cmp.kit.LSP.Position[] The positions inside the text document.
+
+---@class cmp.kit.LSP.SelectionRange
+---@field public range cmp.kit.LSP.Range The [range](#Range) of this selection range.
+---@field public parent? cmp.kit.LSP.SelectionRange The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
+
+---@class cmp.kit.LSP.SelectionRangeRegistrationOptions : cmp.kit.LSP.SelectionRangeOptions, cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.WorkDoneProgressCreateParams
+---@field public token cmp.kit.LSP.ProgressToken The token to be used to report progress.
+
+---@class cmp.kit.LSP.WorkDoneProgressCancelParams
+---@field public token cmp.kit.LSP.ProgressToken The token to be used to report progress.
+
+---@class cmp.kit.LSP.CallHierarchyPrepareParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams
+
+---@class cmp.kit.LSP.CallHierarchyItem
+---@field public name string The name of this item.
+---@field public kind cmp.kit.LSP.SymbolKind The kind of this item.
+---@field public tags? cmp.kit.LSP.SymbolTag[] Tags for this item.
+---@field public detail? string More detail for this item, e.g. the signature of a function.
+---@field public uri string The resource identifier of this item.
+---@field public range cmp.kit.LSP.Range The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g. comments and code.
+---@field public selectionRange cmp.kit.LSP.Range The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.<br>Must be contained by the [`range`](#CallHierarchyItem.range).
+---@field public data? cmp.kit.LSP.LSPAny A data entry field that is preserved between a call hierarchy prepare and<br>incoming calls or outgoing calls requests.
+
+---@class cmp.kit.LSP.CallHierarchyRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.CallHierarchyOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.CallHierarchyIncomingCallsParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public item cmp.kit.LSP.CallHierarchyItem
+
+---@class cmp.kit.LSP.CallHierarchyIncomingCall
+---@field public from cmp.kit.LSP.CallHierarchyItem The item that makes the call.
+---@field public fromRanges cmp.kit.LSP.Range[] The ranges at which the calls appear. This is relative to the caller<br>denoted by [`this.from`](#CallHierarchyIncomingCall.from).
+
+---@class cmp.kit.LSP.CallHierarchyOutgoingCallsParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public item cmp.kit.LSP.CallHierarchyItem
+
+---@class cmp.kit.LSP.CallHierarchyOutgoingCall
+---@field public to cmp.kit.LSP.CallHierarchyItem The item that is called.
+---@field public fromRanges cmp.kit.LSP.Range[] The range at which this item is called. This is the range relative to the caller, e.g the item<br>passed to [`provideCallHierarchyOutgoingCalls`](#CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls)<br>and not [`this.to`](#CallHierarchyOutgoingCall.to).
+
+---@class cmp.kit.LSP.SemanticTokensParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+
+---@class cmp.kit.LSP.SemanticTokens
+---@field public resultId? string An optional result id. If provided and clients support delta updating<br>the client will include the result id in the next semantic token request.<br>A server can then instead of computing all semantic tokens again simply<br>send a delta.
+---@field public data integer[] The actual tokens.
+
+---@class cmp.kit.LSP.SemanticTokensPartialResult
+---@field public data integer[]
+
+---@class cmp.kit.LSP.SemanticTokensRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.SemanticTokensOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.SemanticTokensDeltaParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+---@field public previousResultId string The result id of a previous response. The result Id can either point to a full response<br>or a delta response depending on what was received last.
+
+---@class cmp.kit.LSP.SemanticTokensDelta
+---@field public resultId? string
+---@field public edits cmp.kit.LSP.SemanticTokensEdit[] The semantic token edits to transform a previous result into a new result.
+
+---@class cmp.kit.LSP.SemanticTokensDeltaPartialResult
+---@field public edits cmp.kit.LSP.SemanticTokensEdit[]
+
+---@class cmp.kit.LSP.SemanticTokensRangeParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+---@field public range cmp.kit.LSP.Range The range the semantic tokens are requested for.
+
+---@class cmp.kit.LSP.ShowDocumentParams
+---@field public uri string The document uri to show.
+---@field public external? boolean Indicates to show the resource in an external program.<br>To show for example `https://code.visualstudio.com/`<br>in the default WEB browser set `external` to `true`.
+---@field public takeFocus? boolean An optional property to indicate whether the editor<br>showing the document should take focus or not.<br>Clients might ignore this property if an external<br>program is started.
+---@field public selection? cmp.kit.LSP.Range An optional selection range if the document is a text<br>document. Clients might ignore the property if an<br>external program is started or the file is not a text<br>file.
+
+---@class cmp.kit.LSP.ShowDocumentResult
+---@field public success boolean A boolean indicating if the show was successful.
+
+---@class cmp.kit.LSP.LinkedEditingRangeParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams
+
+---@class cmp.kit.LSP.LinkedEditingRanges
+---@field public ranges cmp.kit.LSP.Range[] A list of ranges that can be edited together. The ranges must have<br>identical length and contain identical text content. The ranges cannot overlap.
+---@field public wordPattern? string An optional word pattern (regular expression) that describes valid contents for<br>the given ranges. If no pattern is provided, the client configuration's word<br>pattern will be used.
+
+---@class cmp.kit.LSP.LinkedEditingRangeRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.LinkedEditingRangeOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.CreateFilesParams
+---@field public files cmp.kit.LSP.FileCreate[] An array of all files/folders created in this operation.
+
+---@class cmp.kit.LSP.WorkspaceEdit
+---@field public changes? table<string, cmp.kit.LSP.TextEdit[]> Holds changes to existing resources.
+---@field public documentChanges? (cmp.kit.LSP.TextDocumentEdit | cmp.kit.LSP.CreateFile | cmp.kit.LSP.RenameFile | cmp.kit.LSP.DeleteFile)[] Depending on the client capability `workspace.workspaceEdit.resourceOperations` document changes<br>are either an array of `TextDocumentEdit`s to express changes to n different text documents<br>where each text document edit addresses a specific version of a text document. Or it can contain<br>above `TextDocumentEdit`s mixed with create, rename and delete file / folder operations.<br><br>Whether a client supports versioned document edits is expressed via<br>`workspace.workspaceEdit.documentChanges` client capability.<br><br>If a client neither supports `documentChanges` nor `workspace.workspaceEdit.resourceOperations` then<br>only plain `TextEdit`s using the `changes` property are supported.
+---@field public changeAnnotations? table<cmp.kit.LSP.ChangeAnnotationIdentifier, cmp.kit.LSP.ChangeAnnotation> A map of change annotations that can be referenced in `AnnotatedTextEdit`s or create, rename and<br>delete file / folder operations.<br><br>Whether clients honor this property depends on the client capability `workspace.changeAnnotationSupport`.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.FileOperationRegistrationOptions
+---@field public filters cmp.kit.LSP.FileOperationFilter[] The actual filters.
+
+---@class cmp.kit.LSP.RenameFilesParams
+---@field public files cmp.kit.LSP.FileRename[] An array of all files/folders renamed in this operation. When a folder is renamed, only<br>the folder will be included, and not its children.
+
+---@class cmp.kit.LSP.DeleteFilesParams
+---@field public files cmp.kit.LSP.FileDelete[] An array of all files/folders deleted in this operation.
+
+---@class cmp.kit.LSP.MonikerParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+
+---@class cmp.kit.LSP.Moniker
+---@field public scheme string The scheme of the moniker. For example tsc or .Net
+---@field public identifier string The identifier of the moniker. The value is opaque in LSIF however<br>schema owners are allowed to define the structure if they want.
+---@field public unique cmp.kit.LSP.UniquenessLevel The scope in which the moniker is unique
+---@field public kind? cmp.kit.LSP.MonikerKind The moniker kind if known.
+
+---@class cmp.kit.LSP.MonikerRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.MonikerOptions
+
+---@class cmp.kit.LSP.TypeHierarchyPrepareParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams
+
+---@class cmp.kit.LSP.TypeHierarchyItem
+---@field public name string The name of this item.
+---@field public kind cmp.kit.LSP.SymbolKind The kind of this item.
+---@field public tags? cmp.kit.LSP.SymbolTag[] Tags for this item.
+---@field public detail? string More detail for this item, e.g. the signature of a function.
+---@field public uri string The resource identifier of this item.
+---@field public range cmp.kit.LSP.Range The range enclosing this symbol not including leading/trailing whitespace<br>but everything else, e.g. comments and code.
+---@field public selectionRange cmp.kit.LSP.Range The range that should be selected and revealed when this symbol is being<br>picked, e.g. the name of a function. Must be contained by the<br>[`range`](#TypeHierarchyItem.range).
+---@field public data? cmp.kit.LSP.LSPAny A data entry field that is preserved between a type hierarchy prepare and<br>supertypes or subtypes requests. It could also be used to identify the<br>type hierarchy in the server, helping improve the performance on<br>resolving supertypes and subtypes.
+
+---@class cmp.kit.LSP.TypeHierarchyRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.TypeHierarchyOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.TypeHierarchySupertypesParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public item cmp.kit.LSP.TypeHierarchyItem
+
+---@class cmp.kit.LSP.TypeHierarchySubtypesParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public item cmp.kit.LSP.TypeHierarchyItem
+
+---@class cmp.kit.LSP.InlineValueParams : cmp.kit.LSP.WorkDoneProgressParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+---@field public range cmp.kit.LSP.Range The document range for which inline values should be computed.
+---@field public context cmp.kit.LSP.InlineValueContext Additional information about the context in which inline values were<br>requested.
+
+---@class cmp.kit.LSP.InlineValueRegistrationOptions : cmp.kit.LSP.InlineValueOptions, cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.InlayHintParams : cmp.kit.LSP.WorkDoneProgressParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+---@field public range cmp.kit.LSP.Range The document range for which inlay hints should be computed.
+
+---@class cmp.kit.LSP.InlayHint
+---@field public position cmp.kit.LSP.Position The position of this hint.
+---@field public label (string | cmp.kit.LSP.InlayHintLabelPart[]) The label of this hint. A human readable string or an array of<br>InlayHintLabelPart label parts.<br><br>*Note* that neither the string nor the label part can be empty.
+---@field public kind? cmp.kit.LSP.InlayHintKind The kind of this hint. Can be omitted in which case the client<br>should fall back to a reasonable default.
+---@field public textEdits? cmp.kit.LSP.TextEdit[] Optional text edits that are performed when accepting this inlay hint.<br><br>*Note* that edits are expected to change the document so that the inlay<br>hint (or its nearest variant) is now part of the document and the inlay<br>hint itself is now obsolete.
+---@field public tooltip? (string | cmp.kit.LSP.MarkupContent) The tooltip text when you hover over this item.
+---@field public paddingLeft? boolean Render padding before the hint.<br><br>Note: Padding should use the editor's background color, not the<br>background color of the hint itself. That means padding can be used<br>to visually align/separate an inlay hint.
+---@field public paddingRight? boolean Render padding after the hint.<br><br>Note: Padding should use the editor's background color, not the<br>background color of the hint itself. That means padding can be used<br>to visually align/separate an inlay hint.
+---@field public data? cmp.kit.LSP.LSPAny A data entry field that is preserved on an inlay hint between<br>a `textDocument/inlayHint` and a `inlayHint/resolve` request.
+
+---@class cmp.kit.LSP.InlayHintRegistrationOptions : cmp.kit.LSP.InlayHintOptions, cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.DocumentDiagnosticParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+---@field public identifier? string The additional identifier  provided during registration.
+---@field public previousResultId? string The result id of a previous response if provided.
+
+---@class cmp.kit.LSP.DocumentDiagnosticReportPartialResult
+---@field public relatedDocuments table<string, (cmp.kit.LSP.FullDocumentDiagnosticReport | cmp.kit.LSP.UnchangedDocumentDiagnosticReport)>
+
+---@class cmp.kit.LSP.DiagnosticServerCancellationData
+---@field public retriggerRequest boolean
+
+---@class cmp.kit.LSP.DiagnosticRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.DiagnosticOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.WorkspaceDiagnosticParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public identifier? string The additional identifier provided during registration.
+---@field public previousResultIds cmp.kit.LSP.PreviousResultId[] The currently known diagnostic reports with their<br>previous result ids.
+
+---@class cmp.kit.LSP.WorkspaceDiagnosticReport
+---@field public items cmp.kit.LSP.WorkspaceDocumentDiagnosticReport[]
+
+---@class cmp.kit.LSP.WorkspaceDiagnosticReportPartialResult
+---@field public items cmp.kit.LSP.WorkspaceDocumentDiagnosticReport[]
+
+---@class cmp.kit.LSP.DidOpenNotebookDocumentParams
+---@field public notebookDocument cmp.kit.LSP.NotebookDocument The notebook document that got opened.
+---@field public cellTextDocuments cmp.kit.LSP.TextDocumentItem[] The text documents that represent the content<br>of a notebook cell.
+
+---@class cmp.kit.LSP.DidChangeNotebookDocumentParams
+---@field public notebookDocument cmp.kit.LSP.VersionedNotebookDocumentIdentifier The notebook document that did change. The version number points<br>to the version after all provided changes have been applied. If<br>only the text document content of a cell changes the notebook version<br>doesn't necessarily have to change.
+---@field public change cmp.kit.LSP.NotebookDocumentChangeEvent The actual changes to the notebook document.<br><br>The changes describe single state changes to the notebook document.<br>So if there are two changes c1 (at array index 0) and c2 (at array<br>index 1) for a notebook in state S then c1 moves the notebook from<br>S to S' and c2 from S' to S''. So c1 is computed on the state S and<br>c2 is computed on the state S'.<br><br>To mirror the content of a notebook using change events use the following approach:<br>- start with the same initial content<br>- apply the 'notebookDocument/didChange' notifications in the order you receive them.<br>- apply the `NotebookChangeEvent`s in a single notification in the order<br>  you receive them.
+
+---@class cmp.kit.LSP.DidSaveNotebookDocumentParams
+---@field public notebookDocument cmp.kit.LSP.NotebookDocumentIdentifier The notebook document that got saved.
+
+---@class cmp.kit.LSP.DidCloseNotebookDocumentParams
+---@field public notebookDocument cmp.kit.LSP.NotebookDocumentIdentifier The notebook document that got closed.
+---@field public cellTextDocuments cmp.kit.LSP.TextDocumentIdentifier[] The text documents that represent the content<br>of a notebook cell that got closed.
+
+---@class cmp.kit.LSP.RegistrationParams
+---@field public registrations cmp.kit.LSP.Registration[]
+
+---@class cmp.kit.LSP.UnregistrationParams
+---@field public unregisterations cmp.kit.LSP.Unregistration[]
+
+---@class cmp.kit.LSP.InitializeParams : cmp.kit.LSP._InitializeParams, cmp.kit.LSP.WorkspaceFoldersInitializeParams
+
+---@class cmp.kit.LSP.InitializeResult
+---@field public capabilities cmp.kit.LSP.ServerCapabilities The capabilities the language server provides.
+---@field public serverInfo? cmp.kit.LSP.InitializeResult.serverInfo Information about the server.<br><br>@since 3.15.0
+
+---@class cmp.kit.LSP.InitializeResult.serverInfo
+---@field public name string The name of the server as defined by the server.
+---@field public version? string The server's version as defined by the server.
+
+---@class cmp.kit.LSP.InitializeError
+---@field public retry boolean Indicates whether the client execute the following retry logic:<br>(1) show the message provided by the ResponseError to the user<br>(2) user selects retry or cancel<br>(3) if user selected retry the initialize method is sent again.
+
+---@class cmp.kit.LSP.InitializedParams
+
+---@class cmp.kit.LSP.DidChangeConfigurationParams
+---@field public settings cmp.kit.LSP.LSPAny The actual changed settings
+
+---@class cmp.kit.LSP.DidChangeConfigurationRegistrationOptions
+---@field public section? (string | string[])
+
+---@class cmp.kit.LSP.ShowMessageParams
+---@field public type cmp.kit.LSP.MessageType The message type. See {@link MessageType}
+---@field public message string The actual message.
+
+---@class cmp.kit.LSP.ShowMessageRequestParams
+---@field public type cmp.kit.LSP.MessageType The message type. See {@link MessageType}
+---@field public message string The actual message.
+---@field public actions? cmp.kit.LSP.MessageActionItem[] The message action items to present.
+
+---@class cmp.kit.LSP.MessageActionItem
+---@field public title string A short title like 'Retry', 'Open Log' etc.
+
+---@class cmp.kit.LSP.LogMessageParams
+---@field public type cmp.kit.LSP.MessageType The message type. See {@link MessageType}
+---@field public message string The actual message.
+
+---@class cmp.kit.LSP.DidOpenTextDocumentParams
+---@field public textDocument cmp.kit.LSP.TextDocumentItem The document that was opened.
+
+---@class cmp.kit.LSP.DidChangeTextDocumentParams
+---@field public textDocument cmp.kit.LSP.VersionedTextDocumentIdentifier The document that did change. The version number points<br>to the version after all provided content changes have<br>been applied.
+---@field public contentChanges cmp.kit.LSP.TextDocumentContentChangeEvent[] The actual content changes. The content changes describe single state changes<br>to the document. So if there are two content changes c1 (at array index 0) and<br>c2 (at array index 1) for a document in state S then c1 moves the document from<br>S to S' and c2 from S' to S''. So c1 is computed on the state S and c2 is computed<br>on the state S'.<br><br>To mirror the content of a document using change events use the following approach:<br>- start with the same initial content<br>- apply the 'textDocument/didChange' notifications in the order you receive them.<br>- apply the `TextDocumentContentChangeEvent`s in a single notification in the order<br>  you receive them.
+
+---@class cmp.kit.LSP.TextDocumentChangeRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions
+---@field public syncKind cmp.kit.LSP.TextDocumentSyncKind How documents are synced to the server.
+
+---@class cmp.kit.LSP.DidCloseTextDocumentParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document that was closed.
+
+---@class cmp.kit.LSP.DidSaveTextDocumentParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document that was saved.
+---@field public text? string Optional the content when saved. Depends on the includeText value<br>when the save notification was requested.
+
+---@class cmp.kit.LSP.TextDocumentSaveRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.SaveOptions
+
+---@class cmp.kit.LSP.WillSaveTextDocumentParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document that will be saved.
+---@field public reason cmp.kit.LSP.TextDocumentSaveReason The 'TextDocumentSaveReason'.
+
+---@class cmp.kit.LSP.TextEdit
+---@field public range cmp.kit.LSP.Range The range of the text document to be manipulated. To insert<br>text into a document create a range where start === end.
+---@field public newText string The string to be inserted. For delete operations use an<br>empty string.
+
+---@class cmp.kit.LSP.DidChangeWatchedFilesParams
+---@field public changes cmp.kit.LSP.FileEvent[] The actual file events.
+
+---@class cmp.kit.LSP.DidChangeWatchedFilesRegistrationOptions
+---@field public watchers cmp.kit.LSP.FileSystemWatcher[] The watchers to register.
+
+---@class cmp.kit.LSP.PublishDiagnosticsParams
+---@field public uri string The URI for which diagnostic information is reported.
+---@field public version? integer Optional the version number of the document the diagnostics are published for.<br><br>@since 3.15.0
+---@field public diagnostics cmp.kit.LSP.Diagnostic[] An array of diagnostic information items.
+
+---@class cmp.kit.LSP.CompletionParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public context? cmp.kit.LSP.CompletionContext The completion context. This is only available it the client specifies<br>to send this using the client capability `textDocument.completion.contextSupport === true`
+
+---@class cmp.kit.LSP.CompletionItem
+---@field public label string The label of this completion item.<br><br>The label property is also by default the text that<br>is inserted when selecting this completion.<br><br>If label details are provided the label itself should<br>be an unqualified name of the completion item.
+---@field public labelDetails? cmp.kit.LSP.CompletionItemLabelDetails Additional details for the label<br><br>@since 3.17.0
+---@field public kind? cmp.kit.LSP.CompletionItemKind The kind of this completion item. Based of the kind<br>an icon is chosen by the editor.
+---@field public tags? cmp.kit.LSP.CompletionItemTag[] Tags for this completion item.<br><br>@since 3.15.0
+---@field public detail? string A human-readable string with additional information<br>about this item, like type or symbol information.
+---@field public documentation? (string | cmp.kit.LSP.MarkupContent) A human-readable string that represents a doc-comment.
+---@field public deprecated? boolean Indicates if this item is deprecated.<br>@deprecated Use `tags` instead.
+---@field public preselect? boolean Select this item when showing.<br><br>*Note* that only one completion item can be selected and that the<br>tool / client decides which item that is. The rule is that the *first*<br>item of those that match best is selected.
+---@field public sortText? string A string that should be used when comparing this item<br>with other items. When `falsy` the [label](#CompletionItem.label)<br>is used.
+---@field public filterText? string A string that should be used when filtering a set of<br>completion items. When `falsy` the [label](#CompletionItem.label)<br>is used.
+---@field public insertText? string A string that should be inserted into a document when selecting<br>this completion. When `falsy` the [label](#CompletionItem.label)<br>is used.<br><br>The `insertText` is subject to interpretation by the client side.<br>Some tools might not take the string literally. For example<br>VS Code when code complete is requested in this example<br>`con<cursor position>` and a completion item with an `insertText` of<br>`console` is provided it will only insert `sole`. Therefore it is<br>recommended to use `textEdit` instead since it avoids additional client<br>side interpretation.
+---@field public insertTextFormat? cmp.kit.LSP.InsertTextFormat The format of the insert text. The format applies to both the<br>`insertText` property and the `newText` property of a provided<br>`textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.<br><br>Please note that the insertTextFormat doesn't apply to<br>`additionalTextEdits`.
+---@field public insertTextMode? cmp.kit.LSP.InsertTextMode How whitespace and indentation is handled during completion<br>item insertion. If not provided the clients default value depends on<br>the `textDocument.completion.insertTextMode` client capability.<br><br>@since 3.16.0
+---@field public textEdit? (cmp.kit.LSP.TextEdit | cmp.kit.LSP.InsertReplaceEdit) An [edit](#TextEdit) which is applied to a document when selecting<br>this completion. When an edit is provided the value of<br>[insertText](#CompletionItem.insertText) is ignored.<br><br>Most editors support two different operations when accepting a completion<br>item. One is to insert a completion text and the other is to replace an<br>existing text with a completion text. Since this can usually not be<br>predetermined by a server it can report both ranges. Clients need to<br>signal support for `InsertReplaceEdits` via the<br>`textDocument.completion.insertReplaceSupport` client capability<br>property.<br><br>*Note 1:* The text edit's range as well as both ranges from an insert<br>replace edit must be a [single line] and they must contain the position<br>at which completion has been requested.<br>*Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range<br>must be a prefix of the edit's replace range, that means it must be<br>contained and starting at the same position.<br><br>@since 3.16.0 additional type `InsertReplaceEdit`
+---@field public textEditText? string The edit text used if the completion item is part of a CompletionList and<br>CompletionList defines an item default for the text edit range.<br><br>Clients will only honor this property if they opt into completion list<br>item defaults using the capability `completionList.itemDefaults`.<br><br>If not provided and a list's default range is provided the label<br>property is used as a text.<br><br>@since 3.17.0
+---@field public additionalTextEdits? cmp.kit.LSP.TextEdit[] An optional array of additional [text edits](#TextEdit) that are applied when<br>selecting this completion. Edits must not overlap (including the same insert position)<br>with the main [edit](#CompletionItem.textEdit) nor with themselves.<br><br>Additional text edits should be used to change text unrelated to the current cursor position<br>(for example adding an import statement at the top of the file if the completion item will<br>insert an unqualified type).
+---@field public commitCharacters? string[] An optional set of characters that when pressed while this completion is active will accept it first and<br>then type that character. *Note* that all commit characters should have `length=1` and that superfluous<br>characters will be ignored.
+---@field public command? cmp.kit.LSP.Command An optional [command](#Command) that is executed *after* inserting this completion. *Note* that<br>additional modifications to the current document should be described with the<br>[additionalTextEdits](#CompletionItem.additionalTextEdits)-property.
+---@field public data? cmp.kit.LSP.LSPAny A data entry field that is preserved on a completion item between a<br>[CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest](#CompletionResolveRequest).
+
+---@class cmp.kit.LSP.CompletionList
+---@field public isIncomplete boolean This list it not complete. Further typing results in recomputing this list.<br><br>Recomputed lists have all their items replaced (not appended) in the<br>incomplete completion sessions.
+---@field public itemDefaults? cmp.kit.LSP.CompletionList.itemDefaults In many cases the items of an actual completion result share the same<br>value for properties like `commitCharacters` or the range of a text<br>edit. A completion list can therefore define item defaults which will<br>be used if a completion item itself doesn't specify the value.<br><br>If a completion list specifies a default value and a completion item<br>also specifies a corresponding value the one from the item is used.<br><br>Servers are only allowed to return default values if the client<br>signals support for this via the `completionList.itemDefaults`<br>capability.<br><br>@since 3.17.0
+---@field public items cmp.kit.LSP.CompletionItem[] The completion items.
+
+---@class cmp.kit.LSP.CompletionList.itemDefaults
+---@field public commitCharacters? string[] A default commit character set.<br><br>@since 3.17.0
+---@field public editRange? (cmp.kit.LSP.Range | { insert: cmp.kit.LSP.Range, replace: cmp.kit.LSP.Range }) A default edit range.<br><br>@since 3.17.0
+---@field public insertTextFormat? cmp.kit.LSP.InsertTextFormat A default insert text format.<br><br>@since 3.17.0
+---@field public insertTextMode? cmp.kit.LSP.InsertTextMode A default insert text mode.<br><br>@since 3.17.0
+---@field public data? cmp.kit.LSP.LSPAny A default data value.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.CompletionRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.CompletionOptions
+
+---@class cmp.kit.LSP.HoverParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams
+
+---@class cmp.kit.LSP.Hover
+---@field public contents (cmp.kit.LSP.MarkupContent | cmp.kit.LSP.MarkedString | cmp.kit.LSP.MarkedString[]) The hover's content
+---@field public range? cmp.kit.LSP.Range An optional range inside the text document that is used to<br>visualize the hover, e.g. by changing the background color.
+
+---@class cmp.kit.LSP.HoverRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.HoverOptions
+
+---@class cmp.kit.LSP.SignatureHelpParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams
+---@field public context? cmp.kit.LSP.SignatureHelpContext The signature help context. This is only available if the client specifies<br>to send this using the client capability `textDocument.signatureHelp.contextSupport === true`<br><br>@since 3.15.0
+
+---@class cmp.kit.LSP.SignatureHelp
+---@field public signatures cmp.kit.LSP.SignatureInformation[] One or more signatures.
+---@field public activeSignature? integer The active signature. If omitted or the value lies outside the<br>range of `signatures` the value defaults to zero or is ignored if<br>the `SignatureHelp` has no signatures.<br><br>Whenever possible implementors should make an active decision about<br>the active signature and shouldn't rely on a default value.<br><br>In future version of the protocol this property might become<br>mandatory to better express this.
+---@field public activeParameter? integer The active parameter of the active signature. If omitted or the value<br>lies outside the range of `signatures[activeSignature].parameters`<br>defaults to 0 if the active signature has parameters. If<br>the active signature has no parameters it is ignored.<br>In future version of the protocol this property might become<br>mandatory to better express the active parameter if the<br>active signature does have any.
+
+---@class cmp.kit.LSP.SignatureHelpRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.SignatureHelpOptions
+
+---@class cmp.kit.LSP.DefinitionParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+
+---@class cmp.kit.LSP.DefinitionRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.DefinitionOptions
+
+---@class cmp.kit.LSP.ReferenceParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public context cmp.kit.LSP.ReferenceContext
+
+---@class cmp.kit.LSP.ReferenceRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.ReferenceOptions
+
+---@class cmp.kit.LSP.DocumentHighlightParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+
+---@class cmp.kit.LSP.DocumentHighlight
+---@field public range cmp.kit.LSP.Range The range this highlight applies to.
+---@field public kind? cmp.kit.LSP.DocumentHighlightKind The highlight kind, default is [text](#DocumentHighlightKind.Text).
+
+---@class cmp.kit.LSP.DocumentHighlightRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.DocumentHighlightOptions
+
+---@class cmp.kit.LSP.DocumentSymbolParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+
+---@class cmp.kit.LSP.SymbolInformation : cmp.kit.LSP.BaseSymbolInformation
+---@field public deprecated? boolean Indicates if this symbol is deprecated.<br><br>@deprecated Use tags instead
+---@field public location cmp.kit.LSP.Location The location of this symbol. The location's range is used by a tool<br>to reveal the location in the editor. If the symbol is selected in the<br>tool the range's start information is used to position the cursor. So<br>the range usually spans more than the actual symbol's name and does<br>normally include things like visibility modifiers.<br><br>The range doesn't have to denote a node range in the sense of an abstract<br>syntax tree. It can therefore not be used to re-construct a hierarchy of<br>the symbols.
+
+---@class cmp.kit.LSP.DocumentSymbol
+---@field public name string The name of this symbol. Will be displayed in the user interface and therefore must not be<br>an empty string or a string only consisting of white spaces.
+---@field public detail? string More detail for this symbol, e.g the signature of a function.
+---@field public kind cmp.kit.LSP.SymbolKind The kind of this symbol.
+---@field public tags? cmp.kit.LSP.SymbolTag[] Tags for this document symbol.<br><br>@since 3.16.0
+---@field public deprecated? boolean Indicates if this symbol is deprecated.<br><br>@deprecated Use tags instead
+---@field public range cmp.kit.LSP.Range The range enclosing this symbol not including leading/trailing whitespace but everything else<br>like comments. This information is typically used to determine if the clients cursor is<br>inside the symbol to reveal in the symbol in the UI.
+---@field public selectionRange cmp.kit.LSP.Range The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.<br>Must be contained by the `range`.
+---@field public children? cmp.kit.LSP.DocumentSymbol[] Children of this symbol, e.g. properties of a class.
+
+---@class cmp.kit.LSP.DocumentSymbolRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.DocumentSymbolOptions
+
+---@class cmp.kit.LSP.CodeActionParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document in which the command was invoked.
+---@field public range cmp.kit.LSP.Range The range for which the command was invoked.
+---@field public context cmp.kit.LSP.CodeActionContext Context carrying additional information.
+
+---@class cmp.kit.LSP.Command
+---@field public title string Title of the command, like `save`.
+---@field public command string The identifier of the actual command handler.
+---@field public arguments? cmp.kit.LSP.LSPAny[] Arguments that the command handler should be<br>invoked with.
+
+---@class cmp.kit.LSP.CodeAction
+---@field public title string A short, human-readable, title for this code action.
+---@field public kind? cmp.kit.LSP.CodeActionKind The kind of the code action.<br><br>Used to filter code actions.
+---@field public diagnostics? cmp.kit.LSP.Diagnostic[] The diagnostics that this code action resolves.
+---@field public isPreferred? boolean Marks this as a preferred action. Preferred actions are used by the `auto fix` command and can be targeted<br>by keybindings.<br><br>A quick fix should be marked preferred if it properly addresses the underlying error.<br>A refactoring should be marked preferred if it is the most reasonable choice of actions to take.<br><br>@since 3.15.0
+---@field public disabled? cmp.kit.LSP.CodeAction.disabled Marks that the code action cannot currently be applied.<br><br>Clients should follow the following guidelines regarding disabled code actions:<br><br>  - Disabled code actions are not shown in automatic [lightbulbs](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)<br>    code action menus.<br><br>  - Disabled actions are shown as faded out in the code action menu when the user requests a more specific type<br>    of code action, such as refactorings.<br><br>  - If the user has a [keybinding](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions)<br>    that auto applies a code action and only disabled code actions are returned, the client should show the user an<br>    error message with `reason` in the editor.<br><br>@since 3.16.0
+---@field public edit? cmp.kit.LSP.WorkspaceEdit The workspace edit this code action performs.
+---@field public command? cmp.kit.LSP.Command A command this code action executes. If a code action<br>provides an edit and a command, first the edit is<br>executed and then the command.
+---@field public data? cmp.kit.LSP.LSPAny A data entry field that is preserved on a code action between<br>a `textDocument/codeAction` and a `codeAction/resolve` request.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.CodeAction.disabled
+---@field public reason string Human readable description of why the code action is currently disabled.<br><br>This is displayed in the code actions UI.
+
+---@class cmp.kit.LSP.CodeActionRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.CodeActionOptions
+
+---@class cmp.kit.LSP.WorkspaceSymbolParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public query string A query string to filter symbols by. Clients may send an empty<br>string here to request all symbols.
+
+---@class cmp.kit.LSP.WorkspaceSymbol : cmp.kit.LSP.BaseSymbolInformation
+---@field public location (cmp.kit.LSP.Location | { uri: string }) The location of the symbol. Whether a server is allowed to<br>return a location without a range depends on the client<br>capability `workspace.symbol.resolveSupport`.<br><br>See SymbolInformation#location for more details.
+---@field public data? cmp.kit.LSP.LSPAny A data entry field that is preserved on a workspace symbol between a<br>workspace symbol request and a workspace symbol resolve request.
+
+---@class cmp.kit.LSP.WorkspaceSymbolRegistrationOptions : cmp.kit.LSP.WorkspaceSymbolOptions
+
+---@class cmp.kit.LSP.CodeLensParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document to request code lens for.
+
+---@class cmp.kit.LSP.CodeLens
+---@field public range cmp.kit.LSP.Range The range in which this code lens is valid. Should only span a single line.
+---@field public command? cmp.kit.LSP.Command The command this code lens represents.
+---@field public data? cmp.kit.LSP.LSPAny A data entry field that is preserved on a code lens item between<br>a [CodeLensRequest](#CodeLensRequest) and a [CodeLensResolveRequest]<br>(#CodeLensResolveRequest)
+
+---@class cmp.kit.LSP.CodeLensRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.CodeLensOptions
+
+---@class cmp.kit.LSP.DocumentLinkParams : cmp.kit.LSP.WorkDoneProgressParams, cmp.kit.LSP.PartialResultParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document to provide document links for.
+
+---@class cmp.kit.LSP.DocumentLink
+---@field public range cmp.kit.LSP.Range The range this link applies to.
+---@field public target? string The uri this link points to. If missing a resolve request is sent later.
+---@field public tooltip? string The tooltip text when you hover over this link.<br><br>If a tooltip is provided, is will be displayed in a string that includes instructions on how to<br>trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary depending on OS,<br>user settings, and localization.<br><br>@since 3.15.0
+---@field public data? cmp.kit.LSP.LSPAny A data entry field that is preserved on a document link between a<br>DocumentLinkRequest and a DocumentLinkResolveRequest.
+
+---@class cmp.kit.LSP.DocumentLinkRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.DocumentLinkOptions
+
+---@class cmp.kit.LSP.DocumentFormattingParams : cmp.kit.LSP.WorkDoneProgressParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document to format.
+---@field public options cmp.kit.LSP.FormattingOptions The format options.
+
+---@class cmp.kit.LSP.DocumentFormattingRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.DocumentFormattingOptions
+
+---@class cmp.kit.LSP.DocumentRangeFormattingParams : cmp.kit.LSP.WorkDoneProgressParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document to format.
+---@field public range cmp.kit.LSP.Range The range to format
+---@field public options cmp.kit.LSP.FormattingOptions The format options
+
+---@class cmp.kit.LSP.DocumentRangeFormattingRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.DocumentRangeFormattingOptions
+
+---@class cmp.kit.LSP.DocumentOnTypeFormattingParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document to format.
+---@field public position cmp.kit.LSP.Position The position around which the on type formatting should happen.<br>This is not necessarily the exact position where the character denoted<br>by the property `ch` got typed.
+---@field public ch string The character that has been typed that triggered the formatting<br>on type request. That is not necessarily the last character that<br>got inserted into the document since the client could auto insert<br>characters as well (e.g. like automatic brace completion).
+---@field public options cmp.kit.LSP.FormattingOptions The formatting options.
+
+---@class cmp.kit.LSP.DocumentOnTypeFormattingRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.DocumentOnTypeFormattingOptions
+
+---@class cmp.kit.LSP.RenameParams : cmp.kit.LSP.WorkDoneProgressParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The document to rename.
+---@field public position cmp.kit.LSP.Position The position at which this request was sent.
+---@field public newName string The new name of the symbol. If the given name is not valid the<br>request must return a [ResponseError](#ResponseError) with an<br>appropriate message set.
+
+---@class cmp.kit.LSP.RenameRegistrationOptions : cmp.kit.LSP.TextDocumentRegistrationOptions, cmp.kit.LSP.RenameOptions
+
+---@class cmp.kit.LSP.PrepareRenameParams : cmp.kit.LSP.TextDocumentPositionParams, cmp.kit.LSP.WorkDoneProgressParams
+
+---@class cmp.kit.LSP.ExecuteCommandParams : cmp.kit.LSP.WorkDoneProgressParams
+---@field public command string The identifier of the actual command handler.
+---@field public arguments? cmp.kit.LSP.LSPAny[] Arguments that the command should be invoked with.
+
+---@class cmp.kit.LSP.ExecuteCommandRegistrationOptions : cmp.kit.LSP.ExecuteCommandOptions
+
+---@class cmp.kit.LSP.ApplyWorkspaceEditParams
+---@field public label? string An optional label of the workspace edit. This label is<br>presented in the user interface for example on an undo<br>stack to undo the workspace edit.
+---@field public edit cmp.kit.LSP.WorkspaceEdit The edits to apply.
+
+---@class cmp.kit.LSP.ApplyWorkspaceEditResult
+---@field public applied boolean Indicates whether the edit was applied or not.
+---@field public failureReason? string An optional textual description for why the edit was not applied.<br>This may be used by the server for diagnostic logging or to provide<br>a suitable error for a request that triggered the edit.
+---@field public failedChange? integer Depending on the client's failure handling strategy `failedChange` might<br>contain the index of the change that failed. This property is only available<br>if the client signals a `failureHandlingStrategy` in its client capabilities.
+
+---@class cmp.kit.LSP.WorkDoneProgressBegin
+---@field public kind "begin"
+---@field public title string Mandatory title of the progress operation. Used to briefly inform about<br>the kind of operation being performed.<br><br>Examples: "Indexing" or "Linking dependencies".
+---@field public cancellable? boolean Controls if a cancel button should show to allow the user to cancel the<br>long running operation. Clients that don't support cancellation are allowed<br>to ignore the setting.
+---@field public message? string Optional, more detailed associated progress message. Contains<br>complementary information to the `title`.<br><br>Examples: "3/25 files", "project/src/module2", "node_modules/some_dep".<br>If unset, the previous progress message (if any) is still valid.
+---@field public percentage? integer Optional progress percentage to display (value 100 is considered 100%).<br>If not provided infinite progress is assumed and clients are allowed<br>to ignore the `percentage` value in subsequent in report notifications.<br><br>The value should be steadily rising. Clients are free to ignore values<br>that are not following this rule. The value range is [0, 100].
+
+---@class cmp.kit.LSP.WorkDoneProgressReport
+---@field public kind "report"
+---@field public cancellable? boolean Controls enablement state of a cancel button.<br><br>Clients that don't support cancellation or don't support controlling the button's<br>enablement state are allowed to ignore the property.
+---@field public message? string Optional, more detailed associated progress message. Contains<br>complementary information to the `title`.<br><br>Examples: "3/25 files", "project/src/module2", "node_modules/some_dep".<br>If unset, the previous progress message (if any) is still valid.
+---@field public percentage? integer Optional progress percentage to display (value 100 is considered 100%).<br>If not provided infinite progress is assumed and clients are allowed<br>to ignore the `percentage` value in subsequent in report notifications.<br><br>The value should be steadily rising. Clients are free to ignore values<br>that are not following this rule. The value range is [0, 100]
+
+---@class cmp.kit.LSP.WorkDoneProgressEnd
+---@field public kind "end"
+---@field public message? string Optional, a final message indicating to for example indicate the outcome<br>of the operation.
+
+---@class cmp.kit.LSP.SetTraceParams
+---@field public value cmp.kit.LSP.TraceValues
+
+---@class cmp.kit.LSP.LogTraceParams
+---@field public message string
+---@field public verbose? string
+
+---@class cmp.kit.LSP.CancelParams
+---@field public id (integer | string) The request id to cancel.
+
+---@class cmp.kit.LSP.ProgressParams
+---@field public token cmp.kit.LSP.ProgressToken The progress token provided by the client or server.
+---@field public value cmp.kit.LSP.LSPAny The progress data.
+
+---@class cmp.kit.LSP.TextDocumentPositionParams
+---@field public textDocument cmp.kit.LSP.TextDocumentIdentifier The text document.
+---@field public position cmp.kit.LSP.Position The position inside the text document.
+
+---@class cmp.kit.LSP.WorkDoneProgressParams
+---@field public workDoneToken? cmp.kit.LSP.ProgressToken An optional token that a server can use to report work done progress.
+
+---@class cmp.kit.LSP.LocationLink
+---@field public originSelectionRange? cmp.kit.LSP.Range Span of the origin of this link.<br><br>Used as the underlined span for mouse interaction. Defaults to the word range at<br>the definition position.
+---@field public targetUri string The target resource identifier of this link.
+---@field public targetRange cmp.kit.LSP.Range The full target range of this link. If the target for example is a symbol then target range is the<br>range enclosing this symbol not including leading/trailing whitespace but everything else<br>like comments. This information is typically used to highlight the range in the editor.
+---@field public targetSelectionRange cmp.kit.LSP.Range The range that should be selected and revealed when this link is being followed, e.g the name of a function.<br>Must be contained by the `targetRange`. See also `DocumentSymbol#range`
+
+---@class cmp.kit.LSP.Range
+---@field public start cmp.kit.LSP.Position The range's start position.
+---@field public end cmp.kit.LSP.Position The range's end position.
+
+---@class cmp.kit.LSP.ImplementationOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.StaticRegistrationOptions
+---@field public id? string The id used to register the request. The id can be used to deregister<br>the request again. See also Registration#id.
+
+---@class cmp.kit.LSP.TypeDefinitionOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.WorkspaceFoldersChangeEvent
+---@field public added cmp.kit.LSP.WorkspaceFolder[] The array of added workspace folders
+---@field public removed cmp.kit.LSP.WorkspaceFolder[] The array of the removed workspace folders
+
+---@class cmp.kit.LSP.ConfigurationItem
+---@field public scopeUri? string The scope to get the configuration section for.
+---@field public section? string The configuration section asked for.
+
+---@class cmp.kit.LSP.TextDocumentIdentifier
+---@field public uri string The text document's uri.
+
+---@class cmp.kit.LSP.Color
+---@field public red integer The red component of this color in the range [0-1].
+---@field public green integer The green component of this color in the range [0-1].
+---@field public blue integer The blue component of this color in the range [0-1].
+---@field public alpha integer The alpha component of this color in the range [0-1].
+
+---@class cmp.kit.LSP.DocumentColorOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.FoldingRangeOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.DeclarationOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.Position
+---@field public line integer Line position in a document (zero-based).<br><br>If a line number is greater than the number of lines in a document, it defaults back to the number of lines in the document.<br>If a line number is negative, it defaults to 0.
+---@field public character integer Character offset on a line in a document (zero-based).<br><br>The meaning of this offset is determined by the negotiated<br>`PositionEncodingKind`.<br><br>If the character value is greater than the line length it defaults back to the<br>line length.
+
+---@class cmp.kit.LSP.SelectionRangeOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.CallHierarchyOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.SemanticTokensOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public legend cmp.kit.LSP.SemanticTokensLegend The legend used by the server
+---@field public range? (boolean | {  }) Server supports providing semantic tokens for a specific range<br>of a document.
+---@field public full? (boolean | { delta?: boolean }) Server supports providing semantic tokens for a full document.
+
+---@class cmp.kit.LSP.SemanticTokensEdit
+---@field public start integer The start offset of the edit.
+---@field public deleteCount integer The count of elements to remove.
+---@field public data? integer[] The elements to insert.
+
+---@class cmp.kit.LSP.LinkedEditingRangeOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.FileCreate
+---@field public uri string A file:// URI for the location of the file/folder being created.
+
+---@class cmp.kit.LSP.TextDocumentEdit
+---@field public textDocument cmp.kit.LSP.OptionalVersionedTextDocumentIdentifier The text document to change.
+---@field public edits (cmp.kit.LSP.TextEdit | cmp.kit.LSP.AnnotatedTextEdit)[] The edits to be applied.<br><br>@since 3.16.0 - support for AnnotatedTextEdit. This is guarded using a<br>client capability.
+
+---@class cmp.kit.LSP.CreateFile : cmp.kit.LSP.ResourceOperation
+---@field public kind "create" A create
+---@field public uri string The resource to create.
+---@field public options? cmp.kit.LSP.CreateFileOptions Additional options
+
+---@class cmp.kit.LSP.RenameFile : cmp.kit.LSP.ResourceOperation
+---@field public kind "rename" A rename
+---@field public oldUri string The old (existing) location.
+---@field public newUri string The new location.
+---@field public options? cmp.kit.LSP.RenameFileOptions Rename options.
+
+---@class cmp.kit.LSP.DeleteFile : cmp.kit.LSP.ResourceOperation
+---@field public kind "delete" A delete
+---@field public uri string The file to delete.
+---@field public options? cmp.kit.LSP.DeleteFileOptions Delete options.
+
+---@class cmp.kit.LSP.ChangeAnnotation
+---@field public label string A human-readable string describing the actual change. The string<br>is rendered prominent in the user interface.
+---@field public needsConfirmation? boolean A flag which indicates that user confirmation is needed<br>before applying the change.
+---@field public description? string A human-readable string which is rendered less prominent in<br>the user interface.
+
+---@class cmp.kit.LSP.FileOperationFilter
+---@field public scheme? string A Uri scheme like `file` or `untitled`.
+---@field public pattern cmp.kit.LSP.FileOperationPattern The actual file operation pattern.
+
+---@class cmp.kit.LSP.FileRename
+---@field public oldUri string A file:// URI for the original location of the file/folder being renamed.
+---@field public newUri string A file:// URI for the new location of the file/folder being renamed.
+
+---@class cmp.kit.LSP.FileDelete
+---@field public uri string A file:// URI for the location of the file/folder being deleted.
+
+---@class cmp.kit.LSP.MonikerOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.TypeHierarchyOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.InlineValueContext
+---@field public frameId integer The stack frame (as a DAP Id) where the execution has stopped.
+---@field public stoppedLocation cmp.kit.LSP.Range The document range where execution has stopped.<br>Typically the end position of the range denotes the line where the inline values are shown.
+
+---@class cmp.kit.LSP.InlineValueText
+---@field public range cmp.kit.LSP.Range The document range for which the inline value applies.
+---@field public text string The text of the inline value.
+
+---@class cmp.kit.LSP.InlineValueVariableLookup
+---@field public range cmp.kit.LSP.Range The document range for which the inline value applies.<br>The range is used to extract the variable name from the underlying document.
+---@field public variableName? string If specified the name of the variable to look up.
+---@field public caseSensitiveLookup boolean How to perform the lookup.
+
+---@class cmp.kit.LSP.InlineValueEvaluatableExpression
+---@field public range cmp.kit.LSP.Range The document range for which the inline value applies.<br>The range is used to extract the evaluatable expression from the underlying document.
+---@field public expression? string If specified the expression overrides the extracted expression.
+
+---@class cmp.kit.LSP.InlineValueOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.InlayHintLabelPart
+---@field public value string The value of this label part.
+---@field public tooltip? (string | cmp.kit.LSP.MarkupContent) The tooltip text when you hover over this label part. Depending on<br>the client capability `inlayHint.resolveSupport` clients might resolve<br>this property late using the resolve request.
+---@field public location? cmp.kit.LSP.Location An optional source code location that represents this<br>label part.<br><br>The editor will use this location for the hover and for code navigation<br>features: This part will become a clickable link that resolves to the<br>definition of the symbol at the given location (not necessarily the<br>location itself), it shows the hover that shows at the given location,<br>and it shows a context menu with further code navigation commands.<br><br>Depending on the client capability `inlayHint.resolveSupport` clients<br>might resolve this property late using the resolve request.
+---@field public command? cmp.kit.LSP.Command An optional command for this label part.<br><br>Depending on the client capability `inlayHint.resolveSupport` clients<br>might resolve this property late using the resolve request.
+
+---@class cmp.kit.LSP.MarkupContent
+---@field public kind cmp.kit.LSP.MarkupKind The type of the Markup
+---@field public value string The content itself
+
+---@class cmp.kit.LSP.InlayHintOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public resolveProvider? boolean The server provides support to resolve additional<br>information for an inlay hint item.
+
+---@class cmp.kit.LSP.RelatedFullDocumentDiagnosticReport : cmp.kit.LSP.FullDocumentDiagnosticReport
+---@field public relatedDocuments? table<string, (cmp.kit.LSP.FullDocumentDiagnosticReport | cmp.kit.LSP.UnchangedDocumentDiagnosticReport)> Diagnostics of related documents. This information is useful<br>in programming languages where code in a file A can generate<br>diagnostics in a file B which A depends on. An example of<br>such a language is C/C++ where marco definitions in a file<br>a.cpp and result in errors in a header file b.hpp.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.RelatedUnchangedDocumentDiagnosticReport : cmp.kit.LSP.UnchangedDocumentDiagnosticReport
+---@field public relatedDocuments? table<string, (cmp.kit.LSP.FullDocumentDiagnosticReport | cmp.kit.LSP.UnchangedDocumentDiagnosticReport)> Diagnostics of related documents. This information is useful<br>in programming languages where code in a file A can generate<br>diagnostics in a file B which A depends on. An example of<br>such a language is C/C++ where marco definitions in a file<br>a.cpp and result in errors in a header file b.hpp.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.FullDocumentDiagnosticReport
+---@field public kind "full" A full document diagnostic report.
+---@field public resultId? string An optional result id. If provided it will<br>be sent on the next diagnostic request for the<br>same document.
+---@field public items cmp.kit.LSP.Diagnostic[] The actual items.
+
+---@class cmp.kit.LSP.UnchangedDocumentDiagnosticReport
+---@field public kind "unchanged" A document diagnostic report indicating<br>no changes to the last result. A server can<br>only return `unchanged` if result ids are<br>provided.
+---@field public resultId string A result id which will be sent on the next<br>diagnostic request for the same document.
+
+---@class cmp.kit.LSP.DiagnosticOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public identifier? string An optional identifier under which the diagnostics are<br>managed by the client.
+---@field public interFileDependencies boolean Whether the language has inter file dependencies meaning that<br>editing code in one file can result in a different diagnostic<br>set in another file. Inter file dependencies are common for<br>most programming languages and typically uncommon for linters.
+---@field public workspaceDiagnostics boolean The server provides support for workspace diagnostics as well.
+
+---@class cmp.kit.LSP.PreviousResultId
+---@field public uri string The URI for which the client knowns a<br>result id.
+---@field public value string The value of the previous result id.
+
+---@class cmp.kit.LSP.NotebookDocument
+---@field public uri string The notebook document's uri.
+---@field public notebookType string The type of the notebook.
+---@field public version integer The version number of this document (it will increase after each<br>change, including undo/redo).
+---@field public metadata? cmp.kit.LSP.LSPObject Additional metadata stored with the notebook<br>document.<br><br>Note: should always be an object literal (e.g. LSPObject)
+---@field public cells cmp.kit.LSP.NotebookCell[] The cells of a notebook.
+
+---@class cmp.kit.LSP.TextDocumentItem
+---@field public uri string The text document's uri.
+---@field public languageId string The text document's language identifier.
+---@field public version integer The version number of this document (it will increase after each<br>change, including undo/redo).
+---@field public text string The content of the opened text document.
+
+---@class cmp.kit.LSP.VersionedNotebookDocumentIdentifier
+---@field public version integer The version number of this notebook document.
+---@field public uri string The notebook document's uri.
+
+---@class cmp.kit.LSP.NotebookDocumentChangeEvent
+---@field public metadata? cmp.kit.LSP.LSPObject The changed meta data if any.<br><br>Note: should always be an object literal (e.g. LSPObject)
+---@field public cells? cmp.kit.LSP.NotebookDocumentChangeEvent.cells Changes to cells
+
+---@class cmp.kit.LSP.NotebookDocumentChangeEvent.cells
+---@field public structure? cmp.kit.LSP.NotebookDocumentChangeEvent.cells.structure Changes to the cell structure to add or<br>remove cells.
+---@field public data? cmp.kit.LSP.NotebookCell[] Changes to notebook cells properties like its<br>kind, execution summary or metadata.
+---@field public textContent? { document: cmp.kit.LSP.VersionedTextDocumentIdentifier, changes: cmp.kit.LSP.TextDocumentContentChangeEvent[] }[] Changes to the text content of notebook cells.
+
+---@class cmp.kit.LSP.NotebookDocumentChangeEvent.cells.structure
+---@field public array cmp.kit.LSP.NotebookCellArrayChange The change to the cell array.
+---@field public didOpen? cmp.kit.LSP.TextDocumentItem[] Additional opened cell text documents.
+---@field public didClose? cmp.kit.LSP.TextDocumentIdentifier[] Additional closed cell text documents.
+
+---@class cmp.kit.LSP.NotebookDocumentIdentifier
+---@field public uri string The notebook document's uri.
+
+---@class cmp.kit.LSP.Registration
+---@field public id string The id used to register the request. The id can be used to deregister<br>the request again.
+---@field public method string The method / capability to register for.
+---@field public registerOptions? cmp.kit.LSP.LSPAny Options necessary for the registration.
+
+---@class cmp.kit.LSP.Unregistration
+---@field public id string The id used to unregister the request or notification. Usually an id<br>provided during the register request.
+---@field public method string The method to unregister for.
+
+---@class cmp.kit.LSP._InitializeParams : cmp.kit.LSP.WorkDoneProgressParams
+---@field public processId (integer | nil) The process Id of the parent process that started<br>the server.<br><br>Is `null` if the process has not been started by another process.<br>If the parent process is not alive then the server should exit.
+---@field public clientInfo? cmp.kit.LSP._InitializeParams.clientInfo Information about the client<br><br>@since 3.15.0
+---@field public locale? string The locale the client is currently showing the user interface<br>in. This must not necessarily be the locale of the operating<br>system.<br><br>Uses IETF language tags as the value's syntax<br>(See https://en.wikipedia.org/wiki/IETF_language_tag)<br><br>@since 3.16.0
+---@field public rootPath? (string | nil) The rootPath of the workspace. Is null<br>if no folder is open.<br><br>@deprecated in favour of rootUri.
+---@field public rootUri (string | nil) The rootUri of the workspace. Is null if no<br>folder is open. If both `rootPath` and `rootUri` are set<br>`rootUri` wins.<br><br>@deprecated in favour of workspaceFolders.
+---@field public capabilities cmp.kit.LSP.ClientCapabilities The capabilities provided by the client (editor or tool)
+---@field public initializationOptions? cmp.kit.LSP.LSPAny User provided initialization options.
+---@field public trace? ("off" | "messages" | "compact" | "verbose") The initial trace setting. If omitted trace is disabled ('off').
+
+---@class cmp.kit.LSP._InitializeParams.clientInfo
+---@field public name string The name of the client as defined by the client.
+---@field public version? string The client's version as defined by the client.
+
+---@class cmp.kit.LSP.WorkspaceFoldersInitializeParams
+---@field public workspaceFolders? (cmp.kit.LSP.WorkspaceFolder[] | nil) The workspace folders configured in the client when the server starts.<br><br>This property is only available if the client supports workspace folders.<br>It can be `null` if the client supports workspace folders but none are<br>configured.<br><br>@since 3.6.0
+
+---@class cmp.kit.LSP.ServerCapabilities
+---@field public positionEncoding? cmp.kit.LSP.PositionEncodingKind The position encoding the server picked from the encodings offered<br>by the client via the client capability `general.positionEncodings`.<br><br>If the client didn't provide any position encodings the only valid<br>value that a server can return is 'utf-16'.<br><br>If omitted it defaults to 'utf-16'.<br><br>@since 3.17.0
+---@field public textDocumentSync? (cmp.kit.LSP.TextDocumentSyncOptions | cmp.kit.LSP.TextDocumentSyncKind) Defines how text documents are synced. Is either a detailed structure<br>defining each notification or for backwards compatibility the<br>TextDocumentSyncKind number.
+---@field public notebookDocumentSync? (cmp.kit.LSP.NotebookDocumentSyncOptions | cmp.kit.LSP.NotebookDocumentSyncRegistrationOptions) Defines how notebook documents are synced.<br><br>@since 3.17.0
+---@field public completionProvider? cmp.kit.LSP.CompletionOptions The server provides completion support.
+---@field public hoverProvider? (boolean | cmp.kit.LSP.HoverOptions) The server provides hover support.
+---@field public signatureHelpProvider? cmp.kit.LSP.SignatureHelpOptions The server provides signature help support.
+---@field public declarationProvider? (boolean | cmp.kit.LSP.DeclarationOptions | cmp.kit.LSP.DeclarationRegistrationOptions) The server provides Goto Declaration support.
+---@field public definitionProvider? (boolean | cmp.kit.LSP.DefinitionOptions) The server provides goto definition support.
+---@field public typeDefinitionProvider? (boolean | cmp.kit.LSP.TypeDefinitionOptions | cmp.kit.LSP.TypeDefinitionRegistrationOptions) The server provides Goto Type Definition support.
+---@field public implementationProvider? (boolean | cmp.kit.LSP.ImplementationOptions | cmp.kit.LSP.ImplementationRegistrationOptions) The server provides Goto Implementation support.
+---@field public referencesProvider? (boolean | cmp.kit.LSP.ReferenceOptions) The server provides find references support.
+---@field public documentHighlightProvider? (boolean | cmp.kit.LSP.DocumentHighlightOptions) The server provides document highlight support.
+---@field public documentSymbolProvider? (boolean | cmp.kit.LSP.DocumentSymbolOptions) The server provides document symbol support.
+---@field public codeActionProvider? (boolean | cmp.kit.LSP.CodeActionOptions) The server provides code actions. CodeActionOptions may only be<br>specified if the client states that it supports<br>`codeActionLiteralSupport` in its initial `initialize` request.
+---@field public codeLensProvider? cmp.kit.LSP.CodeLensOptions The server provides code lens.
+---@field public documentLinkProvider? cmp.kit.LSP.DocumentLinkOptions The server provides document link support.
+---@field public colorProvider? (boolean | cmp.kit.LSP.DocumentColorOptions | cmp.kit.LSP.DocumentColorRegistrationOptions) The server provides color provider support.
+---@field public workspaceSymbolProvider? (boolean | cmp.kit.LSP.WorkspaceSymbolOptions) The server provides workspace symbol support.
+---@field public documentFormattingProvider? (boolean | cmp.kit.LSP.DocumentFormattingOptions) The server provides document formatting.
+---@field public documentRangeFormattingProvider? (boolean | cmp.kit.LSP.DocumentRangeFormattingOptions) The server provides document range formatting.
+---@field public documentOnTypeFormattingProvider? cmp.kit.LSP.DocumentOnTypeFormattingOptions The server provides document formatting on typing.
+---@field public renameProvider? (boolean | cmp.kit.LSP.RenameOptions) The server provides rename support. RenameOptions may only be<br>specified if the client states that it supports<br>`prepareSupport` in its initial `initialize` request.
+---@field public foldingRangeProvider? (boolean | cmp.kit.LSP.FoldingRangeOptions | cmp.kit.LSP.FoldingRangeRegistrationOptions) The server provides folding provider support.
+---@field public selectionRangeProvider? (boolean | cmp.kit.LSP.SelectionRangeOptions | cmp.kit.LSP.SelectionRangeRegistrationOptions) The server provides selection range support.
+---@field public executeCommandProvider? cmp.kit.LSP.ExecuteCommandOptions The server provides execute command support.
+---@field public callHierarchyProvider? (boolean | cmp.kit.LSP.CallHierarchyOptions | cmp.kit.LSP.CallHierarchyRegistrationOptions) The server provides call hierarchy support.<br><br>@since 3.16.0
+---@field public linkedEditingRangeProvider? (boolean | cmp.kit.LSP.LinkedEditingRangeOptions | cmp.kit.LSP.LinkedEditingRangeRegistrationOptions) The server provides linked editing range support.<br><br>@since 3.16.0
+---@field public semanticTokensProvider? (cmp.kit.LSP.SemanticTokensOptions | cmp.kit.LSP.SemanticTokensRegistrationOptions) The server provides semantic tokens support.<br><br>@since 3.16.0
+---@field public monikerProvider? (boolean | cmp.kit.LSP.MonikerOptions | cmp.kit.LSP.MonikerRegistrationOptions) The server provides moniker support.<br><br>@since 3.16.0
+---@field public typeHierarchyProvider? (boolean | cmp.kit.LSP.TypeHierarchyOptions | cmp.kit.LSP.TypeHierarchyRegistrationOptions) The server provides type hierarchy support.<br><br>@since 3.17.0
+---@field public inlineValueProvider? (boolean | cmp.kit.LSP.InlineValueOptions | cmp.kit.LSP.InlineValueRegistrationOptions) The server provides inline values.<br><br>@since 3.17.0
+---@field public inlayHintProvider? (boolean | cmp.kit.LSP.InlayHintOptions | cmp.kit.LSP.InlayHintRegistrationOptions) The server provides inlay hints.<br><br>@since 3.17.0
+---@field public diagnosticProvider? (cmp.kit.LSP.DiagnosticOptions | cmp.kit.LSP.DiagnosticRegistrationOptions) The server has support for pull model diagnostics.<br><br>@since 3.17.0
+---@field public workspace? cmp.kit.LSP.ServerCapabilities.workspace Workspace specific server capabilities.
+---@field public experimental? cmp.kit.LSP.LSPAny Experimental server capabilities.
+
+---@class cmp.kit.LSP.ServerCapabilities.workspace
+---@field public workspaceFolders? cmp.kit.LSP.WorkspaceFoldersServerCapabilities The server supports workspace folder.<br><br>@since 3.6.0
+---@field public fileOperations? cmp.kit.LSP.FileOperationOptions The server is interested in notifications/requests for operations on files.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.VersionedTextDocumentIdentifier : cmp.kit.LSP.TextDocumentIdentifier
+---@field public version integer The version number of this document.
+
+---@class cmp.kit.LSP.SaveOptions
+---@field public includeText? boolean The client is supposed to include the content on save.
+
+---@class cmp.kit.LSP.FileEvent
+---@field public uri string The file's uri.
+---@field public type cmp.kit.LSP.FileChangeType The change type.
+
+---@class cmp.kit.LSP.FileSystemWatcher
+---@field public globPattern cmp.kit.LSP.GlobPattern The glob pattern to watch. See {@link GlobPattern glob pattern} for more detail.<br><br>@since 3.17.0 support for relative patterns.
+---@field public kind? cmp.kit.LSP.WatchKind The kind of events of interest. If omitted it defaults<br>to WatchKind.Create | WatchKind.Change | WatchKind.Delete<br>which is 7.
+
+---@class cmp.kit.LSP.Diagnostic
+---@field public range cmp.kit.LSP.Range The range at which the message applies
+---@field public severity? cmp.kit.LSP.DiagnosticSeverity The diagnostic's severity. Can be omitted. If omitted it is up to the<br>client to interpret diagnostics as error, warning, info or hint.
+---@field public code? (integer | string) The diagnostic's code, which usually appear in the user interface.
+---@field public codeDescription? cmp.kit.LSP.CodeDescription An optional property to describe the error code.<br>Requires the code field (above) to be present/not null.<br><br>@since 3.16.0
+---@field public source? string A human-readable string describing the source of this<br>diagnostic, e.g. 'typescript' or 'super lint'. It usually<br>appears in the user interface.
+---@field public message string The diagnostic's message. It usually appears in the user interface
+---@field public tags? cmp.kit.LSP.DiagnosticTag[] Additional metadata about the diagnostic.<br><br>@since 3.15.0
+---@field public relatedInformation? cmp.kit.LSP.DiagnosticRelatedInformation[] An array of related diagnostic information, e.g. when symbol-names within<br>a scope collide all definitions can be marked via this property.
+---@field public data? cmp.kit.LSP.LSPAny A data entry field that is preserved between a `textDocument/publishDiagnostics`<br>notification and `textDocument/codeAction` request.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.CompletionContext
+---@field public triggerKind cmp.kit.LSP.CompletionTriggerKind How the completion was triggered.
+---@field public triggerCharacter? string The trigger character (a single character) that has trigger code complete.<br>Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+
+---@class cmp.kit.LSP.CompletionItemLabelDetails
+---@field public detail? string An optional string which is rendered less prominently directly after {@link CompletionItem.label label},<br>without any spacing. Should be used for function signatures and type annotations.
+---@field public description? string An optional string which is rendered less prominently after {@link CompletionItem.detail}. Should be used<br>for fully qualified names and file paths.
+
+---@class cmp.kit.LSP.InsertReplaceEdit
+---@field public newText string The string to be inserted.
+---@field public insert cmp.kit.LSP.Range The range if the insert is requested
+---@field public replace cmp.kit.LSP.Range The range if the replace is requested.
+
+---@class cmp.kit.LSP.CompletionOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public triggerCharacters? string[] Most tools trigger completion request automatically without explicitly requesting<br>it using a keyboard shortcut (e.g. Ctrl+Space). Typically they do so when the user<br>starts to type an identifier. For example if the user types `c` in a JavaScript file<br>code complete will automatically pop up present `console` besides others as a<br>completion item. Characters that make up identifiers don't need to be listed here.<br><br>If code complete should automatically be trigger on characters not being valid inside<br>an identifier (for example `.` in JavaScript) list them in `triggerCharacters`.
+---@field public allCommitCharacters? string[] The list of all possible characters that commit a completion. This field can be used<br>if clients don't support individual commit characters per completion item. See<br>`ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`<br><br>If a server provides both `allCommitCharacters` and commit characters on an individual<br>completion item the ones on the completion item win.<br><br>@since 3.2.0
+---@field public resolveProvider? boolean The server provides support to resolve additional<br>information for a completion item.
+---@field public completionItem? cmp.kit.LSP.CompletionOptions.completionItem The server supports the following `CompletionItem` specific<br>capabilities.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.CompletionOptions.completionItem
+---@field public labelDetailsSupport? boolean The server has support for completion item label<br>details (see also `CompletionItemLabelDetails`) when<br>receiving a completion item in a resolve call.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.HoverOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.SignatureHelpContext
+---@field public triggerKind cmp.kit.LSP.SignatureHelpTriggerKind Action that caused signature help to be triggered.
+---@field public triggerCharacter? string Character that caused signature help to be triggered.<br><br>This is undefined when `triggerKind !== SignatureHelpTriggerKind.TriggerCharacter`
+---@field public isRetrigger boolean `true` if signature help was already showing when it was triggered.<br><br>Retriggers occurs when the signature help is already active and can be caused by actions such as<br>typing a trigger character, a cursor move, or document content changes.
+---@field public activeSignatureHelp? cmp.kit.LSP.SignatureHelp The currently active `SignatureHelp`.<br><br>The `activeSignatureHelp` has its `SignatureHelp.activeSignature` field updated based on<br>the user navigating through available signatures.
+
+---@class cmp.kit.LSP.SignatureInformation
+---@field public label string The label of this signature. Will be shown in<br>the UI.
+---@field public documentation? (string | cmp.kit.LSP.MarkupContent) The human-readable doc-comment of this signature. Will be shown<br>in the UI but can be omitted.
+---@field public parameters? cmp.kit.LSP.ParameterInformation[] The parameters of this signature.
+---@field public activeParameter? integer The index of the active parameter.<br><br>If provided, this is used in place of `SignatureHelp.activeParameter`.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.SignatureHelpOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public triggerCharacters? string[] List of characters that trigger signature help automatically.
+---@field public retriggerCharacters? string[] List of characters that re-trigger signature help.<br><br>These trigger characters are only active when signature help is already showing. All trigger characters<br>are also counted as re-trigger characters.<br><br>@since 3.15.0
+
+---@class cmp.kit.LSP.DefinitionOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.ReferenceContext
+---@field public includeDeclaration boolean Include the declaration of the current symbol.
+
+---@class cmp.kit.LSP.ReferenceOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.DocumentHighlightOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.BaseSymbolInformation
+---@field public name string The name of this symbol.
+---@field public kind cmp.kit.LSP.SymbolKind The kind of this symbol.
+---@field public tags? cmp.kit.LSP.SymbolTag[] Tags for this symbol.<br><br>@since 3.16.0
+---@field public containerName? string The name of the symbol containing this symbol. This information is for<br>user interface purposes (e.g. to render a qualifier in the user interface<br>if necessary). It can't be used to re-infer a hierarchy for the document<br>symbols.
+
+---@class cmp.kit.LSP.DocumentSymbolOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public label? string A human-readable string that is shown when multiple outlines trees<br>are shown for the same document.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.CodeActionContext
+---@field public diagnostics cmp.kit.LSP.Diagnostic[] An array of diagnostics known on the client side overlapping the range provided to the<br>`textDocument/codeAction` request. They are provided so that the server knows which<br>errors are currently presented to the user for the given range. There is no guarantee<br>that these accurately reflect the error state of the resource. The primary parameter<br>to compute code actions is the provided range.
+---@field public only? cmp.kit.LSP.CodeActionKind[] Requested kind of actions to return.<br><br>Actions not of this kind are filtered out by the client before being shown. So servers<br>can omit computing them.
+---@field public triggerKind? cmp.kit.LSP.CodeActionTriggerKind The reason why code actions were requested.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.CodeActionOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public codeActionKinds? cmp.kit.LSP.CodeActionKind[] CodeActionKinds that this server may return.<br><br>The list of kinds may be generic, such as `CodeActionKind.Refactor`, or the server<br>may list out every specific kind they provide.
+---@field public resolveProvider? boolean The server provides support to resolve additional<br>information for a code action.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.WorkspaceSymbolOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public resolveProvider? boolean The server provides support to resolve additional<br>information for a workspace symbol.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.CodeLensOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public resolveProvider? boolean Code lens has a resolve provider as well.
+
+---@class cmp.kit.LSP.DocumentLinkOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public resolveProvider? boolean Document links have a resolve provider as well.
+
+---@class cmp.kit.LSP.FormattingOptions
+---@field public tabSize integer Size of a tab in spaces.
+---@field public insertSpaces boolean Prefer spaces over tabs.
+---@field public trimTrailingWhitespace? boolean Trim trailing whitespace on a line.<br><br>@since 3.15.0
+---@field public insertFinalNewline? boolean Insert a newline character at the end of the file if one does not exist.<br><br>@since 3.15.0
+---@field public trimFinalNewlines? boolean Trim all newlines after the final newline at the end of the file.<br><br>@since 3.15.0
+
+---@class cmp.kit.LSP.DocumentFormattingOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.DocumentRangeFormattingOptions : cmp.kit.LSP.WorkDoneProgressOptions
+
+---@class cmp.kit.LSP.DocumentOnTypeFormattingOptions
+---@field public firstTriggerCharacter string A character on which formatting should be triggered, like `{`.
+---@field public moreTriggerCharacter? string[] More trigger characters.
+
+---@class cmp.kit.LSP.RenameOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public prepareProvider? boolean Renames should be checked and tested before being executed.<br><br>@since version 3.12.0
+
+---@class cmp.kit.LSP.ExecuteCommandOptions : cmp.kit.LSP.WorkDoneProgressOptions
+---@field public commands string[] The commands to be executed on the server
+
+---@class cmp.kit.LSP.SemanticTokensLegend
+---@field public tokenTypes string[] The token types a server uses.
+---@field public tokenModifiers string[] The token modifiers a server uses.
+
+---@class cmp.kit.LSP.OptionalVersionedTextDocumentIdentifier : cmp.kit.LSP.TextDocumentIdentifier
+---@field public version (integer | nil) The version number of this document. If a versioned text document identifier<br>is sent from the server to the client and the file is not open in the editor<br>(the server has not received an open notification before) the server can send<br>`null` to indicate that the version is unknown and the content on disk is the<br>truth (as specified with document content ownership).
+
+---@class cmp.kit.LSP.AnnotatedTextEdit : cmp.kit.LSP.TextEdit
+---@field public annotationId cmp.kit.LSP.ChangeAnnotationIdentifier The actual identifier of the change annotation
+
+---@class cmp.kit.LSP.ResourceOperation
+---@field public kind string The resource operation kind.
+---@field public annotationId? cmp.kit.LSP.ChangeAnnotationIdentifier An optional annotation identifier describing the operation.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.CreateFileOptions
+---@field public overwrite? boolean Overwrite existing file. Overwrite wins over `ignoreIfExists`
+---@field public ignoreIfExists? boolean Ignore if exists.
+
+---@class cmp.kit.LSP.RenameFileOptions
+---@field public overwrite? boolean Overwrite target if existing. Overwrite wins over `ignoreIfExists`
+---@field public ignoreIfExists? boolean Ignores if target exists.
+
+---@class cmp.kit.LSP.DeleteFileOptions
+---@field public recursive? boolean Delete the content recursively if a folder is denoted.
+---@field public ignoreIfNotExists? boolean Ignore the operation if the file doesn't exist.
+
+---@class cmp.kit.LSP.FileOperationPattern
+---@field public glob string The glob pattern to match. Glob patterns can have the following syntax:<br>- `*` to match one or more characters in a path segment<br>- `?` to match on one character in a path segment<br>- `**` to match any number of path segments, including none<br>- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)<br>- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)<br>- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+---@field public matches? cmp.kit.LSP.FileOperationPatternKind Whether to match files or folders with this pattern.<br><br>Matches both if undefined.
+---@field public options? cmp.kit.LSP.FileOperationPatternOptions Additional options used during matching.
+
+---@class cmp.kit.LSP.WorkspaceFullDocumentDiagnosticReport : cmp.kit.LSP.FullDocumentDiagnosticReport
+---@field public uri string The URI for which diagnostic information is reported.
+---@field public version (integer | nil) The version number for which the diagnostics are reported.<br>If the document is not marked as open `null` can be provided.
+
+---@class cmp.kit.LSP.WorkspaceUnchangedDocumentDiagnosticReport : cmp.kit.LSP.UnchangedDocumentDiagnosticReport
+---@field public uri string The URI for which diagnostic information is reported.
+---@field public version (integer | nil) The version number for which the diagnostics are reported.<br>If the document is not marked as open `null` can be provided.
+
+---@class cmp.kit.LSP.LSPObject
+
+---@class cmp.kit.LSP.NotebookCell
+---@field public kind cmp.kit.LSP.NotebookCellKind The cell's kind
+---@field public document string The URI of the cell's text document<br>content.
+---@field public metadata? cmp.kit.LSP.LSPObject Additional metadata stored with the cell.<br><br>Note: should always be an object literal (e.g. LSPObject)
+---@field public executionSummary? cmp.kit.LSP.ExecutionSummary Additional execution summary information<br>if supported by the client.
+
+---@class cmp.kit.LSP.NotebookCellArrayChange
+---@field public start integer The start oftest of the cell that changed.
+---@field public deleteCount integer The deleted cells
+---@field public cells? cmp.kit.LSP.NotebookCell[] The new cells, if any
+
+---@class cmp.kit.LSP.ClientCapabilities
+---@field public workspace? cmp.kit.LSP.WorkspaceClientCapabilities Workspace specific client capabilities.
+---@field public textDocument? cmp.kit.LSP.TextDocumentClientCapabilities Text document specific client capabilities.
+---@field public notebookDocument? cmp.kit.LSP.NotebookDocumentClientCapabilities Capabilities specific to the notebook document support.<br><br>@since 3.17.0
+---@field public window? cmp.kit.LSP.WindowClientCapabilities Window specific client capabilities.
+---@field public general? cmp.kit.LSP.GeneralClientCapabilities General client capabilities.<br><br>@since 3.16.0
+---@field public experimental? cmp.kit.LSP.LSPAny Experimental client capabilities.
+
+---@class cmp.kit.LSP.TextDocumentSyncOptions
+---@field public openClose? boolean Open and close notifications are sent to the server. If omitted open close notification should not<br>be sent.
+---@field public change? cmp.kit.LSP.TextDocumentSyncKind Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full<br>and TextDocumentSyncKind.Incremental. If omitted it defaults to TextDocumentSyncKind.None.
+---@field public willSave? boolean If present will save notifications are sent to the server. If omitted the notification should not be<br>sent.
+---@field public willSaveWaitUntil? boolean If present will save wait until requests are sent to the server. If omitted the request should not be<br>sent.
+---@field public save? (boolean | cmp.kit.LSP.SaveOptions) If present save notifications are sent to the server. If omitted the notification should not be<br>sent.
+
+---@class cmp.kit.LSP.NotebookDocumentSyncOptions
+---@field public notebookSelector ({ notebook: (string | cmp.kit.LSP.NotebookDocumentFilter), cells?: { language: string }[] } | { notebook?: (string | cmp.kit.LSP.NotebookDocumentFilter), cells: { language: string }[] })[] The notebooks to be synced
+---@field public save? boolean Whether save notification should be forwarded to<br>the server. Will only be honored if mode === `notebook`.
+
+---@class cmp.kit.LSP.NotebookDocumentSyncRegistrationOptions : cmp.kit.LSP.NotebookDocumentSyncOptions, cmp.kit.LSP.StaticRegistrationOptions
+
+---@class cmp.kit.LSP.WorkspaceFoldersServerCapabilities
+---@field public supported? boolean The server has support for workspace folders
+---@field public changeNotifications? (string | boolean) Whether the server wants to receive workspace folder<br>change notifications.<br><br>If a string is provided the string is treated as an ID<br>under which the notification is registered on the client<br>side. The ID can be used to unregister for these events<br>using the `client/unregisterCapability` request.
+
+---@class cmp.kit.LSP.FileOperationOptions
+---@field public didCreate? cmp.kit.LSP.FileOperationRegistrationOptions The server is interested in receiving didCreateFiles notifications.
+---@field public willCreate? cmp.kit.LSP.FileOperationRegistrationOptions The server is interested in receiving willCreateFiles requests.
+---@field public didRename? cmp.kit.LSP.FileOperationRegistrationOptions The server is interested in receiving didRenameFiles notifications.
+---@field public willRename? cmp.kit.LSP.FileOperationRegistrationOptions The server is interested in receiving willRenameFiles requests.
+---@field public didDelete? cmp.kit.LSP.FileOperationRegistrationOptions The server is interested in receiving didDeleteFiles file notifications.
+---@field public willDelete? cmp.kit.LSP.FileOperationRegistrationOptions The server is interested in receiving willDeleteFiles file requests.
+
+---@class cmp.kit.LSP.CodeDescription
+---@field public href string An URI to open with more information about the diagnostic error.
+
+---@class cmp.kit.LSP.DiagnosticRelatedInformation
+---@field public location cmp.kit.LSP.Location The location of this related diagnostic information.
+---@field public message string The message of this related diagnostic information.
+
+---@class cmp.kit.LSP.ParameterInformation
+---@field public label (string | (integer | integer)[]) The label of this parameter information.<br><br>Either a string or an inclusive start and exclusive end offsets within its containing<br>signature label. (see SignatureInformation.label). The offsets are based on a UTF-16<br>string representation as `Position` and `Range` does.<br><br>*Note*: a label of type string should be a substring of its containing signature label.<br>Its intended use case is to highlight the parameter label part in the `SignatureInformation.label`.
+---@field public documentation? (string | cmp.kit.LSP.MarkupContent) The human-readable doc-comment of this parameter. Will be shown<br>in the UI but can be omitted.
+
+---@class cmp.kit.LSP.NotebookCellTextDocumentFilter
+---@field public notebook (string | cmp.kit.LSP.NotebookDocumentFilter) A filter that matches against the notebook<br>containing the notebook cell. If a string<br>value is provided it matches against the<br>notebook type. '*' matches every notebook.
+---@field public language? string A language id like `python`.<br><br>Will be matched against the language id of the<br>notebook cell document. '*' matches every language.
+
+---@class cmp.kit.LSP.FileOperationPatternOptions
+---@field public ignoreCase? boolean The pattern should be matched ignoring casing.
+
+---@class cmp.kit.LSP.ExecutionSummary
+---@field public executionOrder integer A strict monotonically increasing value<br>indicating the execution order of a cell<br>inside a notebook.
+---@field public success? boolean Whether the execution was successful or<br>not if known by the client.
+
+---@class cmp.kit.LSP.WorkspaceClientCapabilities
+---@field public applyEdit? boolean The client supports applying batch edits<br>to the workspace by supporting the request<br>'workspace/applyEdit'
+---@field public workspaceEdit? cmp.kit.LSP.WorkspaceEditClientCapabilities Capabilities specific to `WorkspaceEdit`s.
+---@field public didChangeConfiguration? cmp.kit.LSP.DidChangeConfigurationClientCapabilities Capabilities specific to the `workspace/didChangeConfiguration` notification.
+---@field public didChangeWatchedFiles? cmp.kit.LSP.DidChangeWatchedFilesClientCapabilities Capabilities specific to the `workspace/didChangeWatchedFiles` notification.
+---@field public symbol? cmp.kit.LSP.WorkspaceSymbolClientCapabilities Capabilities specific to the `workspace/symbol` request.
+---@field public executeCommand? cmp.kit.LSP.ExecuteCommandClientCapabilities Capabilities specific to the `workspace/executeCommand` request.
+---@field public workspaceFolders? boolean The client has support for workspace folders.<br><br>@since 3.6.0
+---@field public configuration? boolean The client supports `workspace/configuration` requests.<br><br>@since 3.6.0
+---@field public semanticTokens? cmp.kit.LSP.SemanticTokensWorkspaceClientCapabilities Capabilities specific to the semantic token requests scoped to the<br>workspace.<br><br>@since 3.16.0.
+---@field public codeLens? cmp.kit.LSP.CodeLensWorkspaceClientCapabilities Capabilities specific to the code lens requests scoped to the<br>workspace.<br><br>@since 3.16.0.
+---@field public fileOperations? cmp.kit.LSP.FileOperationClientCapabilities The client has support for file notifications/requests for user operations on files.<br><br>Since 3.16.0
+---@field public inlineValue? cmp.kit.LSP.InlineValueWorkspaceClientCapabilities Capabilities specific to the inline values requests scoped to the<br>workspace.<br><br>@since 3.17.0.
+---@field public inlayHint? cmp.kit.LSP.InlayHintWorkspaceClientCapabilities Capabilities specific to the inlay hint requests scoped to the<br>workspace.<br><br>@since 3.17.0.
+---@field public diagnostics? cmp.kit.LSP.DiagnosticWorkspaceClientCapabilities Capabilities specific to the diagnostic requests scoped to the<br>workspace.<br><br>@since 3.17.0.
+
+---@class cmp.kit.LSP.TextDocumentClientCapabilities
+---@field public synchronization? cmp.kit.LSP.TextDocumentSyncClientCapabilities Defines which synchronization capabilities the client supports.
+---@field public completion? cmp.kit.LSP.CompletionClientCapabilities Capabilities specific to the `textDocument/completion` request.
+---@field public hover? cmp.kit.LSP.HoverClientCapabilities Capabilities specific to the `textDocument/hover` request.
+---@field public signatureHelp? cmp.kit.LSP.SignatureHelpClientCapabilities Capabilities specific to the `textDocument/signatureHelp` request.
+---@field public declaration? cmp.kit.LSP.DeclarationClientCapabilities Capabilities specific to the `textDocument/declaration` request.<br><br>@since 3.14.0
+---@field public definition? cmp.kit.LSP.DefinitionClientCapabilities Capabilities specific to the `textDocument/definition` request.
+---@field public typeDefinition? cmp.kit.LSP.TypeDefinitionClientCapabilities Capabilities specific to the `textDocument/typeDefinition` request.<br><br>@since 3.6.0
+---@field public implementation? cmp.kit.LSP.ImplementationClientCapabilities Capabilities specific to the `textDocument/implementation` request.<br><br>@since 3.6.0
+---@field public references? cmp.kit.LSP.ReferenceClientCapabilities Capabilities specific to the `textDocument/references` request.
+---@field public documentHighlight? cmp.kit.LSP.DocumentHighlightClientCapabilities Capabilities specific to the `textDocument/documentHighlight` request.
+---@field public documentSymbol? cmp.kit.LSP.DocumentSymbolClientCapabilities Capabilities specific to the `textDocument/documentSymbol` request.
+---@field public codeAction? cmp.kit.LSP.CodeActionClientCapabilities Capabilities specific to the `textDocument/codeAction` request.
+---@field public codeLens? cmp.kit.LSP.CodeLensClientCapabilities Capabilities specific to the `textDocument/codeLens` request.
+---@field public documentLink? cmp.kit.LSP.DocumentLinkClientCapabilities Capabilities specific to the `textDocument/documentLink` request.
+---@field public colorProvider? cmp.kit.LSP.DocumentColorClientCapabilities Capabilities specific to the `textDocument/documentColor` and the<br>`textDocument/colorPresentation` request.<br><br>@since 3.6.0
+---@field public formatting? cmp.kit.LSP.DocumentFormattingClientCapabilities Capabilities specific to the `textDocument/formatting` request.
+---@field public rangeFormatting? cmp.kit.LSP.DocumentRangeFormattingClientCapabilities Capabilities specific to the `textDocument/rangeFormatting` request.
+---@field public onTypeFormatting? cmp.kit.LSP.DocumentOnTypeFormattingClientCapabilities Capabilities specific to the `textDocument/onTypeFormatting` request.
+---@field public rename? cmp.kit.LSP.RenameClientCapabilities Capabilities specific to the `textDocument/rename` request.
+---@field public foldingRange? cmp.kit.LSP.FoldingRangeClientCapabilities Capabilities specific to the `textDocument/foldingRange` request.<br><br>@since 3.10.0
+---@field public selectionRange? cmp.kit.LSP.SelectionRangeClientCapabilities Capabilities specific to the `textDocument/selectionRange` request.<br><br>@since 3.15.0
+---@field public publishDiagnostics? cmp.kit.LSP.PublishDiagnosticsClientCapabilities Capabilities specific to the `textDocument/publishDiagnostics` notification.
+---@field public callHierarchy? cmp.kit.LSP.CallHierarchyClientCapabilities Capabilities specific to the various call hierarchy requests.<br><br>@since 3.16.0
+---@field public semanticTokens? cmp.kit.LSP.SemanticTokensClientCapabilities Capabilities specific to the various semantic token request.<br><br>@since 3.16.0
+---@field public linkedEditingRange? cmp.kit.LSP.LinkedEditingRangeClientCapabilities Capabilities specific to the `textDocument/linkedEditingRange` request.<br><br>@since 3.16.0
+---@field public moniker? cmp.kit.LSP.MonikerClientCapabilities Client capabilities specific to the `textDocument/moniker` request.<br><br>@since 3.16.0
+---@field public typeHierarchy? cmp.kit.LSP.TypeHierarchyClientCapabilities Capabilities specific to the various type hierarchy requests.<br><br>@since 3.17.0
+---@field public inlineValue? cmp.kit.LSP.InlineValueClientCapabilities Capabilities specific to the `textDocument/inlineValue` request.<br><br>@since 3.17.0
+---@field public inlayHint? cmp.kit.LSP.InlayHintClientCapabilities Capabilities specific to the `textDocument/inlayHint` request.<br><br>@since 3.17.0
+---@field public diagnostic? cmp.kit.LSP.DiagnosticClientCapabilities Capabilities specific to the diagnostic pull model.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.NotebookDocumentClientCapabilities
+---@field public synchronization cmp.kit.LSP.NotebookDocumentSyncClientCapabilities Capabilities specific to notebook document synchronization<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.WindowClientCapabilities
+---@field public workDoneProgress? boolean It indicates whether the client supports server initiated<br>progress using the `window/workDoneProgress/create` request.<br><br>The capability also controls Whether client supports handling<br>of progress notifications. If set servers are allowed to report a<br>`workDoneProgress` property in the request specific server<br>capabilities.<br><br>@since 3.15.0
+---@field public showMessage? cmp.kit.LSP.ShowMessageRequestClientCapabilities Capabilities specific to the showMessage request.<br><br>@since 3.16.0
+---@field public showDocument? cmp.kit.LSP.ShowDocumentClientCapabilities Capabilities specific to the showDocument request.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.GeneralClientCapabilities
+---@field public staleRequestSupport? cmp.kit.LSP.GeneralClientCapabilities.staleRequestSupport Client capability that signals how the client<br>handles stale requests (e.g. a request<br>for which the client will not process the response<br>anymore since the information is outdated).<br><br>@since 3.17.0
+---@field public regularExpressions? cmp.kit.LSP.RegularExpressionsClientCapabilities Client capabilities specific to regular expressions.<br><br>@since 3.16.0
+---@field public markdown? cmp.kit.LSP.MarkdownClientCapabilities Client capabilities specific to the client's markdown parser.<br><br>@since 3.16.0
+---@field public positionEncodings? cmp.kit.LSP.PositionEncodingKind[] The position encodings supported by the client. Client and server<br>have to agree on the same position encoding to ensure that offsets<br>(e.g. character position in a line) are interpreted the same on both<br>sides.<br><br>To keep the protocol backwards compatible the following applies: if<br>the value 'utf-16' is missing from the array of position encodings<br>servers can assume that the client supports UTF-16. UTF-16 is<br>therefore a mandatory encoding.<br><br>If omitted it defaults to ['utf-16'].<br><br>Implementation considerations: since the conversion from one encoding<br>into another requires the content of the file / line the conversion<br>is best done where the file is read which is usually on the server<br>side.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.GeneralClientCapabilities.staleRequestSupport
+---@field public cancel boolean The client will actively cancel the request.
+---@field public retryOnContentModified string[] The list of requests for which the client<br>will retry the request if it receives a<br>response with error code `ContentModified`
+
+---@class cmp.kit.LSP.RelativePattern
+---@field public baseUri (cmp.kit.LSP.WorkspaceFolder | string) A workspace folder or a base URI to which this pattern will be matched<br>against relatively.
+---@field public pattern cmp.kit.LSP.Pattern The actual glob pattern;
+
+---@class cmp.kit.LSP.WorkspaceEditClientCapabilities
+---@field public documentChanges? boolean The client supports versioned document changes in `WorkspaceEdit`s
+---@field public resourceOperations? cmp.kit.LSP.ResourceOperationKind[] The resource operations the client supports. Clients should at least<br>support 'create', 'rename' and 'delete' files and folders.<br><br>@since 3.13.0
+---@field public failureHandling? cmp.kit.LSP.FailureHandlingKind The failure handling strategy of a client if applying the workspace edit<br>fails.<br><br>@since 3.13.0
+---@field public normalizesLineEndings? boolean Whether the client normalizes line endings to the client specific<br>setting.<br>If set to `true` the client will normalize line ending characters<br>in a workspace edit to the client-specified new line<br>character.<br><br>@since 3.16.0
+---@field public changeAnnotationSupport? cmp.kit.LSP.WorkspaceEditClientCapabilities.changeAnnotationSupport Whether the client in general supports change annotations on text edits,<br>create file, rename file and delete file changes.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.WorkspaceEditClientCapabilities.changeAnnotationSupport
+---@field public groupsOnLabel? boolean Whether the client groups edits with equal labels into tree nodes,<br>for instance all edits labelled with "Changes in Strings" would<br>be a tree node.
+
+---@class cmp.kit.LSP.DidChangeConfigurationClientCapabilities
+---@field public dynamicRegistration? boolean Did change configuration notification supports dynamic registration.
+
+---@class cmp.kit.LSP.DidChangeWatchedFilesClientCapabilities
+---@field public dynamicRegistration? boolean Did change watched files notification supports dynamic registration. Please note<br>that the current protocol doesn't support static configuration for file changes<br>from the server side.
+---@field public relativePatternSupport? boolean Whether the client has support for {@link  RelativePattern relative pattern}<br>or not.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.WorkspaceSymbolClientCapabilities
+---@field public dynamicRegistration? boolean Symbol request supports dynamic registration.
+---@field public symbolKind? cmp.kit.LSP.WorkspaceSymbolClientCapabilities.symbolKind Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
+---@field public tagSupport? cmp.kit.LSP.WorkspaceSymbolClientCapabilities.tagSupport The client supports tags on `SymbolInformation`.<br>Clients supporting tags have to handle unknown tags gracefully.<br><br>@since 3.16.0
+---@field public resolveSupport? cmp.kit.LSP.WorkspaceSymbolClientCapabilities.resolveSupport The client support partial workspace symbols. The client will send the<br>request `workspaceSymbol/resolve` to the server to resolve additional<br>properties.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.WorkspaceSymbolClientCapabilities.symbolKind
+---@field public valueSet? cmp.kit.LSP.SymbolKind[] The symbol kind values the client supports. When this<br>property exists the client also guarantees that it will<br>handle values outside its set gracefully and falls back<br>to a default value when unknown.<br><br>If this property is not present the client only supports<br>the symbol kinds from `File` to `Array` as defined in<br>the initial version of the protocol.
+
+---@class cmp.kit.LSP.WorkspaceSymbolClientCapabilities.tagSupport
+---@field public valueSet cmp.kit.LSP.SymbolTag[] The tags supported by the client.
+
+---@class cmp.kit.LSP.WorkspaceSymbolClientCapabilities.resolveSupport
+---@field public properties string[] The properties that a client can resolve lazily. Usually<br>`location.range`
+
+---@class cmp.kit.LSP.ExecuteCommandClientCapabilities
+---@field public dynamicRegistration? boolean Execute command supports dynamic registration.
+
+---@class cmp.kit.LSP.SemanticTokensWorkspaceClientCapabilities
+---@field public refreshSupport? boolean Whether the client implementation supports a refresh request sent from<br>the server to the client.<br><br>Note that this event is global and will force the client to refresh all<br>semantic tokens currently shown. It should be used with absolute care<br>and is useful for situation where a server for example detects a project<br>wide change that requires such a calculation.
+
+---@class cmp.kit.LSP.CodeLensWorkspaceClientCapabilities
+---@field public refreshSupport? boolean Whether the client implementation supports a refresh request sent from the<br>server to the client.<br><br>Note that this event is global and will force the client to refresh all<br>code lenses currently shown. It should be used with absolute care and is<br>useful for situation where a server for example detect a project wide<br>change that requires such a calculation.
+
+---@class cmp.kit.LSP.FileOperationClientCapabilities
+---@field public dynamicRegistration? boolean Whether the client supports dynamic registration for file requests/notifications.
+---@field public didCreate? boolean The client has support for sending didCreateFiles notifications.
+---@field public willCreate? boolean The client has support for sending willCreateFiles requests.
+---@field public didRename? boolean The client has support for sending didRenameFiles notifications.
+---@field public willRename? boolean The client has support for sending willRenameFiles requests.
+---@field public didDelete? boolean The client has support for sending didDeleteFiles notifications.
+---@field public willDelete? boolean The client has support for sending willDeleteFiles requests.
+
+---@class cmp.kit.LSP.InlineValueWorkspaceClientCapabilities
+---@field public refreshSupport? boolean Whether the client implementation supports a refresh request sent from the<br>server to the client.<br><br>Note that this event is global and will force the client to refresh all<br>inline values currently shown. It should be used with absolute care and is<br>useful for situation where a server for example detects a project wide<br>change that requires such a calculation.
+
+---@class cmp.kit.LSP.InlayHintWorkspaceClientCapabilities
+---@field public refreshSupport? boolean Whether the client implementation supports a refresh request sent from<br>the server to the client.<br><br>Note that this event is global and will force the client to refresh all<br>inlay hints currently shown. It should be used with absolute care and<br>is useful for situation where a server for example detects a project wide<br>change that requires such a calculation.
+
+---@class cmp.kit.LSP.DiagnosticWorkspaceClientCapabilities
+---@field public refreshSupport? boolean Whether the client implementation supports a refresh request sent from<br>the server to the client.<br><br>Note that this event is global and will force the client to refresh all<br>pulled diagnostics currently shown. It should be used with absolute care and<br>is useful for situation where a server for example detects a project wide<br>change that requires such a calculation.
+
+---@class cmp.kit.LSP.TextDocumentSyncClientCapabilities
+---@field public dynamicRegistration? boolean Whether text document synchronization supports dynamic registration.
+---@field public willSave? boolean The client supports sending will save notifications.
+---@field public willSaveWaitUntil? boolean The client supports sending a will save request and<br>waits for a response providing text edits which will<br>be applied to the document before it is saved.
+---@field public didSave? boolean The client supports did save notifications.
+
+---@class cmp.kit.LSP.CompletionClientCapabilities
+---@field public dynamicRegistration? boolean Whether completion supports dynamic registration.
+---@field public completionItem? cmp.kit.LSP.CompletionClientCapabilities.completionItem The client supports the following `CompletionItem` specific<br>capabilities.
+---@field public completionItemKind? cmp.kit.LSP.CompletionClientCapabilities.completionItemKind
+---@field public insertTextMode? cmp.kit.LSP.InsertTextMode Defines how the client handles whitespace and indentation<br>when accepting a completion item that uses multi line<br>text in either `insertText` or `textEdit`.<br><br>@since 3.17.0
+---@field public contextSupport? boolean The client supports to send additional context information for a<br>`textDocument/completion` request.
+---@field public completionList? cmp.kit.LSP.CompletionClientCapabilities.completionList The client supports the following `CompletionList` specific<br>capabilities.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.CompletionClientCapabilities.completionItem
+---@field public snippetSupport? boolean Client supports snippets as insert text.<br><br>A snippet can define tab stops and placeholders with `$1`, `$2`<br>and `${3:foo}`. `$0` defines the final tab stop, it defaults to<br>the end of the snippet. Placeholders with equal identifiers are linked,<br>that is typing in one will update others too.
+---@field public commitCharactersSupport? boolean Client supports commit characters on a completion item.
+---@field public documentationFormat? cmp.kit.LSP.MarkupKind[] Client supports the following content formats for the documentation<br>property. The order describes the preferred format of the client.
+---@field public deprecatedSupport? boolean Client supports the deprecated property on a completion item.
+---@field public preselectSupport? boolean Client supports the preselect property on a completion item.
+---@field public tagSupport? cmp.kit.LSP.CompletionClientCapabilities.completionItem.tagSupport Client supports the tag property on a completion item. Clients supporting<br>tags have to handle unknown tags gracefully. Clients especially need to<br>preserve unknown tags when sending a completion item back to the server in<br>a resolve call.<br><br>@since 3.15.0
+---@field public insertReplaceSupport? boolean Client support insert replace edit to control different behavior if a<br>completion item is inserted in the text or should replace text.<br><br>@since 3.16.0
+---@field public resolveSupport? cmp.kit.LSP.CompletionClientCapabilities.completionItem.resolveSupport Indicates which properties a client can resolve lazily on a completion<br>item. Before version 3.16.0 only the predefined properties `documentation`<br>and `details` could be resolved lazily.<br><br>@since 3.16.0
+---@field public insertTextModeSupport? cmp.kit.LSP.CompletionClientCapabilities.completionItem.insertTextModeSupport The client supports the `insertTextMode` property on<br>a completion item to override the whitespace handling mode<br>as defined by the client (see `insertTextMode`).<br><br>@since 3.16.0
+---@field public labelDetailsSupport? boolean The client has support for completion item label<br>details (see also `CompletionItemLabelDetails`).<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.CompletionClientCapabilities.completionItem.tagSupport
+---@field public valueSet cmp.kit.LSP.CompletionItemTag[] The tags supported by the client.
+
+---@class cmp.kit.LSP.CompletionClientCapabilities.completionItem.resolveSupport
+---@field public properties string[] The properties that a client can resolve lazily.
+
+---@class cmp.kit.LSP.CompletionClientCapabilities.completionItem.insertTextModeSupport
+---@field public valueSet cmp.kit.LSP.InsertTextMode[]
+
+---@class cmp.kit.LSP.CompletionClientCapabilities.completionItemKind
+---@field public valueSet? cmp.kit.LSP.CompletionItemKind[] The completion item kind values the client supports. When this<br>property exists the client also guarantees that it will<br>handle values outside its set gracefully and falls back<br>to a default value when unknown.<br><br>If this property is not present the client only supports<br>the completion items kinds from `Text` to `Reference` as defined in<br>the initial version of the protocol.
+
+---@class cmp.kit.LSP.CompletionClientCapabilities.completionList
+---@field public itemDefaults? string[] The client supports the following itemDefaults on<br>a completion list.<br><br>The value lists the supported property names of the<br>`CompletionList.itemDefaults` object. If omitted<br>no properties are supported.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.HoverClientCapabilities
+---@field public dynamicRegistration? boolean Whether hover supports dynamic registration.
+---@field public contentFormat? cmp.kit.LSP.MarkupKind[] Client supports the following content formats for the content<br>property. The order describes the preferred format of the client.
+
+---@class cmp.kit.LSP.SignatureHelpClientCapabilities
+---@field public dynamicRegistration? boolean Whether signature help supports dynamic registration.
+---@field public signatureInformation? cmp.kit.LSP.SignatureHelpClientCapabilities.signatureInformation The client supports the following `SignatureInformation`<br>specific properties.
+---@field public contextSupport? boolean The client supports to send additional context information for a<br>`textDocument/signatureHelp` request. A client that opts into<br>contextSupport will also support the `retriggerCharacters` on<br>`SignatureHelpOptions`.<br><br>@since 3.15.0
+
+---@class cmp.kit.LSP.SignatureHelpClientCapabilities.signatureInformation
+---@field public documentationFormat? cmp.kit.LSP.MarkupKind[] Client supports the following content formats for the documentation<br>property. The order describes the preferred format of the client.
+---@field public parameterInformation? cmp.kit.LSP.SignatureHelpClientCapabilities.signatureInformation.parameterInformation Client capabilities specific to parameter information.
+---@field public activeParameterSupport? boolean The client supports the `activeParameter` property on `SignatureInformation`<br>literal.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.SignatureHelpClientCapabilities.signatureInformation.parameterInformation
+---@field public labelOffsetSupport? boolean The client supports processing label offsets instead of a<br>simple label string.<br><br>@since 3.14.0
+
+---@class cmp.kit.LSP.DeclarationClientCapabilities
+---@field public dynamicRegistration? boolean Whether declaration supports dynamic registration. If this is set to `true`<br>the client supports the new `DeclarationRegistrationOptions` return value<br>for the corresponding server capability as well.
+---@field public linkSupport? boolean The client supports additional metadata in the form of declaration links.
+
+---@class cmp.kit.LSP.DefinitionClientCapabilities
+---@field public dynamicRegistration? boolean Whether definition supports dynamic registration.
+---@field public linkSupport? boolean The client supports additional metadata in the form of definition links.<br><br>@since 3.14.0
+
+---@class cmp.kit.LSP.TypeDefinitionClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration. If this is set to `true`<br>the client supports the new `TypeDefinitionRegistrationOptions` return value<br>for the corresponding server capability as well.
+---@field public linkSupport? boolean The client supports additional metadata in the form of definition links.<br><br>Since 3.14.0
+
+---@class cmp.kit.LSP.ImplementationClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration. If this is set to `true`<br>the client supports the new `ImplementationRegistrationOptions` return value<br>for the corresponding server capability as well.
+---@field public linkSupport? boolean The client supports additional metadata in the form of definition links.<br><br>@since 3.14.0
+
+---@class cmp.kit.LSP.ReferenceClientCapabilities
+---@field public dynamicRegistration? boolean Whether references supports dynamic registration.
+
+---@class cmp.kit.LSP.DocumentHighlightClientCapabilities
+---@field public dynamicRegistration? boolean Whether document highlight supports dynamic registration.
+
+---@class cmp.kit.LSP.DocumentSymbolClientCapabilities
+---@field public dynamicRegistration? boolean Whether document symbol supports dynamic registration.
+---@field public symbolKind? cmp.kit.LSP.DocumentSymbolClientCapabilities.symbolKind Specific capabilities for the `SymbolKind` in the<br>`textDocument/documentSymbol` request.
+---@field public hierarchicalDocumentSymbolSupport? boolean The client supports hierarchical document symbols.
+---@field public tagSupport? cmp.kit.LSP.DocumentSymbolClientCapabilities.tagSupport The client supports tags on `SymbolInformation`. Tags are supported on<br>`DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.<br>Clients supporting tags have to handle unknown tags gracefully.<br><br>@since 3.16.0
+---@field public labelSupport? boolean The client supports an additional label presented in the UI when<br>registering a document symbol provider.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.DocumentSymbolClientCapabilities.symbolKind
+---@field public valueSet? cmp.kit.LSP.SymbolKind[] The symbol kind values the client supports. When this<br>property exists the client also guarantees that it will<br>handle values outside its set gracefully and falls back<br>to a default value when unknown.<br><br>If this property is not present the client only supports<br>the symbol kinds from `File` to `Array` as defined in<br>the initial version of the protocol.
+
+---@class cmp.kit.LSP.DocumentSymbolClientCapabilities.tagSupport
+---@field public valueSet cmp.kit.LSP.SymbolTag[] The tags supported by the client.
+
+---@class cmp.kit.LSP.CodeActionClientCapabilities
+---@field public dynamicRegistration? boolean Whether code action supports dynamic registration.
+---@field public codeActionLiteralSupport? cmp.kit.LSP.CodeActionClientCapabilities.codeActionLiteralSupport The client support code action literals of type `CodeAction` as a valid<br>response of the `textDocument/codeAction` request. If the property is not<br>set the request can only return `Command` literals.<br><br>@since 3.8.0
+---@field public isPreferredSupport? boolean Whether code action supports the `isPreferred` property.<br><br>@since 3.15.0
+---@field public disabledSupport? boolean Whether code action supports the `disabled` property.<br><br>@since 3.16.0
+---@field public dataSupport? boolean Whether code action supports the `data` property which is<br>preserved between a `textDocument/codeAction` and a<br>`codeAction/resolve` request.<br><br>@since 3.16.0
+---@field public resolveSupport? cmp.kit.LSP.CodeActionClientCapabilities.resolveSupport Whether the client supports resolving additional code action<br>properties via a separate `codeAction/resolve` request.<br><br>@since 3.16.0
+---@field public honorsChangeAnnotations? boolean Whether the client honors the change annotations in<br>text edits and resource operations returned via the<br>`CodeAction#edit` property by for example presenting<br>the workspace edit in the user interface and asking<br>for confirmation.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.CodeActionClientCapabilities.codeActionLiteralSupport
+---@field public codeActionKind cmp.kit.LSP.CodeActionClientCapabilities.codeActionLiteralSupport.codeActionKind The code action kind is support with the following value<br>set.
+
+---@class cmp.kit.LSP.CodeActionClientCapabilities.codeActionLiteralSupport.codeActionKind
+---@field public valueSet cmp.kit.LSP.CodeActionKind[] The code action kind values the client supports. When this<br>property exists the client also guarantees that it will<br>handle values outside its set gracefully and falls back<br>to a default value when unknown.
+
+---@class cmp.kit.LSP.CodeActionClientCapabilities.resolveSupport
+---@field public properties string[] The properties that a client can resolve lazily.
+
+---@class cmp.kit.LSP.CodeLensClientCapabilities
+---@field public dynamicRegistration? boolean Whether code lens supports dynamic registration.
+
+---@class cmp.kit.LSP.DocumentLinkClientCapabilities
+---@field public dynamicRegistration? boolean Whether document link supports dynamic registration.
+---@field public tooltipSupport? boolean Whether the client supports the `tooltip` property on `DocumentLink`.<br><br>@since 3.15.0
+
+---@class cmp.kit.LSP.DocumentColorClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration. If this is set to `true`<br>the client supports the new `DocumentColorRegistrationOptions` return value<br>for the corresponding server capability as well.
+
+---@class cmp.kit.LSP.DocumentFormattingClientCapabilities
+---@field public dynamicRegistration? boolean Whether formatting supports dynamic registration.
+
+---@class cmp.kit.LSP.DocumentRangeFormattingClientCapabilities
+---@field public dynamicRegistration? boolean Whether range formatting supports dynamic registration.
+
+---@class cmp.kit.LSP.DocumentOnTypeFormattingClientCapabilities
+---@field public dynamicRegistration? boolean Whether on type formatting supports dynamic registration.
+
+---@class cmp.kit.LSP.RenameClientCapabilities
+---@field public dynamicRegistration? boolean Whether rename supports dynamic registration.
+---@field public prepareSupport? boolean Client supports testing for validity of rename operations<br>before execution.<br><br>@since 3.12.0
+---@field public prepareSupportDefaultBehavior? cmp.kit.LSP.PrepareSupportDefaultBehavior Client supports the default behavior result.<br><br>The value indicates the default behavior used by the<br>client.<br><br>@since 3.16.0
+---@field public honorsChangeAnnotations? boolean Whether the client honors the change annotations in<br>text edits and resource operations returned via the<br>rename request's workspace edit by for example presenting<br>the workspace edit in the user interface and asking<br>for confirmation.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.FoldingRangeClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration for folding range<br>providers. If this is set to `true` the client supports the new<br>`FoldingRangeRegistrationOptions` return value for the corresponding<br>server capability as well.
+---@field public rangeLimit? integer The maximum number of folding ranges that the client prefers to receive<br>per document. The value serves as a hint, servers are free to follow the<br>limit.
+---@field public lineFoldingOnly? boolean If set, the client signals that it only supports folding complete lines.<br>If set, client will ignore specified `startCharacter` and `endCharacter`<br>properties in a FoldingRange.
+---@field public foldingRangeKind? cmp.kit.LSP.FoldingRangeClientCapabilities.foldingRangeKind Specific options for the folding range kind.<br><br>@since 3.17.0
+---@field public foldingRange? cmp.kit.LSP.FoldingRangeClientCapabilities.foldingRange Specific options for the folding range.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.FoldingRangeClientCapabilities.foldingRangeKind
+---@field public valueSet? cmp.kit.LSP.FoldingRangeKind[] The folding range kind values the client supports. When this<br>property exists the client also guarantees that it will<br>handle values outside its set gracefully and falls back<br>to a default value when unknown.
+
+---@class cmp.kit.LSP.FoldingRangeClientCapabilities.foldingRange
+---@field public collapsedText? boolean If set, the client signals that it supports setting collapsedText on<br>folding ranges to display custom labels instead of the default text.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.SelectionRangeClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration for selection range providers. If this is set to `true`<br>the client supports the new `SelectionRangeRegistrationOptions` return value for the corresponding server<br>capability as well.
+
+---@class cmp.kit.LSP.PublishDiagnosticsClientCapabilities
+---@field public relatedInformation? boolean Whether the clients accepts diagnostics with related information.
+---@field public tagSupport? cmp.kit.LSP.PublishDiagnosticsClientCapabilities.tagSupport Client supports the tag property to provide meta data about a diagnostic.<br>Clients supporting tags have to handle unknown tags gracefully.<br><br>@since 3.15.0
+---@field public versionSupport? boolean Whether the client interprets the version property of the<br>`textDocument/publishDiagnostics` notification's parameter.<br><br>@since 3.15.0
+---@field public codeDescriptionSupport? boolean Client supports a codeDescription property<br><br>@since 3.16.0
+---@field public dataSupport? boolean Whether code action supports the `data` property which is<br>preserved between a `textDocument/publishDiagnostics` and<br>`textDocument/codeAction` request.<br><br>@since 3.16.0
+
+---@class cmp.kit.LSP.PublishDiagnosticsClientCapabilities.tagSupport
+---@field public valueSet cmp.kit.LSP.DiagnosticTag[] The tags supported by the client.
+
+---@class cmp.kit.LSP.CallHierarchyClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration. If this is set to `true`<br>the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`<br>return value for the corresponding server capability as well.
+
+---@class cmp.kit.LSP.SemanticTokensClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration. If this is set to `true`<br>the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`<br>return value for the corresponding server capability as well.
+---@field public requests cmp.kit.LSP.SemanticTokensClientCapabilities.requests Which requests the client supports and might send to the server<br>depending on the server's capability. Please note that clients might not<br>show semantic tokens or degrade some of the user experience if a range<br>or full request is advertised by the client but not provided by the<br>server. If for example the client capability `requests.full` and<br>`request.range` are both set to true but the server only provides a<br>range provider the client might not render a minimap correctly or might<br>even decide to not show any semantic tokens at all.
+---@field public tokenTypes string[] The token types that the client supports.
+---@field public tokenModifiers string[] The token modifiers that the client supports.
+---@field public formats cmp.kit.LSP.TokenFormat[] The token formats the clients supports.
+---@field public overlappingTokenSupport? boolean Whether the client supports tokens that can overlap each other.
+---@field public multilineTokenSupport? boolean Whether the client supports tokens that can span multiple lines.
+---@field public serverCancelSupport? boolean Whether the client allows the server to actively cancel a<br>semantic token request, e.g. supports returning<br>LSPErrorCodes.ServerCancelled. If a server does the client<br>needs to retrigger the request.<br><br>@since 3.17.0
+---@field public augmentsSyntaxTokens? boolean Whether the client uses semantic tokens to augment existing<br>syntax tokens. If set to `true` client side created syntax<br>tokens and semantic tokens are both used for colorization. If<br>set to `false` the client only uses the returned semantic tokens<br>for colorization.<br><br>If the value is `undefined` then the client behavior is not<br>specified.<br><br>@since 3.17.0
+
+---@class cmp.kit.LSP.SemanticTokensClientCapabilities.requests
+---@field public range? (boolean | {  }) The client will send the `textDocument/semanticTokens/range` request if<br>the server provides a corresponding handler.
+---@field public full? (boolean | { delta?: boolean }) The client will send the `textDocument/semanticTokens/full` request if<br>the server provides a corresponding handler.
+
+---@class cmp.kit.LSP.LinkedEditingRangeClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration. If this is set to `true`<br>the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`<br>return value for the corresponding server capability as well.
+
+---@class cmp.kit.LSP.MonikerClientCapabilities
+---@field public dynamicRegistration? boolean Whether moniker supports dynamic registration. If this is set to `true`<br>the client supports the new `MonikerRegistrationOptions` return value<br>for the corresponding server capability as well.
+
+---@class cmp.kit.LSP.TypeHierarchyClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration. If this is set to `true`<br>the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`<br>return value for the corresponding server capability as well.
+
+---@class cmp.kit.LSP.InlineValueClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration for inline value providers.
+
+---@class cmp.kit.LSP.InlayHintClientCapabilities
+---@field public dynamicRegistration? boolean Whether inlay hints support dynamic registration.
+---@field public resolveSupport? cmp.kit.LSP.InlayHintClientCapabilities.resolveSupport Indicates which properties a client can resolve lazily on an inlay<br>hint.
+
+---@class cmp.kit.LSP.InlayHintClientCapabilities.resolveSupport
+---@field public properties string[] The properties that a client can resolve lazily.
+
+---@class cmp.kit.LSP.DiagnosticClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration. If this is set to `true`<br>the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`<br>return value for the corresponding server capability as well.
+---@field public relatedDocumentSupport? boolean Whether the clients supports related documents for document diagnostic pulls.
+
+---@class cmp.kit.LSP.NotebookDocumentSyncClientCapabilities
+---@field public dynamicRegistration? boolean Whether implementation supports dynamic registration. If this is<br>set to `true` the client supports the new<br>`(TextDocumentRegistrationOptions & StaticRegistrationOptions)`<br>return value for the corresponding server capability as well.
+---@field public executionSummarySupport? boolean The client supports sending execution summary data per cell.
+
+---@class cmp.kit.LSP.ShowMessageRequestClientCapabilities
+---@field public messageActionItem? cmp.kit.LSP.ShowMessageRequestClientCapabilities.messageActionItem Capabilities specific to the `MessageActionItem` type.
+
+---@class cmp.kit.LSP.ShowMessageRequestClientCapabilities.messageActionItem
+---@field public additionalPropertiesSupport? boolean Whether the client supports additional attributes which<br>are preserved and send back to the server in the<br>request's response.
+
+---@class cmp.kit.LSP.ShowDocumentClientCapabilities
+---@field public support boolean The client has support for the showDocument<br>request.
+
+---@class cmp.kit.LSP.RegularExpressionsClientCapabilities
+---@field public engine string The engine's name.
+---@field public version? string The engine's version.
+
+---@class cmp.kit.LSP.MarkdownClientCapabilities
+---@field public parser string The name of the parser.
+---@field public version? string The version of the parser.
+---@field public allowedTags? string[] A list of HTML tags that the client allows / supports in<br>Markdown.<br><br>@since 3.17.0
+
+---@alias cmp.kit.LSP.TextDocumentImplementationResponse (cmp.kit.LSP.Definition | cmp.kit.LSP.DefinitionLink[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentTypeDefinitionResponse (cmp.kit.LSP.Definition | cmp.kit.LSP.DefinitionLink[] | nil)
+
+---@alias cmp.kit.LSP.WorkspaceWorkspaceFoldersResponse (cmp.kit.LSP.WorkspaceFolder[] | nil)
+
+---@alias cmp.kit.LSP.WorkspaceConfigurationResponse cmp.kit.LSP.LSPAny[]
+
+---@alias cmp.kit.LSP.TextDocumentDocumentColorResponse cmp.kit.LSP.ColorInformation[]
+
+---@alias cmp.kit.LSP.TextDocumentColorPresentationResponse cmp.kit.LSP.ColorPresentation[]
+
+---@alias cmp.kit.LSP.TextDocumentFoldingRangeResponse (cmp.kit.LSP.FoldingRange[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentDeclarationResponse (cmp.kit.LSP.Declaration | cmp.kit.LSP.DeclarationLink[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentSelectionRangeResponse (cmp.kit.LSP.SelectionRange[] | nil)
+
+---@alias cmp.kit.LSP.WindowWorkDoneProgressCreateResponse nil
+
+---@alias cmp.kit.LSP.TextDocumentPrepareCallHierarchyResponse (cmp.kit.LSP.CallHierarchyItem[] | nil)
+
+---@alias cmp.kit.LSP.CallHierarchyIncomingCallsResponse (cmp.kit.LSP.CallHierarchyIncomingCall[] | nil)
+
+---@alias cmp.kit.LSP.CallHierarchyOutgoingCallsResponse (cmp.kit.LSP.CallHierarchyOutgoingCall[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentSemanticTokensFullResponse (cmp.kit.LSP.SemanticTokens | nil)
+
+---@alias cmp.kit.LSP.TextDocumentSemanticTokensFullDeltaResponse (cmp.kit.LSP.SemanticTokens | cmp.kit.LSP.SemanticTokensDelta | nil)
+
+---@alias cmp.kit.LSP.TextDocumentSemanticTokensRangeResponse (cmp.kit.LSP.SemanticTokens | nil)
+
+---@alias cmp.kit.LSP.WorkspaceSemanticTokensRefreshResponse nil
+
+---@alias cmp.kit.LSP.WindowShowDocumentResponse cmp.kit.LSP.ShowDocumentResult
+
+---@alias cmp.kit.LSP.TextDocumentLinkedEditingRangeResponse (cmp.kit.LSP.LinkedEditingRanges | nil)
+
+---@alias cmp.kit.LSP.WorkspaceWillCreateFilesResponse (cmp.kit.LSP.WorkspaceEdit | nil)
+
+---@alias cmp.kit.LSP.WorkspaceWillRenameFilesResponse (cmp.kit.LSP.WorkspaceEdit | nil)
+
+---@alias cmp.kit.LSP.WorkspaceWillDeleteFilesResponse (cmp.kit.LSP.WorkspaceEdit | nil)
+
+---@alias cmp.kit.LSP.TextDocumentMonikerResponse (cmp.kit.LSP.Moniker[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentPrepareTypeHierarchyResponse (cmp.kit.LSP.TypeHierarchyItem[] | nil)
+
+---@alias cmp.kit.LSP.TypeHierarchySupertypesResponse (cmp.kit.LSP.TypeHierarchyItem[] | nil)
+
+---@alias cmp.kit.LSP.TypeHierarchySubtypesResponse (cmp.kit.LSP.TypeHierarchyItem[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentInlineValueResponse (cmp.kit.LSP.InlineValue[] | nil)
+
+---@alias cmp.kit.LSP.WorkspaceInlineValueRefreshResponse nil
+
+---@alias cmp.kit.LSP.TextDocumentInlayHintResponse (cmp.kit.LSP.InlayHint[] | nil)
+
+---@alias cmp.kit.LSP.InlayHintResolveResponse cmp.kit.LSP.InlayHint
+
+---@alias cmp.kit.LSP.WorkspaceInlayHintRefreshResponse nil
+
+---@alias cmp.kit.LSP.TextDocumentDiagnosticResponse cmp.kit.LSP.DocumentDiagnosticReport
+
+---@alias cmp.kit.LSP.WorkspaceDiagnosticResponse cmp.kit.LSP.WorkspaceDiagnosticReport
+
+---@alias cmp.kit.LSP.WorkspaceDiagnosticRefreshResponse nil
+
+---@alias cmp.kit.LSP.ClientRegisterCapabilityResponse nil
+
+---@alias cmp.kit.LSP.ClientUnregisterCapabilityResponse nil
+
+---@alias cmp.kit.LSP.InitializeResponse cmp.kit.LSP.InitializeResult
+
+---@alias cmp.kit.LSP.ShutdownResponse nil
+
+---@alias cmp.kit.LSP.WindowShowMessageRequestResponse (cmp.kit.LSP.MessageActionItem | nil)
+
+---@alias cmp.kit.LSP.TextDocumentWillSaveWaitUntilResponse (cmp.kit.LSP.TextEdit[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentCompletionResponse (cmp.kit.LSP.CompletionItem[] | cmp.kit.LSP.CompletionList | nil)
+
+---@alias cmp.kit.LSP.CompletionItemResolveResponse cmp.kit.LSP.CompletionItem
+
+---@alias cmp.kit.LSP.TextDocumentHoverResponse (cmp.kit.LSP.Hover | nil)
+
+---@alias cmp.kit.LSP.TextDocumentSignatureHelpResponse (cmp.kit.LSP.SignatureHelp | nil)
+
+---@alias cmp.kit.LSP.TextDocumentDefinitionResponse (cmp.kit.LSP.Definition | cmp.kit.LSP.DefinitionLink[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentReferencesResponse (cmp.kit.LSP.Location[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentDocumentHighlightResponse (cmp.kit.LSP.DocumentHighlight[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentDocumentSymbolResponse (cmp.kit.LSP.SymbolInformation[] | cmp.kit.LSP.DocumentSymbol[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentCodeActionResponse ((cmp.kit.LSP.Command | cmp.kit.LSP.CodeAction)[] | nil)
+
+---@alias cmp.kit.LSP.CodeActionResolveResponse cmp.kit.LSP.CodeAction
+
+---@alias cmp.kit.LSP.WorkspaceSymbolResponse (cmp.kit.LSP.SymbolInformation[] | cmp.kit.LSP.WorkspaceSymbol[] | nil)
+
+---@alias cmp.kit.LSP.WorkspaceSymbolResolveResponse cmp.kit.LSP.WorkspaceSymbol
+
+---@alias cmp.kit.LSP.TextDocumentCodeLensResponse (cmp.kit.LSP.CodeLens[] | nil)
+
+---@alias cmp.kit.LSP.CodeLensResolveResponse cmp.kit.LSP.CodeLens
+
+---@alias cmp.kit.LSP.WorkspaceCodeLensRefreshResponse nil
+
+---@alias cmp.kit.LSP.TextDocumentDocumentLinkResponse (cmp.kit.LSP.DocumentLink[] | nil)
+
+---@alias cmp.kit.LSP.DocumentLinkResolveResponse cmp.kit.LSP.DocumentLink
+
+---@alias cmp.kit.LSP.TextDocumentFormattingResponse (cmp.kit.LSP.TextEdit[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentRangeFormattingResponse (cmp.kit.LSP.TextEdit[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentOnTypeFormattingResponse (cmp.kit.LSP.TextEdit[] | nil)
+
+---@alias cmp.kit.LSP.TextDocumentRenameResponse (cmp.kit.LSP.WorkspaceEdit | nil)
+
+---@alias cmp.kit.LSP.TextDocumentPrepareRenameResponse (cmp.kit.LSP.PrepareRenameResult | nil)
+
+---@alias cmp.kit.LSP.WorkspaceExecuteCommandResponse (cmp.kit.LSP.LSPAny | nil)
+
+---@alias cmp.kit.LSP.WorkspaceApplyEditResponse cmp.kit.LSP.ApplyWorkspaceEditResult
+
+---@alias cmp.kit.LSP.Definition (cmp.kit.LSP.Location | cmp.kit.LSP.Location[])
+
+---@alias cmp.kit.LSP.DefinitionLink cmp.kit.LSP.LocationLink
+
+---@alias cmp.kit.LSP.LSPArray cmp.kit.LSP.LSPAny[]
+
+---@alias cmp.kit.LSP.LSPAny (cmp.kit.LSP.LSPObject | cmp.kit.LSP.LSPArray | string | integer | integer | integer | boolean | nil)
+
+---@alias cmp.kit.LSP.Declaration (cmp.kit.LSP.Location | cmp.kit.LSP.Location[])
+
+---@alias cmp.kit.LSP.DeclarationLink cmp.kit.LSP.LocationLink
+
+---@alias cmp.kit.LSP.InlineValue (cmp.kit.LSP.InlineValueText | cmp.kit.LSP.InlineValueVariableLookup | cmp.kit.LSP.InlineValueEvaluatableExpression)
+
+---@alias cmp.kit.LSP.DocumentDiagnosticReport (cmp.kit.LSP.RelatedFullDocumentDiagnosticReport | cmp.kit.LSP.RelatedUnchangedDocumentDiagnosticReport)
+
+---@alias cmp.kit.LSP.PrepareRenameResult (cmp.kit.LSP.Range | { range: cmp.kit.LSP.Range, placeholder: string } | { defaultBehavior: boolean })
+
+---@alias cmp.kit.LSP.ProgressToken (integer | string)
+
+---@alias cmp.kit.LSP.DocumentSelector cmp.kit.LSP.DocumentFilter[]
+
+---@alias cmp.kit.LSP.ChangeAnnotationIdentifier string
+
+---@alias cmp.kit.LSP.WorkspaceDocumentDiagnosticReport (cmp.kit.LSP.WorkspaceFullDocumentDiagnosticReport | cmp.kit.LSP.WorkspaceUnchangedDocumentDiagnosticReport)
+
+---@alias cmp.kit.LSP.TextDocumentContentChangeEvent ({ range: cmp.kit.LSP.Range, rangeLength?: integer, text: string } | { text: string })
+
+---@alias cmp.kit.LSP.MarkedString (string | { language: string, value: string })
+
+---@alias cmp.kit.LSP.DocumentFilter (cmp.kit.LSP.TextDocumentFilter | cmp.kit.LSP.NotebookCellTextDocumentFilter)
+
+---@alias cmp.kit.LSP.GlobPattern (cmp.kit.LSP.Pattern | cmp.kit.LSP.RelativePattern)
+
+---@alias cmp.kit.LSP.TextDocumentFilter ({ language: string, scheme?: string, pattern?: string } | { language?: string, scheme: string, pattern?: string } | { language?: string, scheme?: string, pattern: string })
+
+---@alias cmp.kit.LSP.NotebookDocumentFilter ({ notebookType: string, scheme?: string, pattern?: string } | { notebookType?: string, scheme: string, pattern?: string } | { notebookType?: string, scheme?: string, pattern: string })
+
+---@alias cmp.kit.LSP.Pattern string
+
+return LSP

--- a/lua/cmp/kit/Thread/Worker.lua
+++ b/lua/cmp/kit/Thread/Worker.lua
@@ -1,0 +1,62 @@
+local uv = require('luv')
+local AsyncTask = require('cmp.kit.Async.AsyncTask')
+
+---@class cmp.kit.Thread.WorkerOption
+---@field public runtimepath string[]
+
+local Worker = {}
+Worker.__index = Worker
+
+---Create a new thread.
+---@param runner function
+function Worker.new(runner)
+  local self = setmetatable({}, Worker)
+  self.runner = string.dump(runner)
+  return self
+end
+
+---Call worker function.
+---@return cmp.kit.Async.AsyncTask
+function Worker:__call(...)
+  local args = { ... }
+  return AsyncTask.new(function(resolve, reject)
+    uv.new_work(function(runner, args, option)
+      args = vim.mpack.decode(args)
+      option = vim.mpack.decode(option)
+
+      --Initialize cwd.
+      require('luv').chdir(option.cwd)
+
+      --Initialize package.loaders.
+      table.insert(package.loaders, 2, vim._load_package)
+
+      --Run runner function.
+      local ok, res = pcall(function()
+        return require('cmp.kit.Async.AsyncTask').resolve(assert(loadstring(runner))(unpack(args))):sync()
+      end)
+
+      res = vim.mpack.encode({ res })
+
+      --Return error or result.
+      if not ok then
+        return res, nil
+      else
+        return nil, res
+      end
+    end, function(err, res)
+      if err then
+        reject(vim.mpack.decode(err)[1])
+      else
+        resolve(vim.mpack.decode(res)[1])
+      end
+    end):queue(
+      self.runner,
+      vim.mpack.encode(args),
+      vim.mpack.encode({
+        cwd = uv.cwd(),
+      })
+    )
+  end)
+end
+
+return Worker

--- a/lua/cmp/kit/Vim/Keymap.lua
+++ b/lua/cmp/kit/Vim/Keymap.lua
@@ -1,0 +1,67 @@
+local kit = require('cmp.kit')
+local AsyncTask = require('cmp.kit.Async.AsyncTask')
+
+local Keymap = {}
+
+Keymap._callbacks = {}
+
+---Replace termcodes.
+---@param keys string
+---@return string
+function Keymap.termcodes(keys)
+  return vim.api.nvim_replace_termcodes(keys, true, true, true)
+end
+
+---Set callback for consuming next typeahead.
+---@param callback fun()
+---@return cmp.kit.Async.AsyncTask
+function Keymap.next(callback)
+  return Keymap.send('', 'in'):next(callback)
+end
+
+---Send keys.
+---@param keys string
+---@param mode string
+---@return cmp.kit.Async.AsyncTask
+function Keymap.send(keys, mode)
+  if mode:find('t', 1, true) ~= nil then
+    error('Keymap.send: mode must not contain "t"')
+  end
+
+  local unique_id = kit.unique_id()
+  return AsyncTask.new(function(resolve)
+    Keymap._callbacks[unique_id] = resolve
+
+    local callback = Keymap.termcodes(('<Cmd>lua require("cmp.kit.Vim.Keymap")._resolve(%s)<CR>'):format(unique_id))
+    if string.match(mode, 'i') then
+      vim.api.nvim_feedkeys(callback, 'in', true)
+      vim.api.nvim_feedkeys(keys, mode, true)
+    else
+      vim.api.nvim_feedkeys(keys, mode, true)
+      vim.api.nvim_feedkeys(callback, 'n', true)
+    end
+  end):catch(function()
+    Keymap._callbacks[unique_id] = nil
+  end)
+end
+
+---Test spec helper.
+---@param spec fun(): any
+function Keymap.spec(spec)
+  local task = AsyncTask.resolve():next(spec)
+  vim.api.nvim_feedkeys('', 'x', true)
+  task:sync()
+  collectgarbage('collect')
+  vim.wait(200, function()
+    return true
+  end)
+end
+
+---Resolve running keys.
+---@param unique_id integer
+function Keymap._resolve(unique_id)
+  Keymap._callbacks[unique_id]()
+  Keymap._callbacks[unique_id] = nil
+end
+
+return Keymap

--- a/lua/cmp/kit/Vim/RegExp.lua
+++ b/lua/cmp/kit/Vim/RegExp.lua
@@ -26,6 +26,7 @@ end
 ---@param text string
 ---@param pattern string
 ---@param pos number 1-origin index
+---@return string?, integer?, integer? 1-origin-index
 function RegExp.extract_at(text, pattern, pos)
   local before_text = text:sub(1, pos - 1)
   local after_text = text:sub(pos)

--- a/lua/cmp/kit/Vim/RegExp.lua
+++ b/lua/cmp/kit/Vim/RegExp.lua
@@ -1,0 +1,41 @@
+local RegExp = {}
+
+---@type table<string, { match_str: fun(self, text: string) }>
+RegExp._cache = {}
+
+---Create a RegExp object.
+---@param pattern string
+---@return { match_str: fun(self, text: string) }
+function RegExp.get(pattern)
+  if not RegExp._cache[pattern] then
+    RegExp._cache[pattern] = vim.regex(pattern)
+  end
+  return RegExp._cache[pattern]
+end
+
+---Grep and substitute text.
+---@param text string
+---@param pattern string
+---@param replacement string
+---@return string
+function RegExp.gsub(text, pattern, replacement)
+  return vim.fn.substitute(text, pattern, replacement, 'g')
+end
+
+---Match pattern in text for specified position.
+---@param text string
+---@param pattern string
+---@param pos number 1-origin index
+function RegExp.extract_at(text, pattern, pos)
+  local before_text = text:sub(1, pos - 1)
+  local after_text = text:sub(pos)
+  local b_s, _ = RegExp.get(pattern .. '$'):match_str(before_text)
+  local _, a_e = RegExp.get('^' .. pattern):match_str(after_text)
+  if b_s or a_e then
+    b_s = b_s or #before_text
+    a_e = #before_text + (a_e or 0)
+    return text:sub(b_s + 1, a_e), b_s + 1, a_e + 1
+  end
+end
+
+return RegExp

--- a/lua/cmp/kit/Vim/Syntax.lua
+++ b/lua/cmp/kit/Vim/Syntax.lua
@@ -1,0 +1,49 @@
+local kit = require('cmp.kit')
+
+local Syntax = {}
+
+---Get all syntax groups for specified position.
+---NOTE: This function accepts 0-origin cursor position.
+---@param cursor number[]
+---@return string[]
+function Syntax.get_syntax_groups(cursor)
+  return kit.concat(Syntax.get_vim_syntax_groups(cursor), Syntax.get_treesitter_syntax_groups(cursor))
+end
+
+---Get vim's syntax groups for specified position.
+---NOTE: This function accepts 0-origin cursor position.
+---@param cursor number[]
+---@return string[]
+function Syntax.get_vim_syntax_groups(cursor)
+  local unique = {}
+  local groups = {}
+  for _, syntax_id in ipairs(vim.fn.synstack(cursor[1] + 1, cursor[2] + 1)) do
+    local name = vim.fn.synIDattr(vim.fn.synIDtrans(syntax_id), 'name')
+    if not unique[name] then
+      unique[name] = true
+      table.insert(groups, name)
+    end
+  end
+  for _, syntax_id in ipairs(vim.fn.synstack(cursor[1] + 1, cursor[2] + 1)) do
+    local name = vim.fn.synIDattr(syntax_id, 'name')
+    if not unique[name] then
+      unique[name] = true
+      table.insert(groups, name)
+    end
+  end
+  return groups
+end
+
+---Get tree-sitter's syntax groups for specified position.
+---NOTE: This function accepts 0-origin cursor position.
+---@param cursor number[]
+---@return string[]
+function Syntax.get_treesitter_syntax_groups(cursor)
+  local groups = {}
+  for _, capture in ipairs(vim.treesitter.get_captures_at_pos(0, cursor[1], cursor[2])) do
+    table.insert(groups, ('@%s'):format(capture.capture))
+  end
+  return groups
+end
+
+return Syntax

--- a/lua/cmp/kit/_/Vim/Buffer.lua
+++ b/lua/cmp/kit/_/Vim/Buffer.lua
@@ -1,0 +1,53 @@
+local Highlight = require('cmp.kit._.Vim.Highlight')
+
+local Buffer = {}
+
+---Ensure buffer number.
+---NOTE: This function only supports '%' as special symbols.
+---NOTE: This function uses `vim.fn.bufload`. It can cause side-effect.
+---@param expr string|number
+---@return number
+function Buffer.ensure(expr)
+  if type(expr) == 'number' then
+    if not vim.api.nvim_buf_is_valid(expr) then
+      error(string.format([=[[kit.Vim.Buffer] expr=`%s` is not a valid]=], expr))
+    end
+  else
+    if expr == '%' then
+      expr = vim.api.nvim_get_current_buf()
+    end
+    if vim.fn.bufexists(expr) == 0 then
+      expr = vim.fn.bufadd(expr)
+      vim.api.nvim_buf_set_option(expr, 'buflisted', true)
+    else
+      expr = vim.fn.bufnr(expr)
+    end
+  end
+  if not vim.api.nvim_buf_is_loaded(expr) then
+    vim.fn.bufload(expr)
+  end
+  return expr
+end
+
+---Get buffer line.
+---@param expr string|number
+---@param line number
+---@return string
+function Buffer.at(expr, line)
+  return vim.api.nvim_buf_get_lines(Buffer.ensure(expr), line, line + 1, false)[1] or ''
+end
+
+---Open buffer.
+---@param cmd table # The `new` command argument. See :help nvim_parse_cmd()`
+---@param range? cmp.kit.LSP.Range
+function Buffer.open(cmd, range)
+  vim.cmd.new(cmd)
+
+  local Range = require('cmp.kit.LSP.Range')
+  if range and Range.is(range) and not Range.empty(range) then
+    vim.api.nvim_win_set_cursor(0, { range.start.line + 1, range.start.character })
+    Highlight.blink(range)
+  end
+end
+
+return Buffer

--- a/lua/cmp/kit/_/Vim/Highlight.lua
+++ b/lua/cmp/kit/_/Vim/Highlight.lua
@@ -1,0 +1,36 @@
+local kit = require('cmp.kit')
+local Async = require('cmp.kit.Async')
+local AsyncTask = require('cmp.kit.Async.AsyncTask')
+
+local Highlight = {}
+
+Highlight.namespace = vim.api.nvim_create_namespace('cmp.kit.Vim.Highlight')
+
+---Blink specified range.
+---@param range cmp.kit.LSP.Range
+---@param option? { delay: integer, count: integer }
+---@return cmp.kit.Async.AsyncTask
+function Highlight.blink(range, option)
+  option = kit.merge(option or {}, {
+    delay = 150,
+    count = 2,
+  })
+
+  local function timeout(time)
+    return AsyncTask.new(function(resolve)
+      vim.defer_fn(vim.schedule_wrap(resolve), time)
+    end)
+  end
+
+  return Async.run(function()
+    timeout(option.delay * 1.2):await()
+    for _ = 1, option.count do
+      vim.highlight.range(0, Highlight.namespace, 'IncSearch', { range.start.line, range.start.character }, { range['end'].line, range['end'].character }, {})
+      timeout(option.delay * 0.8):await()
+      vim.api.nvim_buf_clear_namespace(0, Highlight.namespace, 0, -1)
+      timeout(option.delay):await()
+    end
+  end)
+end
+
+return Highlight

--- a/lua/cmp/kit/_/Vim/TreeSitter.lua
+++ b/lua/cmp/kit/_/Vim/TreeSitter.lua
@@ -1,0 +1,301 @@
+local TreeSitter = {}
+
+---@alias cmp.kit._.Vim.TreeSitter.VisitStatus 'stop'|'skip'
+TreeSitter.VisitStatus = {}
+TreeSitter.VisitStatus.Stop = 'stop'
+TreeSitter.VisitStatus.Skip = 'skip'
+
+---Get the leaf node at the specified position.
+---@param row integer # 0-based
+---@param col integer # 0-based
+---@return userdata?
+function TreeSitter.get_node_at(row, col)
+  local parser = TreeSitter.get_parser()
+  if not parser then
+    return
+  end
+
+  for _, tree in ipairs(parser:trees()) do
+    local node = tree:root():descendant_for_range(row, col, row, col)
+    if node then
+      local leaf = TreeSitter.get_first_leaf(node)
+      if leaf then
+        return leaf
+      end
+    end
+  end
+end
+
+---Get first leaf node within the specified node.
+---@param node userdata
+---@return userdata?
+function TreeSitter.get_first_leaf(node)
+  if node:child_count() > 0 then
+    return TreeSitter.get_first_leaf(node:child(0))
+  end
+  return node
+end
+
+---Get last leaf node within the specified node.
+---@param node userdata
+---@return userdata?
+function TreeSitter.get_last_leaf(node)
+  if node:child_count() > 0 then
+    return TreeSitter.get_last_leaf(node:child(node:child_count() - 1))
+  end
+  return node
+end
+
+---Get next leaf node.
+---@param node userdata
+---@return userdata?
+function TreeSitter.get_next_leaf(node)
+  local function next(node_)
+    local next_sibling = node_:next_sibling()
+    if next_sibling then
+      return TreeSitter.get_first_leaf(next_sibling)
+    else
+      local parent = node_:parent()
+      while parent do
+        next_sibling = parent:next_sibling()
+        if next_sibling then
+          return TreeSitter.get_first_leaf(next_sibling)
+        end
+        parent = parent:parent()
+      end
+    end
+  end
+
+  return next(TreeSitter.get_first_leaf(node))
+end
+
+---Get prev leaf node.
+---@param node userdata
+---@return userdata
+function TreeSitter.get_prev_leaf(node)
+  local function prev(node_)
+    local prev_sibling = node_:prev_sibling()
+    if prev_sibling then
+      return TreeSitter.get_last_leaf(prev_sibling)
+    else
+      local parent = node_:parent()
+      while parent do
+        prev_sibling = parent:prev_sibling()
+        if prev_sibling then
+          return TreeSitter.get_last_leaf(prev_sibling)
+        end
+        parent = parent:parent()
+      end
+    end
+  end
+
+  return prev(TreeSitter.get_last_leaf(node))
+end
+
+---Return the node contained the position or not.
+---@param node userdata
+---@param row integer # 0-based
+---@param col integer # 0-based
+---@param option { s: boolean, e: boolean }
+---@return boolean
+function TreeSitter.within(node, row, col, option)
+  option = option or {}
+  option.s = option.s ~= nil and option.s or true
+  option.e = option.e ~= nil and option.e or false
+
+  local s_row, s_col, e_row, e_col = node:range()
+  local s_in = s_row < row or (s_row == row and (option.s and (s_col <= col) or (s_col < col)))
+  local e_in = row < e_row or (row == e_row and (option.e and (col <= e_col) or (col < e_col)))
+  return s_in and e_in
+end
+
+---Extract nodes that matched the specified mapping.
+---@param scope userdata
+---@param mapping table
+---@return userdata[]
+function TreeSitter.extract(scope, mapping)
+  local nodes = {}
+  for node_type, next_mapping in pairs(mapping) do
+    if node_type == scope:type() then
+      if type(next_mapping) == 'table' then
+        for c in scope:iter_children() do
+          for _, node in ipairs(TreeSitter.extract(c, next_mapping)) do
+            table.insert(nodes, node)
+          end
+        end
+      elseif next_mapping == true then
+        table.insert(nodes, scope)
+      end
+    end
+  end
+  return nodes
+end
+
+---Return the node is matched the specified mapping.
+---@param node userdata
+---@param mapping table
+---@return userdata?
+function TreeSitter.matches(node, mapping)
+  local parent = node
+  while parent do
+    if vim.tbl_contains(TreeSitter.extract(parent, mapping), node) then
+      return parent
+    end
+    parent = parent:parent()
+  end
+end
+
+---Search next specific node.
+---@param node userdata
+---@param predicate fun(node: userdata): boolean
+---@return userdata?
+function TreeSitter.search_next(node, predicate)
+  local current = node
+  while current do
+    -- down search.
+    local matched = nil
+    TreeSitter.visit(current, function(node_)
+      if node ~= node_ and predicate(node_) then
+        matched = node_
+        return TreeSitter.VisitStatus.Stop
+      end
+    end)
+    if matched then
+      return matched
+    end
+
+    -- up search.
+    while current do
+      local next_sibling = current:next_sibling()
+      if next_sibling then
+        current = next_sibling
+        break
+      end
+      current = current:parent()
+    end
+  end
+end
+
+---Search specific parent node.
+---@param node userdata
+---@param predicate fun(node: userdata): boolean
+---@return userdata?
+function TreeSitter.search_parent(node, predicate)
+  local parent = node:parent()
+  while parent do
+    if predicate(parent) then
+      return parent
+    end
+    parent = parent:parent()
+  end
+end
+
+---Get all parents.
+---@param node userdata
+---@return userdata[]
+function TreeSitter.parents(node)
+  local parents = {}
+  while node do
+    table.insert(parents, 1, node)
+    node = node:parent()
+  end
+  return parents
+end
+
+---Visit all nodes.
+---@param scope userdata
+---@param predicate fun(node: userdata, ctx: { depth: integer }): boolean
+---@param option? { reversed: boolean }
+function TreeSitter.visit(scope, predicate, option)
+  option = option or { reversed = false }
+
+  local function visit(node, ctx)
+    if not node then
+      return true
+    end
+
+    local status = predicate(node, ctx)
+    if status == TreeSitter.VisitStatus.Stop then
+      return status -- stop visitting.
+    elseif status ~= TreeSitter.VisitStatus.Skip then
+      local init, last, step
+      if option.reversed then
+        init, last, step = node:child_count() - 1, 0, -1
+      else
+        init, last, step = 0, node:child_count() - 1, 1
+      end
+      for i = init, last, step do
+        if visit(node:child(i), { depth = ctx.depth + 1 }) == TreeSitter.VisitStatus.Stop then
+          return TreeSitter.VisitStatus.Stop
+        end
+      end
+    end
+  end
+
+  return visit(scope, { depth = 1 })
+end
+
+---Return the node is matched the specified capture.
+---@param query userdata
+---@param node userdata
+---@return boolean
+function TreeSitter.is_capture(query, node, capture)
+  for id, match in query:iter_captures(node:parent()) do
+    if match:id() == node:id() and query.captures[id] == capture then
+      return true
+    end
+  end
+  return false
+end
+
+---Get node text.
+---@param node userdata
+---@return string[]
+function TreeSitter.get_node_text(node)
+  local ok, text = pcall(function()
+    local args = { 0, node:range() }
+    table.insert(args, {})
+    return vim.api.nvim_buf_get_text(unpack(args))
+  end)
+  if not ok then
+    return { '' }
+  end
+  return text
+end
+
+---Get parser.
+---@return table
+function TreeSitter.get_parser()
+  return vim.treesitter.get_parser(0, vim.api.nvim_buf_get_option(0, 'filetype'))
+end
+
+---Dump node or node-table.
+---@param node userdata|userdata[]
+function TreeSitter.dump(node)
+  if not node then
+    return print(node)
+  end
+
+  if type(node) == 'table' then
+    if #node == 0 then
+      return print('empty table')
+    end
+    for _, v in ipairs(node) do
+      TreeSitter.dump(v)
+    end
+    return
+  end
+
+  local message = node:type()
+  local current = node:parent()
+  while current do
+    message = current:type() .. ' ~ ' .. message
+    current = current:parent()
+    if not current then
+      break
+    end
+  end
+  print(message)
+end
+
+return TreeSitter

--- a/lua/cmp/kit/_/Vim/Window.lua
+++ b/lua/cmp/kit/_/Vim/Window.lua
@@ -1,0 +1,39 @@
+---@class cmp.kit.Vim.Window
+---@field public specifier cmp.kit.Vim.Window.Specifier
+---@field public option table<string, string | integer | boolean>
+---@field public win? integer
+---@field public buf? integer
+local Window = {}
+Window.__index = Window
+
+---@enum cmp.kit.Vim.Window.SplitDirection
+Window.SplitDirection = {
+  Top = 'top',
+  Bottom = 'bottom',
+  Left = 'left',
+  Right = 'right',
+  Current = 'current',
+}
+
+---@alias cmp.kit.Vim.Window.Specifier cmp.kit.Vim.Window.FloatSpecifier | cmp.kit.Vim.Window.SplitSpecifier
+
+---@class cmp.kit.Vim.Window.FloatSpecifier
+---@field public row integer 0-origin screen cell width
+---@field public col integer 0-origin screen cell width
+---@field public width integer 0-origin screen cell width
+---@field public height integer 0-origin screen cell width
+
+---@class cmp.kit.Vim.Window.SplitSpecifier
+---@field public direction cmp.kit.Vim.Window.SplitDirection
+---@field public width integer 0-origin screen cell width
+---@field public height integer 0-origin screen cell width
+
+---@param specifier cmp.kit.Vim.Window.Specifier
+function Window.new(specifier)
+  local self = setmetatable({}, Window)
+  self.specifier = specifier
+  self.option = {}
+  return self
+end
+
+return Window

--- a/lua/cmp/kit/init.lua
+++ b/lua/cmp/kit/init.lua
@@ -1,0 +1,163 @@
+local kit = {}
+
+local is_thread = vim.is_thread()
+
+---Create gabage collection detector.
+---@param callback fun(...: any): any
+---@return userdata
+function kit.gc(callback)
+  local gc = newproxy(true)
+  if vim.is_thread() or os.getenv('NODE_ENV') == 'test' then
+    getmetatable(gc).__gc = callback
+  else
+    getmetatable(gc).__gc = vim.schedule_wrap(callback)
+  end
+  return gc
+end
+
+---Safe version of vim.schedule.
+---@param fn fun(...: any): any
+function kit.safe_schedule(fn)
+  if is_thread then
+    fn()
+  else
+    vim.schedule(fn)
+  end
+end
+
+---Safe version of vim.schedule_wrap.
+---@param fn fun(...: any): any
+function kit.safe_schedule_wrap(fn)
+  if is_thread then
+    return fn
+  else
+    return vim.schedule_wrap(fn)
+  end
+end
+
+---Create unique id.
+---@return integer
+kit.unique_id = setmetatable({
+  unique_id = 0,
+}, {
+  __call = function(self)
+    self.unique_id = self.unique_id + 1
+    return self.unique_id
+  end,
+})
+
+---Merge two tables.
+---@generic T
+---NOTE: This doesn't merge array-like table.
+---@param tbl1 T
+---@param tbl2 T
+---@return T
+function kit.merge(tbl1, tbl2)
+  local is_dict1 = type(tbl1) == 'table' and (not vim.tbl_islist(tbl1) or vim.tbl_isempty(tbl1))
+  local is_dict2 = type(tbl2) == 'table' and (not vim.tbl_islist(tbl2) or vim.tbl_isempty(tbl2))
+  if is_dict1 and is_dict2 then
+    local new_tbl = {}
+    for k, v in pairs(tbl2) do
+      if tbl1[k] ~= vim.NIL then
+        new_tbl[k] = kit.merge(tbl1[k], v)
+      end
+    end
+    for k, v in pairs(tbl1) do
+      if tbl2[k] == nil then
+        new_tbl[k] = v ~= vim.NIL and v or nil
+      end
+    end
+    return new_tbl
+  elseif is_dict1 and not is_dict2 then
+    return kit.merge(tbl1, {})
+  elseif not is_dict1 and is_dict2 then
+    return kit.merge(tbl2, {})
+  end
+
+  if tbl1 == vim.NIL then
+    return nil
+  elseif tbl1 == nil then
+    return tbl2
+  else
+    return tbl1
+  end
+end
+
+---Concatenate two tables.
+---NOTE: This doesn't concatenate dict-like table.
+---@param tbl1 table
+---@param tbl2 table
+function kit.concat(tbl1, tbl2)
+  local new_tbl = {}
+  for _, item in ipairs(tbl1) do
+    table.insert(new_tbl, item)
+  end
+  for _, item in ipairs(tbl2) do
+    table.insert(new_tbl, item)
+  end
+  return new_tbl
+end
+
+---The value to array.
+---@param value any
+---@return table
+function kit.to_array(value)
+  if type(value) == 'table' then
+    if vim.tbl_islist(value) or vim.tbl_isempty(value) then
+      return value
+    end
+  end
+  return { value }
+end
+
+---Check the value is array.
+---@param value any
+---@return boolean
+function kit.is_array(value)
+  return type(value) == 'table' and (vim.tbl_islist(value) or vim.tbl_isempty(value))
+end
+
+---Reverse the array.
+---@param array table
+---@return table
+function kit.reverse(array)
+  if not kit.is_array(array) then
+    error('[kit] specified value is not an array.')
+  end
+
+  local new_array = {}
+  for i = #array, 1, -1 do
+    table.insert(new_array, array[i])
+  end
+  return new_array
+end
+
+---@generic T
+---@param value T?
+---@param default T
+function kit.default(value, default)
+  if value == nil then
+    return default
+  end
+  return value
+end
+
+---Get object path with default value.
+---@generic T
+---@param value table
+---@param path integer|string|(string|integer)[]
+---@param default? T
+---@return T
+function kit.get(value, path, default)
+  local result = value
+  for _, key in ipairs(kit.to_array(path)) do
+    if type(result) == 'table' then
+      result = result[key]
+    else
+      return default
+    end
+  end
+  return result or default
+end
+
+return kit

--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -256,37 +256,31 @@ end
 ---@return string[]
 source.get_trigger_characters = function(self)
   local params = self:get_source_config()
-  return params.override.get_trigger_characters(
-    params,
-    function(params)
-      local trigger_characters = {}
-      if self.source.get_trigger_characters then
-        trigger_characters = self.source:get_trigger_characters(misc.copy(params)) or {}
-      end
-      if config.get().completion.get_trigger_characters then
-        return config.get().completion.get_trigger_characters(trigger_characters)
-      end
-      return trigger_characters
+  return params.override.get_trigger_characters(params, function(params)
+    local trigger_characters = {}
+    if self.source.get_trigger_characters then
+      trigger_characters = self.source:get_trigger_characters(misc.copy(params)) or {}
     end
-  )
+    if config.get().completion.get_trigger_characters then
+      return config.get().completion.get_trigger_characters(trigger_characters)
+    end
+    return trigger_characters
+  end)
 end
 
 ---Get keyword_pattern
 ---@return string
 source.get_keyword_pattern = function(self)
   local params = self:get_source_config()
-  return params.override.get_keyword_pattern(
-    params,
-    function(params)
-      if self.source.get_keyword_pattern then
-        local keyword_pattern = self.source:get_keyword_pattern(misc.copy(params))
-        if keyword_pattern then
-          return keyword_pattern
-        end
+  return params.override.get_keyword_pattern(params, function(params)
+    if self.source.get_keyword_pattern then
+      local keyword_pattern = self.source:get_keyword_pattern(misc.copy(params))
+      if keyword_pattern then
+        return keyword_pattern
       end
-      return config.get().completion.keyword_pattern
     end
-  )
+    return config.get().completion.keyword_pattern
+  end)
 end
 
 ---Invoke completion

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -57,6 +57,16 @@ cmp.ItemField = {
 ---@field public reason? cmp.ContextReason
 ---@field public config? cmp.ConfigSchema
 
+---@class cmp.CustomSource
+---@field public get_debug_name? fun(self: cmp.CustomSource): string
+---@field public get_position_encoding_kind? fun(self: cmp.CustomSource): lsp.PositionEncodingKind
+---@field public is_available? fun(self: cmp.CustomSource): boolean
+---@field public get_trigger_characters? fun(self: cmp.CustomSource, config: cmp.SourceApiParams): string[]
+---@field public get_keyword_pattern? fun(self: cmp.CustomSource, config: cmp.SourceApiParams): string
+---@field public complete fun(self: cmp.CustomSource, config: cmp.SourceCompletionApiParams, callback: fun(response: lsp.CompletionResponse))
+---@field public resolve? fun(self: cmp.CustomSource, completion_item: lsp.CompletionItem, callback: fun(completion_item: lsp.CompletionItem))
+---@field public execute? fun(self: cmp.CustomSource, completion_item: lsp.CompletionItem, callback: fun())
+
 ---@class cmp.Setup
 ---@field public __call fun(c: cmp.ConfigSchema)
 ---@field public buffer fun(c: cmp.ConfigSchema)
@@ -64,21 +74,23 @@ cmp.ItemField = {
 ---@field public cmdline fun(type: string|string[], c: cmp.ConfigSchema)
 ---@field public filetype fun(type: string|string[], c: cmp.ConfigSchema)
 
----@class cmp.SourceApiParams: cmp.SourceConfig
+---@alias cmp.SourceApiParams cmp.SourceConfig
 
 ---@class cmp.SourceCompletionApiParams : cmp.SourceConfig
 ---@field public offset integer
 ---@field public context cmp.Context
 ---@field public completion_context lsp.CompletionContext
 
----@class cmp.Mapping
+---@class cmp.ModeMapping
 ---@field public i nil|function(fallback: function): void
 ---@field public c nil|function(fallback: function): void
 ---@field public x nil|function(fallback: function): void
 ---@field public s nil|function(fallback: function): void
 
+---@alias cmp.Mapping cmp.ModeMapping|function(fallback: function): void
+
 ---@class cmp.ConfigSchema
----@field private revision integer
+---@field public revision integer
 ---@field public enabled boolean | fun(): boolean
 ---@field public performance cmp.PerformanceConfig
 ---@field public preselect cmp.PreselectMode
@@ -100,8 +112,8 @@ cmp.ItemField = {
 ---@field public fetching_timeout integer
 
 ---@class cmp.WindowConfig
----@field completion cmp.WindowConfig
----@field documentation cmp.WindowConfig|nil
+---@field completion cmp.CompletionWindowConfig
+---@field documentation cmp.DocumentationWindowConfig|nil
 
 ---@class cmp.CompletionConfig
 ---@field public autocomplete cmp.TriggerEvent[]
@@ -110,14 +122,20 @@ cmp.ItemField = {
 ---@field public keyword_length integer
 ---@field public keyword_pattern string
 
----@class cmp.WindowConfig
+---@class cmp.BaseWindowConfig
 ---@field public border string|string[]
 ---@field public winhighlight string
 ---@field public zindex integer|nil
+
+---@class cmp.CompletionWindowConfig : cmp.BaseWindowConfig
+---@field public col_offset integer
+---@field public side_padding integer
+---@field public scrolloff integer|nil
+---@field public scrollbar boolean
+
+---@class cmp.DocumentationWindowConfig : cmp.BaseWindowConfig
 ---@field public max_width integer|nil
 ---@field public max_height integer|nil
----@field public scrolloff integer|nil
----@field public scrollbar boolean|true
 
 ---@class cmp.ConfirmationConfig
 ---@field public default_behavior cmp.ConfirmBehavior
@@ -149,18 +167,23 @@ cmp.ItemField = {
 ---@class cmp.SourceConfig
 ---@field public name string
 ---@field public option table|nil
+---@field public override? cmp.SourceOverrideConfig
 ---@field public priority integer|nil
----@field public trigger_characters string[]|nil
----@field public keyword_pattern string|nil
 ---@field public keyword_length integer|nil
 ---@field public max_item_count integer|nil
 ---@field public group_index integer|nil
 ---@field public entry_filter nil|function(entry: cmp.Entry, ctx: cmp.Context): boolean
 
----@class cmp.ViewConfig
----@field public entries cmp.EntriesConfig
+---@class cmp.SourceOverrideConfig
+---@field public is_available? fun(is_available: fun(): boolean): boolean
+---@field public get_trigger_characters? fun(params: cmp.SourceApiParams, get_trigger_characters: (fun(params: cmp.SourceApiParams): string[])): string[]
+---@field public get_keyword_pattern? fun(params: cmp.SourceApiParams, get_keyword_pattern: fun(params: cmp.SourceApiParams): string): string
+---@field public complete fun(params: cmp.SourceCompletionApiParams, callback: fun(response: lsp.CompletionResponse), complete: fun(params: cmp.SourceCompletionApiParams, callback: fun(response: lsp.CompletionResponse)))
+---@field public resolve fun(completion_item: lsp.CompletionItem, callback: fun(completion_item: lsp.CompletionItem), resolve: fun(completion_item: lsp.CompletionItem, callback: fun(completion_item: lsp.CompletionItem)))
+---@field public execute fun(completion_item: lsp.CompletionItem, callback: fun(), execute: fun(completion_item: lsp.CompletionItem, callback: fun()))
 
----@alias cmp.EntriesConfig cmp.CustomEntriesConfig|cmp.NativeEntriesConfig|cmp.WildmenuEntriesConfig|string
+---@class cmp.ViewConfig
+---@field public entries cmp.CustomEntriesConfig|cmp.NativeEntriesConfig|cmp.WildmenuEntriesConfig|string
 
 ---@class cmp.CustomEntriesConfig
 ---@field name 'custom'


### PR DESCRIPTION
This PR adds the `sources[n].override` option that enables to override custom source behavior.

For example, you can change `is_available` condition like this.

```lua
cmp.setup {

  sources = {
    {
      name = 'nvim_lsp',
      override = {
        is_available = function()
          return context.in_treesitter_capture('comment')
        end
      }
    }
  }

}
```

This PR has following breaking changes.

- Remove `config.sources[n].keyword_pattern` option.
- Remove `config.sources[n].trigger_characters` option.