### PR TITLE
Feat: scrollbar option

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -632,8 +632,9 @@ window.completion.side_padding~
 
                                      *cmp-config.window.completion.scrollbar*
 window.completion.scrollbar~
-  `boolean`
-  Wether the scrollbar should be enabled if there are more items that fit
+  `boolean | cmp.ScrollbarOption`
+  Wether the scrollbar should be enabled if there are more items that fit.
+  If set to `true`, is is the same as `{ position = 'edge', thumb_char = ' ' }`.
 
                                      *cmp-config.window.documentation.max_width*
 window.documentation.max_width~

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -634,7 +634,7 @@ window.completion.side_padding~
 window.completion.scrollbar~
   `boolean | cmp.ScrollbarOption`
   Wether the scrollbar should be enabled if there are more items that fit.
-  If set to `true`, is is the same as `{ position = 'edge', thumb_char = ' ' }`.
+  If set to `true`, it is the same as `{ position = 'edge', thumb_char = ' ' }`.
 
                                      *cmp-config.window.documentation.max_width*
 window.documentation.max_width~

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -96,7 +96,10 @@ return function()
         scrolloff = 0,
         col_offset = 0,
         side_padding = 1,
-        scrollbar = true,
+        scrollbar = {
+          position = 'edge',
+          thumb_char = ' ',
+        },
       },
       documentation = {
         max_height = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -57,6 +57,9 @@ cmp.ItemField = {
 ---@field public reason? cmp.ContextReason
 ---@field public config? cmp.ConfigSchema
 
+---@class cmp.ScrollbarOption
+---@field public thumb_char string
+
 ---@class cmp.Setup
 ---@field public __call fun(c: cmp.ConfigSchema)
 ---@field public buffer fun(c: cmp.ConfigSchema)
@@ -117,7 +120,7 @@ cmp.ItemField = {
 ---@field public max_width integer|nil
 ---@field public max_height integer|nil
 ---@field public scrolloff integer|nil
----@field public scrollbar boolean|true
+---@field public scrollbar boolean|cmp.ScrollbarOption
 
 ---@class cmp.ConfirmationConfig
 ---@field public default_behavior cmp.ConfirmBehavior

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -58,6 +58,7 @@ cmp.ItemField = {
 ---@field public config? cmp.ConfigSchema
 
 ---@class cmp.ScrollbarOption
+---@field public position 'edge' | 'inside'
 ---@field public thumb_char string
 
 ---@class cmp.Setup

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -170,9 +170,16 @@ window.update = function(self)
     if self.thumb_win and vim.api.nvim_win_is_valid(self.thumb_win) then
       vim.api.nvim_win_set_config(self.thumb_win, style)
     else
+      local thumb_buf = buffer.ensure(self.name .. 'thumb_buf')
       style.noautocmd = true
-      self.thumb_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'thumb_buf'), false, style)
+      self.thumb_win = vim.api.nvim_open_win(thumb_buf, false, style)
       vim.api.nvim_win_set_option(self.thumb_win, 'winhighlight', 'EndOfBuffer:PmenuThumb,NormalFloat:PmenuThumb')
+
+      local thumb = {}
+      for _ = 1, thumb_height do
+        table.insert(thumb, config.get().window.completion.scrollbar.thumb_char or ' ')
+      end
+      vim.api.nvim_buf_set_lines(thumb_buf, 0, thumb_height, false, thumb)
     end
   else
     if self.sbar_win and vim.api.nvim_win_is_valid(self.sbar_win) then

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -53,7 +53,7 @@ window.option = function(self, key, value)
   self.opt[key] = value
   if self:visible() then
     local eventignore = vim.opt.eventignore:get()
-    vim.opt.eventignore:append("OptionSet")
+    vim.opt.eventignore:append('OptionSet')
     vim.api.nvim_win_set_option(self.win, key, value)
     vim.opt.eventignore = eventignore
   end
@@ -77,7 +77,7 @@ window.buffer_option = function(self, key, value)
   local existing_buf = buffer.get(self.name)
   if existing_buf then
     local eventignore = vim.opt.eventignore:get()
-    vim.opt.eventignore:append("OptionSet")
+    vim.opt.eventignore:append('OptionSet')
     vim.api.nvim_buf_set_option(existing_buf, key, value)
     vim.opt.eventignore = eventignore
   end

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -142,7 +142,7 @@ window.update = function(self)
         width = 1,
         height = self.style.height,
         row = info.row,
-        col = info.col + info.width - info.scrollbar_offset, -- info.col was already contained the scrollbar offset.
+        col = info.col + info.width - info.scrollbar_offset + info.scrollbar_pos, -- info.col was already contained the scrollbar offset.
         zindex = (self.style.zindex and (self.style.zindex + 1) or 1),
       }
       if self.sbar_win and vim.api.nvim_win_is_valid(self.sbar_win) then
@@ -164,7 +164,7 @@ window.update = function(self)
       width = 1,
       height = math.max(1, thumb_height),
       row = info.row + thumb_offset + (info.border_info.visible and info.border_info.top or 0),
-      col = info.col + info.width - 1, -- info.col was already added scrollbar offset.
+      col = info.col + info.width + info.scrollbar_pos - 1, -- info.col was already added scrollbar offset.
       zindex = (self.style.zindex and (self.style.zindex + 2) or 2),
     }
     if self.thumb_win and vim.api.nvim_win_is_valid(self.thumb_win) then
@@ -237,6 +237,7 @@ window.info = function(self)
     border_info = border_info,
     scrollable = false,
     scrollbar_offset = 0,
+    scrollbar_pos = scrollbar.position == 'inside' and -1 or 0,
   }
 
   if self:get_content_height() > info.inner_height and scrollbar then

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -147,6 +147,7 @@ custom_entries_view.open = function(self, offset, entries)
   width = width + self.column_width.abbr + (self.column_width.kind > 0 and 1 or 0)
   width = width + self.column_width.kind + (self.column_width.menu > 0 and 1 or 0)
   width = width + self.column_width.menu + 1
+  width = width + (completion.scrollbar.position == 'inside' and 1 or 0)
 
   local height = vim.api.nvim_get_option('pumheight')
   height = height ~= 0 and height or #self.entries

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -66,6 +66,8 @@ docs_view.open = function(self, e, view)
     return self:close()
   end
 
+  width = width + (config.get().window.completion.scrollbar.position == 'inside' and 1 or 0)
+
   -- Calculate window position.
   local right_col = view.col + view.width
   local left_col = view.col - width - border_info.horiz


### PR DESCRIPTION
Added options to customize the appearance and position of the scrollbars.

For example:

```lua
scrollbar = true,
-- or
scrollbar = {
  thumb_char = " ",
  position = "edge",
},
```

![image](https://user-images.githubusercontent.com/105504350/210284654-6cbbb5f5-b0f7-42dd-a8fc-6882d6964283.png)

---

```lua
scrollbar = {
  thumb_char = "▐",
  position = "inside",
},

-- change hl
```

![image](https://user-images.githubusercontent.com/105504350/210284761-ff36da79-dca3-4f45-9bee-760d17c824e3.png)

---

```lua
scrollbar = {
  thumb_char = "│",
  position = "edge",
},

-- change hl
```

![image](https://user-images.githubusercontent.com/105504350/210284941-fab76168-59ed-499a-a15b-2a59b476c89e.png)
