### PR TITLE
Allow window.documentation.max_{width, height} to be set to 0

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -647,12 +647,14 @@ window.completion.scrollbar~
                                      *cmp-config.window.documentation.max_width*
 window.documentation.max_width~
   `number`
-  The documentation window's max width.
+  The documentation window's max width, can be set to 0 to use all available
+  space.
 
                                     *cmp-config.window.documentation.max_height*
 window.documentation.max_height~
   `number`
-  The documentation window's max height.
+  The documentation window's max height, can be set to 0 to use all available
+  space.
 
                                             *cmp-config.experimental.ghost_text*
 experimental.ghost_text~

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -37,7 +37,10 @@ docs_view.open = function(self, e, view)
   local border_info = window.get_border_info({ style = documentation })
   local right_space = vim.o.columns - (view.col + view.width) - 1
   local left_space = view.col - 1
-  local max_width = math.min(documentation.max_width, math.max(left_space, right_space))
+  local max_width = math.max(left_space, right_space)
+  if documentation.max_width > 0 then
+    max_width = math.min(documentation.max_width, max_width)
+  end
 
   -- Update buffer content if needed.
   if not self.entry or e.id ~= self.entry.id then
@@ -51,17 +54,23 @@ docs_view.open = function(self, e, view)
       vim.cmd([[syntax clear]])
       vim.api.nvim_buf_set_lines(self.window:get_buffer(), 0, -1, false, {})
     end)
-    vim.lsp.util.stylize_markdown(self.window:get_buffer(), documents, {
+    local opts = {
       max_width = max_width - border_info.horiz,
-      max_height = documentation.max_height,
-    })
+    }
+    if documentation.max_height > 0 then
+      opts.max_height = documentation.max_height
+    end
+    vim.lsp.util.stylize_markdown(self.window:get_buffer(), documents, opts)
   end
 
   -- Calculate window size.
-  local width, height = vim.lsp.util._make_floating_popup_size(vim.api.nvim_buf_get_lines(self.window:get_buffer(), 0, -1, false), {
+  local opts = {
     max_width = max_width - border_info.horiz,
-    max_height = documentation.max_height - border_info.vert,
-  })
+  }
+  if documentation.max_height > 0 then
+    opts.max_height = documentation.max_height - border_info.vert
+  end
+  local width, height = vim.lsp.util._make_floating_popup_size(vim.api.nvim_buf_get_lines(self.window:get_buffer(), 0, -1, false), opts)
   if width <= 0 or height <= 0 then
     return self:close()
   end


### PR DESCRIPTION
To allow for using all available screen space, as we can omit a max_height/max_width when creating a documentation popup). I've found this to be useful with neovim-gtk's native GUI completion menus.