### PR TITLE
Improved: ALL option settings do not fire the `OptionSet` event

### DIFF
--- a/lua/cmp/utils/options.lua
+++ b/lua/cmp/utils/options.lua
@@ -1,0 +1,25 @@
+local M = {}
+
+-- Set window option without triggering the OptionSet event
+---@param window number
+---@param name string
+---@param value any
+M.win_set_option = function(window, name, value)
+  local eventignore = vim.opt.eventignore:get()
+  vim.opt.eventignore:append('OptionSet')
+  vim.api.nvim_win_set_option(window, name, value)
+  vim.opt.eventignore = eventignore
+end
+
+-- Set buffer option without triggering the OptionSet event
+---@param buffer number
+---@param name string
+---@param value any
+M.buf_set_option = function(buffer, name, value)
+  local eventignore = vim.opt.eventignore:get()
+  vim.opt.eventignore:append('OptionSet')
+  vim.api.nvim_buf_set_option(buffer, name, value)
+  vim.opt.eventignore = eventignore
+end
+
+return M

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -1,4 +1,5 @@
 local misc = require('cmp.utils.misc')
+local opt = require('cmp.utils.options')
 local buffer = require('cmp.utils.buffer')
 local api = require('cmp.utils.api')
 local config = require('cmp.config')
@@ -37,8 +38,7 @@ window.new = function()
 end
 
 ---Set window option.
----NOTE: If the window already visible, immediately applied to it. The OptionSet
--- event is not triggered
+---NOTE: If the window already visible, immediately applied to it.
 ---@param key string
 ---@param value any
 window.option = function(self, key, value)
@@ -52,16 +52,12 @@ window.option = function(self, key, value)
 
   self.opt[key] = value
   if self:visible() then
-    local eventignore = vim.opt.eventignore:get()
-    vim.opt.eventignore:append("OptionSet")
-    vim.api.nvim_win_set_option(self.win, key, value)
-    vim.opt.eventignore = eventignore
+    opt.win_set_option(self.win, key, value)
   end
 end
 
 ---Set buffer option.
----NOTE: If the buffer already visible, immediately applied to it. The OptionSet
--- event is not triggered.
+---NOTE: If the buffer already visible, immediately applied to it.
 ---@param key string
 ---@param value any
 window.buffer_option = function(self, key, value)
@@ -76,10 +72,7 @@ window.buffer_option = function(self, key, value)
   self.buffer_opt[key] = value
   local existing_buf = buffer.get(self.name)
   if existing_buf then
-    local eventignore = vim.opt.eventignore:get()
-    vim.opt.eventignore:append("OptionSet")
-    vim.api.nvim_buf_set_option(existing_buf, key, value)
-    vim.opt.eventignore = eventignore
+    opt.buf_set_option(existing_buf, key, value)
   end
 end
 
@@ -107,7 +100,7 @@ window.get_buffer = function(self)
   local buf, created_new = buffer.ensure(self.name)
   if created_new then
     for k, v in pairs(self.buffer_opt) do
-      vim.api.nvim_buf_set_option(buf, k, v)
+      opt.buf_set_option(buf, k, v)
     end
   end
   return buf
@@ -131,7 +124,7 @@ window.open = function(self, style)
     s.noautocmd = true
     self.win = vim.api.nvim_open_win(self:get_buffer(), false, s)
     for k, v in pairs(self.opt) do
-      vim.api.nvim_win_set_option(self.win, k, v)
+      opt.win_set_option(self.win, k, v)
     end
   end
   self:update()
@@ -158,7 +151,7 @@ window.update = function(self)
       else
         style.noautocmd = true
         self.sbar_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'sbar_buf'), false, style)
-        vim.api.nvim_win_set_option(self.sbar_win, 'winhighlight', 'EndOfBuffer:PmenuSbar,NormalFloat:PmenuSbar')
+        opt.win_set_option(self.sbar_win, 'winhighlight', 'EndOfBuffer:PmenuSbar,NormalFloat:PmenuSbar')
       end
     end
 
@@ -180,7 +173,7 @@ window.update = function(self)
     else
       style.noautocmd = true
       self.thumb_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'thumb_buf'), false, style)
-      vim.api.nvim_win_set_option(self.thumb_win, 'winhighlight', 'EndOfBuffer:PmenuThumb,NormalFloat:PmenuThumb')
+      opt.win_set_option(self.thumb_win, 'winhighlight', 'EndOfBuffer:PmenuThumb,NormalFloat:PmenuThumb')
     end
   else
     if self.sbar_win and vim.api.nvim_win_is_valid(self.sbar_win) then


### PR DESCRIPTION
Sorry for the git crazyness, im still learning and not very comfortable with rebasing etc.

Anyway: I reverted the last commit because I missed some nvim_{win,buf}_set_option commands. Since there are many of them, I created a wrapper function to avoid duplicate code. As of now, the OptionSet event is never triggered.

Closes https://github.com/hrsh7th/nvim-cmp/issues/1413