### PR TITLE
Fix: commandline ! doesn't show with <Tab> or <S-Tab>

### DIFF
--- a/lua/cmp/config/mapping.lua
+++ b/lua/cmp/config/mapping.lua
@@ -1,5 +1,6 @@
 local types = require('cmp.types')
 local misc = require('cmp.utils.misc')
+local feedkeys = require('cmp.utils.feedkeys')
 local keymap = require('cmp.utils.keymap')
 
 local function merge_keymaps(base, override)
@@ -89,7 +90,7 @@ mapping.preset.cmdline = function(override)
         if cmp.visible() then
           cmp.select_next_item()
         else
-          cmp.complete()
+          feedkeys.call(keymap.t('<C-z>'), 'n')
         end
       end,
     },
@@ -99,7 +100,7 @@ mapping.preset.cmdline = function(override)
         if cmp.visible() then
           cmp.select_prev_item()
         else
-          cmp.complete()
+          feedkeys.call(keymap.t('<C-z>'), 'n')
         end
       end,
     },


### PR DESCRIPTION
This partially reverts 53f49c5145d05a53b997d3f647f97e5ac8e9bd5c so that if you type `:!` and press `<Tab>` or `<S-Tab>` the command line completions shows up again.

Fix #1441