### PR TITLE
fix: de-duplicate completion correctly

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -268,7 +268,7 @@ entry.get_vim_item = function(self, suggest_offset)
 
     -- remove duplicated string.
     if self:get_offset() ~= self.context.cursor.col then
-      for i = 1, #word - 1 do
+      for i = 1, #word do
         if str.has_prefix(self.context.cursor_after_line, string.sub(word, i, #word)) then
           word = string.sub(word, 1, i - 1)
           break


### PR DESCRIPTION
When the common overlap between the candidate we're trying to complete and the characters after the cursor is less than 2, nvim-cmp will fail to de-duplicate that redundant character. For example, trying to complete `foobar` in `foob|r` will get you `foobarr`.

This fix ensures that last character of the candidate also gets checked.

Ref: https://github.com/hrsh7th/nvim-cmp/issues/1463