### PR TITLE
Use label if sortText is not set in cmp.config.compare.sort_text

### DIFF
--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -77,6 +77,13 @@ compare.sort_text = function(entry1, entry2)
     elseif diff > 0 then
       return false
     end
+  elseif entry1.completion_item.label and entry2.completion_item.label then
+    local diff = vim.stricmp(entry1.completion_item.label, entry2.completion_item.label)
+    if diff < 0 then
+      return true
+    elseif diff > 0 then
+      return false
+    end
   end
 end
 


### PR DESCRIPTION
According to the spec:

```
/**
 * A string that should be used when comparing this item
 * with other items. When omitted the label is used
 * as the sort text for this item.
 */
sortText?: string;
```

See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/