### PR TITLE
fix: annotate complete option as optional

### DIFF
--- a/lua/cmp/config/mapping.lua
+++ b/lua/cmp/config/mapping.lua
@@ -133,7 +133,7 @@ mapping.preset.cmdline = function(override)
 end
 
 ---Invoke completion
----@param option cmp.CompleteParams
+---@param option? cmp.CompleteParams
 mapping.complete = function(option)
   return function(fallback)
     if not require('cmp').complete(option) then


### PR DESCRIPTION
Annotates the complete option as optional. The current suggest default complete mapping without parameters `cmp.mapping.complete()` throws a `missing-parameter` warning if having added the cmp dir to runtime for type assistance.