### PR TITLE
fix(rockspec): add doc folder

### DIFF
--- a/nvim-cmp-scm-1.rockspec
+++ b/nvim-cmp-scm-1.rockspec
@@ -32,6 +32,7 @@ build = {
   type = 'builtin',
   copy_directories = {
     'autoload',
+    'doc',
     'plugin'
   }
 }


### PR DESCRIPTION
Fixes the missing documentation was missing when installing through luarocks.