### PR TITLE
Adds option for setting the filetype of documentation window

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -420,7 +420,7 @@ entry.get_completion_item = function(self)
 end
 
 ---Create documentation
----@return string
+---@return {content: string, ft: string}
 entry.get_documentation = function(self)
   local item = self:get_completion_item()
 
@@ -439,7 +439,11 @@ entry.get_documentation = function(self)
     })
   end
 
+  local ft = "cmp_ros"
   local documentation = item.documentation
+  if documentation ~= nil and documentation.ft ~= nil then
+    ft = documentation.ft
+  end
   if type(documentation) == 'string' and documentation ~= '' then
     local value = str.trim(documentation)
     if value ~= '' then
@@ -458,7 +462,7 @@ entry.get_documentation = function(self)
     end
   end
 
-  return vim.lsp.util.convert_input_to_markdown_lines(documents)
+  return {content = vim.lsp.util.convert_input_to_markdown_lines(documents), ft = ft}
 end
 
 ---Get completion item kind

--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -439,7 +439,7 @@ entry.get_documentation = function(self)
     })
   end
 
-  local ft = "cmp_ros"
+  local ft = "cmp_docs"
   local documentation = item.documentation
   if documentation ~= nil and documentation.ft ~= nil then
     ft = documentation.ft

--- a/lua/cmp/types/lsp.lua
+++ b/lua/cmp/types/lsp.lua
@@ -225,6 +225,7 @@ lsp.CompletionItemKind = vim.tbl_add_reverse_lookup(lsp.CompletionItemKind)
 ---@class lsp.MarkupContent
 ---@field public kind lsp.MarkupKind
 ---@field public value string
+---@field public ft string
 
 ---@class lsp.Position
 ---@field public line integer

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -17,7 +17,6 @@ docs_view.new = function()
   self.window:option('scrolloff', 0)
   self.window:option('showbreak', 'NONE')
   self.window:option('wrap', true)
-  self.window:buffer_option('filetype', 'cmp_docs')
   return self
 end
 
@@ -38,20 +37,20 @@ docs_view.open = function(self, e, view)
   local right_space = vim.o.columns - (view.col + view.width) - 1
   local left_space = view.col - 1
   local max_width = math.min(documentation.max_width, math.max(left_space, right_space))
-
   -- Update buffer content if needed.
   if not self.entry or e.id ~= self.entry.id then
     local documents = e:get_documentation()
-    if #documents == 0 then
+    if #documents.content == 0 then
       return self:close()
     end
 
     self.entry = e
     vim.api.nvim_buf_call(self.window:get_buffer(), function()
       vim.cmd([[syntax clear]])
+      self.window:buffer_option('filetype', documents.ft)
       vim.api.nvim_buf_set_lines(self.window:get_buffer(), 0, -1, false, {})
     end)
-    vim.lsp.util.stylize_markdown(self.window:get_buffer(), documents, {
+    vim.lsp.util.stylize_markdown(self.window:get_buffer(), documents.content, {
       max_width = max_width - border_info.horiz,
       max_height = documentation.max_height,
     })


### PR DESCRIPTION
This adds the option to add a custom filetype for the documentation window. An entry with set filetype looks tile this:
```lua
    completion_item.documentation = {
      kind = require("cmp").lsp.MarkupKind.PlainText,
      ft = "ros",
      value = table.concat(completion_item.data.msg.definition, "\n"),
    }
```