### PR TITLE
Select nth item in the completion list, and number first ten items

### DIFF
--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -43,6 +43,7 @@ return function()
     formatting = {
       expandable_indicator = true,
       fields = { 'abbr', 'kind', 'menu' },
+      number_options = false,
       format = function(_, vim_item)
         return vim_item
       end,

--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -149,6 +149,19 @@ cmp.select_next_item = cmp.sync(function(option)
   return false
 end)
 
+---Select the nth item in the completion list
+---@param n integer
+cmp.select_nth = cmp.sync(function(n, option)
+  option = option or {}
+  if cmp.core.view:visible() then
+    local release = cmp.core:suspend()
+    cmp.core.view:select_nth(n, option)
+    vim.schedule(release)
+    return true
+  end
+  return false
+end)
+
 ---Select prev item if possible
 cmp.select_prev_item = cmp.sync(function(option)
   option = option or {}

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -137,6 +137,7 @@ cmp.ItemField = {
 ---@class cmp.FormattingConfig
 ---@field public fields cmp.ItemField[]
 ---@field public expandable_indicator boolean
+---@field public number_options boolean
 ---@field public format fun(entry: cmp.Entry, vim_item: vim.CompletedItem): vim.CompletedItem
 
 ---@class cmp.SnippetConfig

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -164,12 +164,14 @@ view.select_next_item = function(self, option)
   self:_get_entries_view():select_next_item(option)
 end
 
+---Select the nth menu item showing on screen
 view.select_nth = function (self, n, options)
   local entries_view = self:_get_entries_view()
+  local win_info = vim.fn.getwininfo(entries_view:get_window().win)[1]
   if entries_view:is_direction_top_down() then
-    entries_view:_select(n, options)
+    entries_view:_select(n + win_info.topline - 1, options)
   else
-    entries_view:_select(entries_view:info().height + 1 - n, options)
+    entries_view:_select(win_info.botline + 1 - n, options)
   end
 end
 

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -164,8 +164,13 @@ view.select_next_item = function(self, option)
   self:_get_entries_view():select_next_item(option)
 end
 
-view.select_nth = function (self, n, option)
-  self:_get_entries_view():_select(n, option)
+view.select_nth = function (self, n, options)
+  local entries_view = self:_get_entries_view()
+  if entries_view:is_direction_top_down() then
+    entries_view:_select(n, options)
+  else
+    entries_view:_select(entries_view:info().height + 1 - n, options)
+  end
 end
 
 ---Select prev menu item.

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -164,6 +164,10 @@ view.select_next_item = function(self, option)
   self:_get_entries_view():select_next_item(option)
 end
 
+view.select_nth = function (self, n, option)
+  self:_get_entries_view():_select(n, option)
+end
+
 ---Select prev menu item.
 ---@param option cmp.SelectOption
 view.select_prev_item = function(self, option)

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -64,6 +64,9 @@ custom_entries_view.new = function()
         if e then
           local v = e:get_view(self.offset, buf)
           local o = config.get().window.completion.side_padding
+          if config.get().formatting.number_options then
+            o = o + 2
+          end
           local a = 0
           for _, field in ipairs(fields) do
             if field == types.cmp.ItemField.Abbr then
@@ -147,6 +150,9 @@ custom_entries_view.open = function(self, offset, entries)
   width = width + self.column_width.abbr + (self.column_width.kind > 0 and 1 or 0)
   width = width + self.column_width.kind + (self.column_width.menu > 0 and 1 or 0)
   width = width + self.column_width.menu + 1
+  if config.get().formatting.number_options then
+    width = width + 3
+  end
 
   local height = vim.api.nvim_get_option('pumheight')
   height = height ~= 0 and height or #self.entries
@@ -249,12 +255,25 @@ custom_entries_view.draw = function(self)
   local texts = {}
   local fields = config.get().formatting.fields
   local entries_buf = self.entries_win:get_buffer()
+  local index = 0
+  if not config.get().formatting.number_options then
+    index = 10 -- this disables adding the text to the things
+  end
   for i = topline, botline - 1 do
     local e = self.entries[i + 1]
     if e then
       local view = e:get_view(self.offset, entries_buf)
       local text = {}
       table.insert(text, string.rep(' ', config.get().window.completion.side_padding))
+
+      -- add the number if it's configured
+      if index < 10 then
+        table.insert(text, string.format('%s ', index))
+        index = index + 1
+      else
+        table.insert(text, '  ')
+      end
+
       for _, field in ipairs(fields) do
         table.insert(text, view[field].text)
         table.insert(text, string.rep(' ', 1 + self.column_width[field] - view[field].width))

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -99,6 +99,10 @@ custom_entries_view.new = function()
   return self
 end
 
+custom_entries_view.get_window = function(self)
+  return self.entries_win
+end
+
 custom_entries_view.ready = function()
   return vim.fn.pumvisible() == 0
 end

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -256,9 +256,13 @@ custom_entries_view.draw = function(self)
   local fields = config.get().formatting.fields
   local entries_buf = self.entries_win:get_buffer()
   local index = 0
-  if not config.get().formatting.number_options then
-    index = 10 -- this disables adding the text to the things
+  local delta = 1
+
+  if not self:is_direction_top_down() then
+    index = info.height - 1
+    delta = -1
   end
+
   for i = topline, botline - 1 do
     local e = self.entries[i + 1]
     if e then
@@ -266,13 +270,12 @@ custom_entries_view.draw = function(self)
       local text = {}
       table.insert(text, string.rep(' ', config.get().window.completion.side_padding))
 
-      -- add the number if it's configured
-      if index < 10 then
+      if config.get().formatting.number_options and index < 10 then
         table.insert(text, string.format('%s ', index))
-        index = index + 1
       else
         table.insert(text, '  ')
       end
+      index = index + delta
 
       for _, field in ipairs(fields) do
         table.insert(text, view[field].text)


### PR DESCRIPTION
As discussed in #1482 being able to press alt + n to select the nth item in the completion list would be pretty cool. Unfortunately there is not a great way to implement that right now, and there's (as far as I could tell) no way to number the items in the completion menu. This PR is the result of that.

- Adds a configuration option to number the first 10 items in the completion list 0 through 9
- Adds `cmp.select_nth(n)` which selects the nth item in the completion list. 

I've accounted for scrolling, and the completion list being flipped.

![image](https://user-images.githubusercontent.com/56943754/226140606-c6286d64-8735-4ffe-a505-6af571ae7a25.png)

The new function allows for alt+n bindings to select items like the following:
```lua
for i = 0, 9, 1 do
  local key = table.concat({ "<M-", i, ">" })
  keys[key] = function(fallback)
    if cmp.visible() and #cmp.get_entries() > i then
      return cmp.select_nth(i + 1)
    end

    return fallback()
  end
end
``` 

`select_nth` doesn't appear to work in command line completion. The numbering isn't very configurable, but I'd be happy to add some options to configure that (ie. show the numbers on the right, start at 1, number the first x items, and stuff like that)

If this gets accepted, I plan to add a wiki page detailing how to setup binds like this, with a section for macos users, b/c alt + 1 on macos by default types some symbol or another. 