### PR TITLE
Add selectIfUnique option in completion confirm

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -185,12 +185,13 @@ end)
 cmp.confirm = cmp.sync(function(option, callback)
   option = option or {}
   option.select = option.select or false
+  option.selectIfUnique = option.selectIfUnique or false
   option.behavior = option.behavior or cmp.get_config().confirmation.default_behavior or cmp.ConfirmBehavior.Insert
   callback = callback or function() end
 
   if cmp.core.view:visible() then
     local e = cmp.core.view:get_selected_entry()
-    if not e and option.select then
+    if not e and (option.select or (option.selectIfUnique and (#(cmp.core.view:get_entries()) == 1))) then
       e = cmp.core.view:get_first_entry()
     end
     if e then


### PR DESCRIPTION
As title.

This is to satisfy the desire to automatically select the first entry if there is only one entry upon confirm completion without actual selecting any entries beforehand.

Feel free to close this if you think this is not desirable/should be done in user's own config instead.

And thanks for writing this plugin :)