### PR TITLE
Document cmd.ConfirmBehavior options

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -218,6 +218,14 @@ NOTE: `<Cmd>lua require('cmp').complete()<CR>` can be used to call these functio
   If you didn't select any item and the option table contains `select = true`,
   nvim-cmp will automatically select the first item.
 
+  You can control, how the completion item is injected into
+  the file through the `behavior` option:
+
+  `behavior=cmd.ConfirmBehavior.Insert`: inserts the selected item and
+    moves adjacent text to the right (default).
+  `bheavior=cmd.ConfirmBehavior.Replace`: replaces adjecent text with
+    the selected item.
+
 *cmp.event:on* (%EVENT_NAME%, callback)
   Subscribe to nvim-cmp's event. Events are listed below.
 


### PR DESCRIPTION
The way nvim-cmp inserts text can be controlled via the `behavior` option (part of `ConfirmOption`). There are many tutorials mentioning those, and they are well received.

Yet, the documentation does not mention them.

This PR adds a bit of documentation what options are available, and how they differ.