### PR TITLE
vim.treesitter.query.get_node_text deprecated fixed

### DIFF
--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -203,7 +203,7 @@ compare.scopes = setmetatable({
         for _, definition in pairs(definitions) do
           if s <= definition.node:start() and definition.node:end_() <= e then
             if scope:id() == locals.containing_scope(definition.node, buf):id() then
-              local text = vim.treesitter.query.get_node_text(definition.node, buf) or ''
+              local text = vim.treesitter.get_node_text(definition.node, buf) or ''
               if not self.scopes_map[text] then
                 self.scopes_map[text] = depth
               end


### PR DESCRIPTION
I update my nvim to 0.9.0 and treesitter to 0.20.8. Then the vim show the issue that vim.treesitter.query.get_node_text has deprecated. The new api is vim.treesitter.get_node_text. so I replace the deprecated api to the newer one from the source code.
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/72802064/231316140-824bca86-5c02-4e6c-ac63-1d176e22c547.png">
