### PR TITLE
feat: add col_offset option for doc view

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -629,10 +629,11 @@ window.completion.scrolloff~
   Specify the window's scrolloff option.
   See |'scrolloff'|.
 
-                                       *cmp-config.window.completion.col_offset*
+                       *cmp-config.window.{completion,documentation}.col_offset*
 window.completion.col_offset~
   `number`
   Offsets the completion window relative to the cursor.
+  Offsets the documentation window relative to the completion window.
 
                                      *cmp-config.window.completion.side_padding*
 window.completion.side_padding~

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -105,6 +105,7 @@ return function()
         max_width = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
         border = { '', '', '', ' ', '', '', '', ' ' },
         winhighlight = 'FloatBorder:NormalFloat',
+        col_offset = 0,
       },
     },
   }

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -118,6 +118,7 @@ cmp.ItemField = {
 ---@field public max_height integer|nil
 ---@field public scrolloff integer|nil
 ---@field public scrollbar boolean|true
+---@field public col_offset integer|nil
 
 ---@class cmp.ConfirmationConfig
 ---@field public default_behavior cmp.ConfirmBehavior

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -58,10 +58,11 @@ docs_view.open = function(self, e, view)
   end
 
   -- Calculate window size.
-  local width, height = vim.lsp.util._make_floating_popup_size(vim.api.nvim_buf_get_lines(self.window:get_buffer(), 0, -1, false), {
-    max_width = max_width - border_info.horiz,
-    max_height = documentation.max_height - border_info.vert,
-  })
+  local width, height = vim.lsp.util._make_floating_popup_size(
+    vim.api.nvim_buf_get_lines(self.window:get_buffer(), 0, -1, false), {
+      max_width = max_width - border_info.horiz,
+      max_height = documentation.max_height - border_info.vert,
+    })
   if width <= 0 or height <= 0 then
     return self:close()
   end
@@ -95,7 +96,7 @@ docs_view.open = function(self, e, view)
     width = width,
     height = height,
     row = view.row,
-    col = col,
+    col = col + documentation.col_offset,
     border = documentation.border,
     zindex = documentation.zindex or 50,
   }
@@ -103,7 +104,7 @@ docs_view.open = function(self, e, view)
 
   -- Correct left-col for scrollbar existence.
   if left then
-    style.col = style.col - self.window:info().scrollbar_offset
+    style.col = col - self.window:info().scrollbar_offset - documentation.col_offset
     self.window:open(style)
   end
 end


### PR DESCRIPTION
I would like to add a `col_offset` field for the documentation view similar to the completion view. I prefer borderless windows with the windows separated. I have attached screenshots of the change. Please let me know what you think. Thanks!

## col_offset=0
![docs_viewlua-4haevg-6](https://user-images.githubusercontent.com/10135646/233675039-02358053-ad2f-45b6-bc20-3d7778a7c4d6.png)
![docs_viewlua-4haevg-7](https://user-images.githubusercontent.com/10135646/233675069-e31fbe95-7396-477a-9159-edd4b156d78d.png)
## col_offset=2
![docs_viewlua-n7jopr-3](https://user-images.githubusercontent.com/10135646/233675103-9e6912ef-f9fb-47e4-93d7-153a1e6d03b2.png)
![docs_viewlua-n7jopr-2](https://user-images.githubusercontent.com/10135646/233675089-a415f4eb-a2e0-4b40-a5a8-c4377af4715e.png)
