### PR TITLE
fix: #1533

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -62,11 +62,12 @@ entry.get_offset = function(self)
       if range then
         offset = self.context.cache:ensure('entry:' .. 'get_offset:' .. tostring(range.start.character), function()
           for idx = range.start.character + 1, self.source_offset do
-            if not char.is_white(string.byte(self.context.cursor_line, idx)) then
+            local byte = string.byte(self.context.cursor_line, idx)
+            if byte ~= nil and not char.is_white(byte) then
               return idx
             end
           end
-          return offset
+          return offset + 1
         end)
       end
     else

--- a/lua/cmp/entry_spec.lua
+++ b/lua/cmp/entry_spec.lua
@@ -302,4 +302,37 @@ describe('entry', function()
     assert.are.equal(e:get_vim_item(e:get_offset()).word, '__init__(self) -> None:')
     assert.are.equal(e:get_filter_text(), '__init__')
   end)
+
+  it('[#1533] keyword pattern that include whitespace', function()
+    local state = spec.state(' ', 3, 2)
+    local state_source = state.source()
+
+    state_source.get_keyword_pattern = function(_)
+      return '.'
+    end
+
+    state.input(' ')
+    local e = entry.new(state.manual(), state_source, {
+      filterText = "constructor() {\n     ... st = 'test';\n  ",
+      kind = 1,
+      label = "constructor() {\n     ... st = 'test';\n  }",
+      textEdit = {
+        newText = "constructor() {\n    this.test = 'test';\n  }",
+        range = {
+          ["end"] = {
+            character = 2,
+            col = 3,
+            line = 2,
+            row = 3
+          },
+          start = {
+            character = 0,
+            line = 2
+          }
+        }
+      }
+    })
+    assert.are.equal(e:get_offset(), 3)
+    assert.are.equal(e:get_vim_item(e:get_offset()).word, 'constructor() {')
+  end)
 end)


### PR DESCRIPTION
1. With `string.byte(self.context.cursor_line, idx) == nil` it was evaluating to true which doesn't seem correct. But usually it happen for trailing byte, so idx returned was actually equals to `offset`.
```lua
char.is_white(string.byte(self.context.cursor_line, idx))
```
2. When all the chars are whitespaces, the actual offset returns and number of spaces, but the first element index should be +1.