### PR TITLE
fix(ghost_text): safely apply virtual_text highlight

### DIFF
--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -37,7 +37,7 @@ ghost_text_view.new = function()
       if #text > 0 then
         vim.api.nvim_buf_set_extmark(0, ghost_text_view.ns, row - 1, col, {
           right_gravity = false,
-          virt_text = { { text, c.hl_group or 'Comment' } },
+          virt_text = { { text, type(c) == 'table' and c.hl_group or 'Comment' } },
           virt_text_pos = 'overlay',
           hl_mode = 'combine',
           ephemeral = true,


### PR DESCRIPTION
Fix #1565. 

Somehow, commit [5a80cd4](https://github.com/hrsh7th/nvim-cmp/commit/5a80cd4eca61cd4f5e10165bbb5dc5411d6a5a76) introduce a regression where `experimental.ghost_text` cannot be enabled with a boolean anymore.

This fix check first the type of the ghost_text config before applying the highlight.
