### PR TITLE
docs: fix typos, add confirm.behavior example cfg

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -219,14 +219,20 @@ NOTE: `<Cmd>lua require('cmp').complete()<CR>` can be used to call these functio
   If you didn't select any item and the option table contains `select = true`,
   nvim-cmp will automatically select the first item.
 
-  You can control, how the completion item is injected into
+  You can control how the completion item is injected into
   the file through the `behavior` option:
 
-  `behavior=cmd.ConfirmBehavior.Insert`: inserts the selected item and
+  `behavior=cmp.ConfirmBehavior.Insert`: inserts the selected item and
     moves adjacent text to the right (default).
-  `behavior=cmd.ConfirmBehavior.Replace`: replaces adjecent text with
-    the selected item.
-
+  `behavior=cmp.ConfirmBehavior.Replace`: replaces adjecent text with
+    the selected item.    
+>lua
+  cmp.setup {
+    mapping = {
+      ["<CR>"] = cmp.mapping.confirm({ select = true, behavior = cmp.ConfirmBehavior.Replace }),
+    }
+  }
+<
 *cmp.event:on* (%EVENT_NAME%, callback)
   Subscribe to nvim-cmp's event. Events are listed below.
 


### PR DESCRIPTION
The documentation that explained ConfirmBehavior had typos and lacked a configuration example. This commit fixes the typos and provides an example configuration.