### PR TITLE
fix: handle godot LSP better

### DIFF
--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -423,7 +423,11 @@ core.confirm = function(self, e, option, callback)
     local completion_item = misc.copy(e:get_completion_item())
     if not completion_item.textEdit then
       completion_item.textEdit = {}
-      completion_item.textEdit.newText = completion_item.insertText or completion_item.word or completion_item.label
+      local insertText = completion_item.insertText
+      if misc.empty(insertText) then
+        insertText = nil
+      end
+      completion_item.textEdit.newText = insertText or completion_item.word or completion_item.label
     end
     local behavior = option.behavior or config.get().confirmation.default_behavior
     if behavior == types.cmp.ConfirmBehavior.Replace then


### PR DESCRIPTION
This fixes #1119 (basically using the solution prescribed there, except `misc.safe` is no longer a function). I'm not super familiar with LSP, but I use neovim and godot frequently and would like to see this working. Let me know how I can improve this. In my testing this fixed the issue and didn't cause any noticeable side-effects.