### PR TITLE
feat(ghost_view): made inline ghost text optional. Enabled by default on 0.10.0

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -371,6 +371,9 @@ NOTE: `kind` is a symbol after each completion option.
 *CmpItemMenu*
   The menu field's highlight group.
 
+*CmpGhostText*
+  Highlight group for ghost text. Defaults to `Comment`
+
 ==============================================================================
 FileType                                                          *cmp-filetype*
 

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -677,8 +677,9 @@ window.documentation.max_height~
 
                                             *cmp-config.experimental.ghost_text*
 experimental.ghost_text~
-  `boolean | { hl_group = string }`
-  Whether to enable the ghost_text feature.
+  `boolean | { hl_group = string, inline = boolean }`
+  Whether to enable the ghost_text feature. Defaults to inline when running
+  on Neovim >= 0.10.0
 
 ==============================================================================
 Config Helper                                                *cmp-config-helper*

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -150,6 +150,7 @@ cmp.ItemField = {
 
 ---@class cmp.GhostTextConfig
 ---@field hl_group string
+---@field inline? boolean Defaults to true
 
 ---@class cmp.SourceConfig
 ---@field public name string

--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -5,6 +5,8 @@ local types = require('cmp.types')
 local api = require('cmp.utils.api')
 
 ---@class cmp.GhostTextView
+---@field win? number
+---@field entry? cmp.Entry
 local ghost_text_view = {}
 
 ghost_text_view.ns = vim.api.nvim_create_namespace('cmp:GHOST_TEXT')
@@ -25,6 +27,15 @@ ghost_text_view.new = function()
         return
       end
 
+      local opts = vim.tbl_deep_extend('force', {
+        hl_group = 'CmpGhostText',
+        inline = true,
+      }, type(c) == 'table' and c or {})
+
+      if not has_inline then
+        opts.inline = false
+      end
+
       if not self.entry then
         return
       end
@@ -35,18 +46,16 @@ ghost_text_view.new = function()
       end
 
       local line = vim.api.nvim_get_current_line()
-      if not has_inline then
-        if string.sub(line, col + 1) ~= '' then
-          return
-        end
+      if not opts.inline and string.sub(line, col + 1) ~= '' then
+        return
       end
 
       local text = self.text_gen(self, line, col)
       if #text > 0 then
         vim.api.nvim_buf_set_extmark(0, ghost_text_view.ns, row - 1, col, {
           right_gravity = false,
-          virt_text = { { text, type(c) == 'table' and c.hl_group or 'Comment' } },
-          virt_text_pos = has_inline and 'inline' or 'overlay',
+          virt_text = { { text, opts.hl_group } },
+          virt_text_pos = opts.inline and 'inline' or 'overlay',
           hl_mode = 'combine',
           ephemeral = true,
         })

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -18,6 +18,7 @@ vim.api.nvim_set_hl(0, 'CmpItemAbbrMatch', { link = 'CmpItemAbbrMatchDefault', d
 vim.api.nvim_set_hl(0, 'CmpItemAbbrMatchFuzzy', { link = 'CmpItemAbbrMatchFuzzyDefault', default = true })
 vim.api.nvim_set_hl(0, 'CmpItemKind', { link = 'CmpItemKindDefault', default = true })
 vim.api.nvim_set_hl(0, 'CmpItemMenu', { link = 'CmpItemMenuDefault', default = true })
+vim.api.nvim_set_hl(0, 'CmpGhostText', { link = 'Comment', default = true })
 for kind in pairs(types.lsp.CompletionItemKind) do
   if type(kind) == 'string' then
     local name = ('CmpItemKind%s'):format(kind)


### PR DESCRIPTION
Added an `inline` config option for ghost text and a new hl group `CmpGhostText` that defaults to `Comment`.

Inline is still enabled by default on Neovim 0.10.0, but can now be disabled:

```lua
  {
    "hrsh7th/nvim-cmp",
    dev = true,
    opts = {
      experimental = {
        ghost_text = { inline = false },
      },
    },
  },
```