### PR TITLE
Adding check for `isyieldable`.

### DIFF
--- a/lua/cmp/utils/async.lua
+++ b/lua/cmp/utils/async.lua
@@ -276,7 +276,7 @@ end
 
 -- This will yield when called from a coroutine
 function async.yield(...)
-  if not coroutine.isyieldable() then
+  if coroutine.isyieldable ~= nil and not coroutine.isyieldable() then
     error('Trying to yield from a non-yieldable context')
     return ...
   end


### PR DESCRIPTION
I recently synced my plugins and it seems like #1583 did cause an issue. Specifically what was happening is that when getting sources, the `couroutine.isyieldable` method would not exist. I did some research looking through neovim's docs/help-pages and found no reference to this function both online and in the help-pages. My rudimentary conclusion is that potentially I am running an outdated version of neovim where this method does not exist on coroutines *yet* and I potentially need to upgrade.

If I am right in this I suggest either adding a note to the breaking changes page or refine/merge this PR so that other versions of neovim continue to work here.

My current running version of neovim is `v0.9.0 Release` with LuaJIT `2.0.4`