### PR TITLE
Try to fix input deplay

### DIFF
--- a/lua/cmp/utils/async.lua
+++ b/lua/cmp/utils/async.lua
@@ -29,9 +29,7 @@ vim.api.nvim_create_autocmd('VimLeavePre', {
 ---@return cmp.AsyncThrottle
 async.throttle = function(fn, timeout)
   local time = nil
-  local timer = assert(vim.loop.new_timer())
   local _async = nil ---@type Async?
-  timers[#timers + 1] = timer
   return setmetatable({
     running = false,
     timeout = timeout,
@@ -44,7 +42,6 @@ async.throttle = function(fn, timeout)
       if reset_time ~= false then
         time = nil
       end
-      timer:stop()
       if _async then
         _async:cancel()
         _async = nil


### PR DESCRIPTION
**Try solve:** https://github.com/hrsh7th/nvim-cmp/issues/1606 https://github.com/hrsh7th/nvim-cmp/issues/1608

I'm not sure what it's correct solution. Because most important problem it this code

```lua
cmp.sync = function(callback)
  return function(...)
    cmp.core.filter:sync(1000)
    if callback then
      return callback(...)
    end
  end
end
``` 

https://github.com/hrsh7th/nvim-cmp/blob/fc0f694af1a742ada77e5b1c91ff405c746f4a26/lua/cmp/utils/async.lua#L38-L42

This function using in other cmp function like a cmp.visible. There are enough plugins using this functions.
For example for check what autocomplete menu is open lsp-signature call cmp.visible on every move cursor. If LSP server respond fastly we not see input lag. But when lsp server respond slowly we have input delay ~1 sec. IDK maybe input delay referenced with incorrect work vim.wait but more true way i think make async analogs for sync functions like cmp.visible. This will definitely solve the problem (i think)