### PR TITLE
fix: allow ghost_text type to accept values of true

### DIFF
--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -150,7 +150,7 @@ cmp.ItemField = {
 ---@field public expand fun(args: cmp.SnippetExpansionParams)
 
 ---@class cmp.ExperimentalConfig
----@field public ghost_text cmp.GhostTextConfig|false
+---@field public ghost_text cmp.GhostTextConfig|boolean
 
 ---@class cmp.GhostTextConfig
 ---@field hl_group string


### PR DESCRIPTION
Fix type of ghost_text to not create a warning when set to true
<img width="625" alt="Screenshot 2023-06-10 at 11 44 59 AM" src="https://github.com/hrsh7th/nvim-cmp/assets/92702993/2eec2460-1edb-40e0-8f01-1b736bed0c2f">

The existing type appears to be forcing the user to supply a table containing a hl_group for ghost text by specifying a value of false otherwise,
<img width="384" alt="Screenshot 2023-06-10 at 11 54 16 AM" src="https://github.com/hrsh7th/nvim-cmp/assets/92702993/42a5ca35-bc3c-497a-8c33-040f2ec88b53">
and yet the ghost text implementation clearly allows a value of ghost_text other than a table with hl_group by defaulting to 'Comment'
<img width="596" alt="Screenshot 2023-06-10 at 11 55 28 AM" src="https://github.com/hrsh7th/nvim-cmp/assets/92702993/e6f605fe-0669-4629-8a14-76067704fd78">

