### PR TITLE
fix type of the config.autocomplete to accept false

### DIFF
--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -111,7 +111,7 @@ cmp.ItemField = {
 ---@field documentation cmp.WindowConfig|nil
 
 ---@class cmp.CompletionConfig
----@field public autocomplete cmp.TriggerEvent[]
+---@field public autocomplete cmp.TriggerEvent[]|false
 ---@field public completeopt string
 ---@field public get_trigger_characters fun(trigger_characters: string[]): string[]
 ---@field public keyword_length integer


### PR DESCRIPTION
I have fixed it to match the following as described in the help

> completion.autocomplete
>   `cmp.TriggerEvent[] | false`
