### PR TITLE
fix(ghost_text): `ephemeral` causes inline virt-text support check to fail

### DIFF
--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -15,7 +15,7 @@ local has_inline = (function()
       virt_text = { { ' ', 'Comment' } },
       virt_text_pos = 'inline',
       hl_mode = 'combine',
-      ephemeral = true,
+      ephemeral = false,
     })
     vim.api.nvim_buf_del_extmark(0, ghost_text_view.ns, id)
   end))


### PR DESCRIPTION
I'm on neovim nightly and inline `ghost_text` was not working for me. TL;DR: `ephemeral` option seems to somehow cause the check for inline virt-text support to fail, while it's actually supported.

I noticed you check for inline virt-text support here:
https://github.com/hrsh7th/nvim-cmp/blob/2743dd989e9b932e1b4813a4927d7b84272a14e2/lua/cmp/view/ghost_text_view.lua#L12-L22

So, I ran it to see whether it reports if I have inline support or not and I got an error back:

```lua
local ns = vim.api.nvim_create_namespace('thing')
local id = vim.api.nvim_buf_set_extmark(0, ns, 0, 0,{
  virt_text = { { ' ', 'Comment' } },
  virt_text_pos = 'inline',
  hl_mode = 'combine',
  ephemeral = true
})
vim.api.nvim_buf_del_extmark(0, ns, id)
```

```
E5108: Error executing lua [string ":lua"]:1: not yet implemented
stack traceback:
        [C]: in function 'nvim_buf_set_extmark'
        [string ":lua"]:1: in main chunk
```

I tracked it down to [this](https://github.com/neovim/neovim/blob/3ecd45ded044c47efa76b74e9e3b720fbe27adc7/src/nvim/api/extmark.c#L875-L889) snippet from neovim's source code:

```c
  if (ephemeral && decor_state.win && decor_state.win->w_buffer == buf) {
    decor_add_ephemeral((int)line, (int)col, line2, col2, &decor, (uint64_t)ns_id, id);
  } else {
    if (ephemeral) {
      api_set_error(err, kErrorTypeException, "not yet implemented");
      goto error;
    }


    extmark_set(buf, (uint32_t)ns_id, &id, (int)line, (colnr_T)col, line2, col2,
                has_decor ? &decor : NULL, right_gravity, end_right_gravity,
                kExtmarkNoUndo, err);
    if (ERROR_SET(err)) {
      goto error;
    }
  }
```

Which suggested it had something to do with the `ephemeral` option, so I set it to `false` and that fixed it. I am not really sure why `ephemeral` is needed during the check if you delete the virt-text afterwards anyway. Feel free to correct me.