### PR TITLE
Add toggle documentation functionality

### DIFF
--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -41,6 +41,7 @@ return function()
       completeopt = 'menu,menuone,noselect',
       keyword_pattern = [[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%(-\w*\)*\)]],
       keyword_length = 1,
+      doc_visibility = 'OnEntryChange',
     },
 
     formatting = {

--- a/lua/cmp/config/mapping.lua
+++ b/lua/cmp/config/mapping.lua
@@ -178,6 +178,15 @@ mapping.scroll_docs = function(delta)
   end
 end
 
+-- Toggle the documentation window.
+mapping.toggle_docs = function()
+  return function(fallback)
+    if not require('cmp').toggle_docs() then
+      fallback()
+    end
+  end
+end
+
 ---Select next completion item.
 mapping.select_next_item = function(option)
   return function(fallback)

--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -181,6 +181,16 @@ cmp.scroll_docs = cmp.sync(function(delta)
   end
 end)
 
+---Toggle the documentation window.
+cmp.toggle_docs = cmp.sync(function()
+  if cmp.core.view:visible() then
+    cmp.core.view:toggle_docs()
+    return true
+  else
+    return false
+  end
+end)
+
 ---Confirm completion
 cmp.confirm = cmp.sync(function(option, callback)
   option = option or {}

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -39,6 +39,13 @@ cmp.ItemField = {
   Menu = 'menu',
 }
 
+---@alias cmp.DocVisibility 'OnEntryChange' | 'Toggle' | 'Disabled'
+cmp.DocVisibility = {
+  OnEntryChange = 'OnEntryChange',
+  Toggle = 'Toggle',
+  Disabled = 'Disabled',
+}
+
 ---@class cmp.ContextOption
 ---@field public reason cmp.ContextReason|nil
 
@@ -117,6 +124,7 @@ cmp.ItemField = {
 ---@field public get_trigger_characters fun(trigger_characters: string[]): string[]
 ---@field public keyword_length integer
 ---@field public keyword_pattern string
+---@field public doc_visibility cmp.DocVisibility
 
 ---@class cmp.WindowConfig
 ---@field public border string|string[]

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -156,6 +156,21 @@ view.visible = function(self)
   return self:_get_entries_view():visible()
 end
 
+---Toggle the documentation window.
+view.toggle_docs = function(self)
+  local e = self:get_selected_entry()
+  if not e or self.docs_view:visible() then
+    self.docs_view:close()
+  else
+    e:resolve(vim.schedule_wrap(self.resolve_dedup(function()
+      if not self:visible() then
+        return
+      end
+      self.docs_view:open(e, self:_get_entries_view():info())
+    end)))
+  end
+end
+
 ---Scroll documentation window if possible.
 ---@param delta integer
 view.scroll_docs = function(self, delta)
@@ -239,7 +254,9 @@ view.on_entry_change = async.throttle(function(self)
       if not self:visible() then
         return
       end
-      self.docs_view:open(e, self:_get_entries_view():info())
+      if config.get().completion.doc_visibility == 'OnEntryChange' then
+        self.docs_view:open(e, self:_get_entries_view():info())
+      end
     end)))
   else
     self.docs_view:close()

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -27,7 +27,8 @@ end
 ---@param view cmp.WindowStyle
 docs_view.open = function(self, e, view)
   local documentation = config.get().window.documentation
-  if not documentation then
+  local vis = config.get().completion.doc_visibility
+  if not documentation or vis == 'Disabled' then
     return
   end
 


### PR DESCRIPTION
Fixes #674 

I haven't documented yet how the setting works since I first want to get a thumbs up from @hrsh7th, but the idea is:

<s>- If `completion.doc_visibility` is `'OnEntryChange'`, then the documentation window will appear when the currently selected entry changes.
- If set to `'Toggle'`, then it is assumed that the user will create the corresponding mapping to open/close the window.
- If set to `'Disabled'`, then the window will never open.

This might be confusing with the current way to disable the documentation window via `window.documentation`, so if this goes in we might want to deprecate that setting.</s>