### PR TITLE
perf: fix `nvim_replace_termcodes` being called on every `CursorMoved`

### DIFF
--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -41,8 +41,9 @@ end)
 autocmd.emit('ColorScheme')
 
 if vim.on_key then
+  local control_c_termcode = vim.api.nvim_replace_termcodes('<C-c>', true, true, true)
   vim.on_key(function(keys)
-    if keys == vim.api.nvim_replace_termcodes('<C-c>', true, true, true) then
+    if keys == control_c_termcode then
       vim.schedule(function()
         if not api.is_suitable_mode() then
           autocmd.emit('InsertLeave')
@@ -51,6 +52,7 @@ if vim.on_key then
     end
   end, vim.api.nvim_create_namespace('cmp.plugin'))
 end
+
 
 vim.api.nvim_create_user_command('CmpStatus', function()
   require('cmp').status()


### PR DESCRIPTION
Previously `vim.api.nvim_replace_termcodes('<C-c>', true, true, true)` was called every time the `CursorMoved` autocommand event fired. Even though afaik there is no reason to do so as the termcode stays the same. I discovered this by profiling with [profile.nvim](https://github.com/stevearc/profile.nvim) while trying to fix another issue (unrelated to cmp).

Feel free to change the variable name.