### PR TITLE
Fix: Buffer is not 'modifiable'

### DIFF
--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -140,7 +140,13 @@ custom_entries_view.open = function(self, offset, entries)
       end
     end
   end
-  vim.api.nvim_buf_set_lines(entries_buf, 0, -1, false, lines)
+  if vim.bo[entries_buf].modifiable == false then
+    vim.bo[entries_buf].modifiable = true
+    vim.api.nvim_buf_set_lines(entries_buf, 0, -1, false, lines)
+    vim.bo[entries_buf].modifiable = false
+  else
+    vim.api.nvim_buf_set_lines(entries_buf, 0, -1, false, lines)
+  end
   vim.api.nvim_buf_set_option(entries_buf, 'modified', false)
 
   local width = 0
@@ -264,7 +270,13 @@ custom_entries_view.draw = function(self)
       table.insert(texts, table.concat(text, ''))
     end
   end
-  vim.api.nvim_buf_set_lines(entries_buf, topline, botline, false, texts)
+  if vim.bo[entries_buf].modifiable == false then
+    vim.bo[entries_buf].modifiable = true
+    vim.api.nvim_buf_set_lines(entries_buf, topline, botline, false, texts)
+    vim.bo[entries_buf].modifiable = false
+  else
+    vim.api.nvim_buf_set_lines(entries_buf, topline, botline, false, texts)
+  end
   vim.api.nvim_buf_set_option(entries_buf, 'modified', false)
 
   if api.is_cmdline_mode() then


### PR DESCRIPTION
### Description
When I try to open a file with `-M` option. 
**command:** `nvim -M <filename>`.
The completion of commandline will be break.

### Root cause
I found that `nvim_buf_set_lines` cannot work when the buffer is `unmodifiable`.

### Solution
Add judgement before 'nvim_buf_set_lines': if the buffer is `unmodifiable`, make it `modifiable` temporarily.

### Related Issue
I think #1113 is relative to this problem.
