### PR TITLE
fix(ghost_text): ephemeral-like inline ghost-text workaround

### DIFF
--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -25,11 +25,17 @@ ghost_text_view.new = function()
   local self = setmetatable({}, { __index = ghost_text_view })
   self.win = nil
   self.entry = nil
+  self.extmark_id = nil
   vim.api.nvim_set_decoration_provider(ghost_text_view.ns, {
     on_win = function(_, win)
-      return win == self.win
-    end,
-    on_line = function(_, _, _, on_row)
+      if self.extmark_id then
+        vim.api.nvim_buf_del_extmark(0, ghost_text_view.ns, self.extmark_id)
+      end
+
+      if win ~= self.win then
+        return false
+      end
+
       local c = config.get().experimental.ghost_text
       if not c then
         return
@@ -40,9 +46,6 @@ ghost_text_view.new = function()
       end
 
       local row, col = unpack(vim.api.nvim_win_get_cursor(0))
-      if on_row ~= row - 1 then
-        return
-      end
 
       local line = vim.api.nvim_get_current_line()
       if not has_inline then
@@ -53,12 +56,12 @@ ghost_text_view.new = function()
 
       local text = self.text_gen(self, line, col)
       if #text > 0 then
-        vim.api.nvim_buf_set_extmark(0, ghost_text_view.ns, row - 1, col, {
-          right_gravity = false,
+        self.extmark_id = vim.api.nvim_buf_set_extmark(0, ghost_text_view.ns, row - 1, col, {
+          right_gravity = true,
           virt_text = { { text, type(c) == 'table' and c.hl_group or 'Comment' } },
           virt_text_pos = has_inline and 'inline' or 'overlay',
           hl_mode = 'combine',
-          ephemeral = true,
+          ephemeral = false,
         })
       end
     end,


### PR DESCRIPTION
This is a workaround to get inline ghost-text to work as expected without using ephemeral extmarks. See refs for context.

Refs:
  - https://github.com/hrsh7th/nvim-cmp/pull/1645
  - https://github.com/neovim/neovim/issues/24797