### PR TITLE
feat: match default border color to standard neovim float border hl

### DIFF
--- a/lua/cmp/config/window.lua
+++ b/lua/cmp/config/window.lua
@@ -4,7 +4,7 @@ window.bordered = function(opts)
   opts = opts or {}
   return {
     border = opts.border or 'rounded',
-    winhighlight = opts.winhighlight or 'Normal:Normal,FloatBorder:Normal,CursorLine:Visual,Search:None',
+    winhighlight = opts.winhighlight or 'Normal:Normal,FloatBorder:FloatBorder,CursorLine:Visual,Search:None',
     zindex = opts.zindex or 1001,
     scrolloff = opts.scrolloff or 0,
     col_offset = opts.col_offset or 0,


### PR DESCRIPTION
This commit differentiates the border color from the inner content color of the nvim-cmp float. The `FloatBorder` group links to `VertSplit` by default and is usually set by the colorscheme, so this commit makes nvim-cmp match with other float window colors. 

Say this is our usual LSP float window:
![lspfloatexample](https://github.com/hrsh7th/nvim-cmp/assets/55766287/ce2a8105-f475-4155-a02c-16d59d98109b)

Previously our cmp window looks like this:
![cmpbefore](https://github.com/hrsh7th/nvim-cmp/assets/55766287/c43f12b3-ac29-4445-934d-cbad45d62450)

Now it will match the LSP window (and other floating windows):
![cmpafter](https://github.com/hrsh7th/nvim-cmp/assets/55766287/7b2e0d20-1db8-4995-bd2b-dc02a1c7a416)

This was discussed in #748 but was closed without any change.

NOTE: This commit changes the default for `config.window.bordered`, but the borderless default remains the same since there is no border there anyway. If one was added the border would look as it does in the old way but at that point the user would probably be configuring everything manually anyway.