### PR TITLE
Revert "add context check for invalid detection"

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -568,7 +568,7 @@ entry.is_invalid = function(self)
   is_invalid = is_invalid or misc.empty(self.completion_item.label)
   if self.completion_item.textEdit then
     local range = self.completion_item.textEdit.range or self.completion_item.textEdit.insert
-    is_invalid = is_invalid or range.start.line ~= range['end'].line or range.start.line ~= self.context.cursor.line
+    is_invalid = is_invalid or range.start.line ~= range['end'].line
   end
   return is_invalid
 end


### PR DESCRIPTION
This reverts commit 3b9f28061a67b19cadc13946de981426a6425e4a.

Fixes some LSPs (especially those with context overwriting, e.g. AI code
completion tools) not being shown in the results
<https://github.com/jcdickinson/codeium.nvim/blob/main/lua/codeium/source.lua#L36-L48>
