### PR TITLE
    Add option to not reverse select_next_item on bottom_up list (#1346)

### DIFF
--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -285,7 +285,7 @@ end
 custom_entries_view.select_next_item = function(self, option)
   if self:visible() then
     local cursor = vim.api.nvim_win_get_cursor(self.entries_win.win)[1]
-    local is_top_down = self:is_direction_top_down()
+    local is_top_down = self:is_direction_top_down() or option.preserve_mapping_verticality
     local last = #self.entries
 
     if not self.entries_win:option('cursorline') then
@@ -322,7 +322,7 @@ end
 custom_entries_view.select_prev_item = function(self, option)
   if self:visible() then
     local cursor = vim.api.nvim_win_get_cursor(self.entries_win.win)[1]
-    local is_top_down = self:is_direction_top_down()
+    local is_top_down = self:is_direction_top_down() or option.preserve_mapping_verticality
     local last = #self.entries
 
     if not self.entries_win:option('cursorline') then


### PR DESCRIPTION
    * add feature requested in (#1346)

Add a parameter to the function preserve_mapping_verticality, which will keep mappings like <Up> and <Down> not reversed even when used custom view is used with `selection_order = 'top_down'` configuration.

Example use configuration:
```
    ["<Down>"] = cmp.mapping(cmp.mapping.select_next_item { behavior = cmp.SelectBehavior.Select, preserve_mapping_verticality = true }, { "i", "s" }),
    ["<Up>"] = cmp.mapping(cmp.mapping.select_prev_item { behavior = cmp.SelectBehavior.Select, preserve_mapping_verticality = true }, { "i", "s" }),
```