### PR TITLE
Favor existing values in completion_item over resovled_completion_item

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -423,7 +423,7 @@ entry.get_completion_item = function(self)
     if self.resolved_completion_item then
       local completion_item = misc.copy(self.completion_item)
       for k, v in pairs(self.resolved_completion_item) do
-        completion_item[k] = v or completion_item[k]
+        completion_item[k] = completion_item[k] or v
       end
       return completion_item
     end


### PR DESCRIPTION
Fix/workaround for #1705

"Workaround" because I think ultimately the issue is in the Astro language server or an upstream language server returning wrong ranges for `completionItem/resolve` requests.

Excuse me if there is a reason this behaviour is undesirable. Since the [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion) says that properties provided in `textDocument/completion` "must not be changed during resolve" and VS Code presumably (I don't know where its code for handling completions is) behaves like this, as it's not affected by the above issue, I kind of assume this would be fine.

Also, just out of curiosity, is there a reason this doesn't use `vim.tbl_extend()`?