### PR TITLE
feat: add option for view to follow cursor

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -679,6 +679,13 @@ view.docs.auto_open~
 
   Specify whether to show the docs_view when selecting an item.
 
+                                                 *cmp-config.view.follow_cursor*
+view.follow_cursor*
+  `boolean`
+
+  Specify whether the pmenu should follow the current position of the cursor
+  as the user types. `false` by default.
+
                            *cmp-config.window.{completion,documentation}.border*
 window.{completion,documentation}.border~
   `string | string[] | nil`

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -94,6 +94,7 @@ return function()
       entries = {
         name = 'custom',
         selection_order = 'top_down',
+        follow_cursor = false,
       },
       docs = {
         auto_open = true,

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -176,6 +176,7 @@ cmp.ItemField = {
 ---@class cmp.CustomEntriesViewConfig
 ---@field name 'custom'
 ---@field selection_order 'top_down'|'near_cursor'
+---@field follow_cursor boolean
 
 ---@class cmp.NativeEntriesViewConfig
 ---@field name 'native'

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -153,9 +153,12 @@ custom_entries_view.open = function(self, offset, entries)
   height = height ~= 0 and height or #self.entries
   height = math.min(height, #self.entries)
 
+  local delta = 0
+  if not config.get().view.entries.follow_cursor then
+    local cursor_before_line = api.get_cursor_before_line()
+    delta = vim.fn.strdisplaywidth(cursor_before_line:sub(self.offset))
+  end
   local pos = api.get_screen_cursor()
-  local cursor_before_line = api.get_cursor_before_line()
-  local delta = vim.fn.strdisplaywidth(cursor_before_line:sub(self.offset))
   local row, col = pos[1], pos[2] - delta - 1
 
   local border_info = window.get_border_info({ style = completion })


### PR DESCRIPTION
~~Creates an option to allow the custom entries
view to follow the user's cursor as they type.~~

This PR adds an option to allow the view, both custom and native, to follow the user's cursor as they type.

To enable, set
```lua
require("cmp").setup({
  view = {
    entries = {
      follow_cursor = true
    }
  }
})
```

Original custom view source at https://github.com/lvimuser/nvim-cmp/commit/7569056388417d887baf2e959e18a767bcfe84f1

Closes #1660