### PR TITLE
ci: fix broken tests

### DIFF
--- a/lua/cmp/core_spec.lua
+++ b/lua/cmp/core_spec.lua
@@ -220,11 +220,11 @@ describe('cmp.core', function()
                 character = 6,
               },
             },
-            newText = 'foobarbaz',
+            newText = 'AIUEO',
           },
         })
-        assert.are.same(state.buffer, { '***foobarbaz***' })
-        assert.are.same(state.cursor[2], 12)
+        assert.are.same(state.buffer, { '***AIUEO***' })
+        assert.are.same(state.cursor[2], 6)
       end)
     end)
   end)

--- a/lua/cmp/utils/feedkeys_spec.lua
+++ b/lua/cmp/utils/feedkeys_spec.lua
@@ -23,8 +23,8 @@ describe('feedkeys', function()
     })
   end)
 
-  it('bacckspace', function()
-    vim.cmd([[setlocal backspace=0]])
+  it('backspace', function()
+    vim.cmd([[setlocal backspace=""]])
     feedkeys.call(keymap.t('iaiueo'), 'nx')
     feedkeys.call(keymap.t('a<BS><BS>'), 'nx')
     assert.are.same(vim.api.nvim_buf_get_lines(0, 0, -1, false), {


### PR DESCRIPTION
The `backspace` setting only accepts strings.
Here, I assume that 0 was intended to set
backspace to a nil value, which can be done with
the empty string.