### PR TITLE
fix: remove usages from vim.lsp.util.parse_snippet

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -114,9 +114,6 @@ entry.get_word = function(self)
     local word
     if self:get_completion_item().textEdit and not misc.empty(self:get_completion_item().textEdit.newText) then
       word = str.trim(self:get_completion_item().textEdit.newText)
-      if self:get_completion_item().insertTextFormat == types.lsp.InsertTextFormat.Snippet then
-        word = vim.lsp.util.parse_snippet(word)
-      end
       local overwrite = self:get_overwrite()
       if 0 < overwrite[2] or self:get_completion_item().insertTextFormat == types.lsp.InsertTextFormat.Snippet then
         word = str.get_word(word, string.byte(self.context.cursor_after_line, 1), overwrite[1] or 0)
@@ -124,7 +121,7 @@ entry.get_word = function(self)
     elseif not misc.empty(self:get_completion_item().insertText) then
       word = str.trim(self:get_completion_item().insertText)
       if self:get_completion_item().insertTextFormat == types.lsp.InsertTextFormat.Snippet then
-        word = str.get_word(vim.lsp.util.parse_snippet(word))
+        word = str.get_word(word)
       end
     else
       word = str.trim(self:get_completion_item().label)
@@ -432,7 +429,7 @@ entry.get_completion_item = function(self)
 end
 
 ---Create documentation
----@return string
+---@return string[]
 entry.get_documentation = function(self)
   local item = self:get_completion_item()
 

--- a/lua/cmp/utils/str.lua
+++ b/lua/cmp/utils/str.lua
@@ -99,8 +99,8 @@ end
 
 ---get_word
 ---@param text string
----@param stop_char integer
----@param min_length integer
+---@param stop_char? integer
+---@param min_length? integer
 ---@return string
 str.get_word = function(text, stop_char, min_length)
   min_length = min_length or 0

--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -1,7 +1,6 @@
 local config = require('cmp.config')
 local misc = require('cmp.utils.misc')
 local str = require('cmp.utils.str')
-local types = require('cmp.types')
 local api = require('cmp.utils.api')
 
 ---@class cmp.GhostTextView
@@ -71,9 +70,6 @@ end
 ---  of character differences instead of just byte difference.
 ghost_text_view.text_gen = function(self, line, cursor_col)
   local word = self.entry:get_insert_text()
-  if self.entry.completion_item.insertTextFormat == types.lsp.InsertTextFormat.Snippet then
-    word = vim.lsp.util.parse_snippet(word)
-  end
   word = str.oneline(word)
   local word_clen = vim.str_utfindex(word)
   local cword = string.sub(line, self.entry:get_offset(), cursor_col)


### PR DESCRIPTION
This function is [now deprecated](https://github.com/neovim/neovim/pull/25733).