### PR TITLE
feat:allow highlight overrides for scrollbar and scrollbar thumb

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -718,6 +718,18 @@ window.completion.scrollbar~
   `boolean`
   Whether the scrollbar should be enabled if there are more items that fit
 
+                              *cmp-config.window.completion.scrollbar_highlight*
+window.completion.scrollbar_highlight~
+  `string`
+  Specify the scrollbar's winhighlight option.
+  See |nvim_open_win|.
+
+                        *cmp-config.window.completion.scrollbar_thumb_highlight*
+window.completion.scrollbar_thumb_highlight~
+  `string`
+  Specify the scrollbar thumb's winhighlight option.
+  See |nvim_open_win|.
+
                                      *cmp-config.window.documentation.max_width*
 window.documentation.max_width~
   `number`

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -108,6 +108,8 @@ return function()
         col_offset = 0,
         side_padding = 1,
         scrollbar = true,
+        scrollbar_highlight = 'EndOfBuffer:PmenuSbar,NormalFloat:PmenuSbar',
+        scrollbar_thumb_highlight = 'EndOfBuffer:PmenuThumb,NormalFloat:PmenuThumb',
       },
       documentation = {
         max_height = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),

--- a/lua/cmp/config/window.lua
+++ b/lua/cmp/config/window.lua
@@ -10,6 +10,8 @@ window.bordered = function(opts)
     col_offset = opts.col_offset or 0,
     side_padding = opts.side_padding or 1,
     scrollbar = opts.scrollbar == nil and true or opts.scrollbar,
+    scrollbar_highlight = opts.scrollbar_highlight or 'EndOfBuffer:PmenuSbar,NormalFloat:PmenuSbar',
+    scrollbar_thumb_highlight = opts.scrollbar_thumb_highlight or 'EndOfBuffer:PmenuThumb,NormalFloat:PmenuThumb',
   }
 end
 

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -126,6 +126,8 @@ cmp.ItemField = {
 ---@field public max_height integer|nil
 ---@field public scrolloff integer|nil
 ---@field public scrollbar boolean|true
+---@field public scrollbar_highlight string
+---@field public scrollbar_thumb_highlight string
 
 ---@class cmp.ConfirmationConfig
 ---@field public default_behavior cmp.ConfirmBehavior

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -133,6 +133,8 @@ end
 ---Update
 window.update = function(self)
   local info = self:info()
+  local scrollbar_highlight = config.get().window.completion.scrollbarhighlight
+  local scrollbar_thumb_highlight = config.get().window.completion.scrollbarthumbhighlight
   if info.scrollable then
     -- Draw the background of the scrollbar
 
@@ -151,7 +153,7 @@ window.update = function(self)
       else
         style.noautocmd = true
         self.sbar_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'sbar_buf'), false, style)
-        opt.win_set_option(self.sbar_win, 'winhighlight', 'EndOfBuffer:PmenuSbar,NormalFloat:PmenuSbar')
+        opt.win_set_option(self.sbar_win, 'winhighlight', scrollbar_highlight)
       end
     end
 
@@ -173,7 +175,7 @@ window.update = function(self)
     else
       style.noautocmd = true
       self.thumb_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'thumb_buf'), false, style)
-      opt.win_set_option(self.thumb_win, 'winhighlight', 'EndOfBuffer:PmenuThumb,NormalFloat:PmenuThumb')
+      opt.win_set_option(self.thumb_win, 'winhighlight', scrollbar_thumb_highlight)
     end
   else
     if self.sbar_win and vim.api.nvim_win_is_valid(self.sbar_win) then

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -133,8 +133,8 @@ end
 ---Update
 window.update = function(self)
   local info = self:info()
-  local scrollbar_highlight = config.get().window.completion.scrollbarhighlight
-  local scrollbar_thumb_highlight = config.get().window.completion.scrollbarthumbhighlight
+  local scrollbar_highlight = config.get().window.completion.scrollbar_highlight
+  local scrollbar_thumb_highlight = config.get().window.completion.scrollbar_thumb_highlight
   if info.scrollable then
     -- Draw the background of the scrollbar
 


### PR DESCRIPTION
This PR adds two config options to `window.completion` which allow the user to override the default highlight groups for the `winhighlight` of the **scrollbar** and the **scrollbar thumb**, which were previously hard-coded. The following files are changed:

1. `lua/cmp/config/default.lua`: Added entries in default config table for `scrollbar_highlight` and `scrollbar_thumb_highlight`
2. `lua/cmp/config/window.lua`: Added entries in the settings table returned by `window.bordered()` for `scrollbar_highlight` and `scrollbar_thumb_highlight`
3. `lua/cmp/utils/window.lua`: in `window.update()`, retrieve the default or user-customized values for `scrollbar_highlight` and `scrollbar_thumb_highlight`, and use those when setting the window options (this is where the previous hard-coded values are replaced)
4. `lua/cmp/types/cmp.lua`: Defined `scrollbar_highlight` and `scrollbar_thumb_highlight` in `cmp.WindowConfig` class.
5. `doc/cmp.txt`: Updated documentation