### PR TITLE
inline ghost text emulation for older neovim versions(v0.8.0-v0.10.0)

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -730,7 +730,7 @@ window.documentation.max_height~
 
                                             *cmp-config.experimental.ghost_text*
 experimental.ghost_text~
-  `boolean | { hl_group = string inline_emulation = boolean}`
+  `boolean | { hl_group: string, inline_emulation: boolean}`
   Whether to enable the ghost_text feature.
   inline_emulation is emulating inline ghost text for older neovim versions
 

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -730,8 +730,9 @@ window.documentation.max_height~
 
                                             *cmp-config.experimental.ghost_text*
 experimental.ghost_text~
-  `boolean | { hl_group = string }`
+  `boolean | { hl_group = string inline_emulation = boolean}`
   Whether to enable the ghost_text feature.
+  inline_emulation is emulating inline ghost text for older neovim versions
 
 ==============================================================================
 Config Helper                                                *cmp-config-helper*

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -732,7 +732,7 @@ window.documentation.max_height~
 experimental.ghost_text~
   `boolean | { hl_group: string, inline_emulation: boolean}`
   Whether to enable the ghost_text feature.
-  inline_emulation is emulating inline ghost text for older neovim versions
+  inline_emulation emulates inline ghost text for neovim v0.8.0+.
 
 ==============================================================================
 Config Helper                                                *cmp-config-helper*

--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -50,6 +50,7 @@ end
 local function gen_ts_nodes(begin_text,begin_hl,row,col,line)
    local nodes = { { begin_text, begin_hl } }
    col = col + 1
+   row = row - 1
    local start_pos = col
    for i = col, #line, 1 do
       local char = line:sub(i, i)

--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -84,7 +84,7 @@ local function get_hl(r, pos)
    end
    local ts_hls = result.treesitter
    if #ts_hls ~= 0 then
-      for i = #ts_hls,0,-1 do
+      for i = #ts_hls,1,-1 do
          if not hl_iscleared(ts_hls[i].hl_group_link) then
             return ts_hls[i].hl_group_link
          end

--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -164,28 +164,27 @@ ghost_text_view.new = function()
       end
 
       local line = vim.api.nvim_get_current_line()
+      if type(c) == 'table' and c.inline_emulation then
+        local text = self.text_gen(self, line, col)
+        local nodes = gen_hl_nodes(
+          text,c.hl_group or 'Comment',
+          row,col,line
+        )
+        vim.api.nvim_buf_set_extmark(0, ghost_text_view.ns, row - 1, col, {
+          right_gravity = false,
+          virt_text = nodes,
+          virt_text_pos = 'overlay',
+          hl_mode = 'combine',
+          ephemeral = true,
+        })
+        return
+      end
       if not has_inline then
-        if type(c) == 'table' and c.inline_emulation then
-          local text = self.text_gen(self, line, col)
-          local nodes = gen_hl_nodes(
-            text,c.hl_group or 'Comment',
-            row,col,line
-          )
-          vim.api.nvim_buf_set_extmark(0, ghost_text_view.ns, row - 1, col, {
-            right_gravity = false,
-            virt_text = nodes,
-            virt_text_pos = 'overlay',
-            hl_mode = 'combine',
-            ephemeral = true,
-          })
-          return
-        else
           if string.sub(line, col + 1) ~= '' then
             return
           end
-        end
       end
-     local text = self.text_gen(self, line, col)
+      local text = self.text_gen(self, line, col)
 
       if #text > 0 then
         vim.api.nvim_buf_set_extmark(0, ghost_text_view.ns, row - 1, col, {


### PR DESCRIPTION
the emulation is working fine with treesitter and lsp but for the built-in syntax it might not be that accurate so i made it as an option and off by default until i figure out the issues with syntax