### PR TITLE
Adds mapping for select_next_item and select_next_item in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ lua <<EOF
       -- documentation = cmp.config.window.bordered(),
     },
     mapping = cmp.mapping.preset.insert({
+      ['<C-n>'] = cmp.mapping.select_next_item(),
+      ['<C-p>'] = cmp.mapping.select_prev_item(),
       ['<C-b>'] = cmp.mapping.scroll_docs(-4),
       ['<C-f>'] = cmp.mapping.scroll_docs(4),
       ['<C-Space>'] = cmp.mapping.complete(),


### PR DESCRIPTION
This adds mappings for <C-n> and <C-p> in the proposed configuration.  Without these mappings <C-n> changes the pop-up menu to some other set of completions (built-in buffer words?) and the plugin does not work properly.

Detailed example: If i have snippets named `logd` and `loge` and I type `le`, both options will show in the menu due to fuzzy matching, but when I press <C-n> to select the next item in the list, the list of options changes and I can't select the `loge` snippet.