### PR TITLE
docs: suggest a better way to configure LSP capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,11 @@ lua <<EOF
     })
   })
 
-  -- Set up lspconfig.
-  local capabilities = require('cmp_nvim_lsp').default_capabilities()
+  -- Set up lspconfig. See https://github.com/hrsh7th/cmp-nvim-lsp/
+  local capabilities = vim.tbl_deep_extend("force",
+    vim.lsp.protocol.make_client_capabilities(),
+    require('cmp_nvim_lsp').default_capabilities()
+  )
   -- Replace <YOUR_LSP_SERVER> with each lsp server you've enabled.
   require('lspconfig')['<YOUR_LSP_SERVER>'].setup {
     capabilities = capabilities


### PR DESCRIPTION
Using `require('cmp_nvim_lsp').default_capabilities()` alone will be not
enough. We have to merge with the default LSP capabilities producced by
`vim.lsp.protocol.make_client_capabilities()`.

See also https://github.com/hrsh7th/cmp-nvim-lsp/pull/64

Closes #1265
