### PR TITLE
feat: sort source entries before slicing when using max_item_count

### DIFF
--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -134,24 +134,6 @@ source.get_entries = function(self, ctx)
     self.cache:set({ 'get_entries', tostring(self.revision) }, { entries = entries, ctx = ctx, offset = self.offset })
   end
 
-  if self:get_source_config().max_item_count then
-    local comparetors = config.get().sorting.comparators
-    table.sort(entries, function(e1, e2)
-      for _, fn in ipairs(comparetors) do
-        local diff = fn(e1, e2)
-        if diff ~= nil then
-          return diff
-        end
-      end
-    end)
-
-    local limited_entries = {}
-    for i = 1, math.min(#entries, self:get_source_config().max_item_count) do
-      limited_entries[i] = entries[i]
-    end
-    entries = limited_entries
-  end
-
   return entries
 end
 

--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -135,6 +135,16 @@ source.get_entries = function(self, ctx)
   end
 
   if self:get_source_config().max_item_count then
+    local comparetors = config.get().sorting.comparators
+    table.sort(entries, function(e1, e2)
+      for _, fn in ipairs(comparetors) do
+        local diff = fn(e1, e2)
+        if diff ~= nil then
+          return diff
+        end
+      end
+    end)
+
     local limited_entries = {}
     for i = 1, math.min(#entries, self:get_source_config().max_item_count) do
       limited_entries[i] = entries[i]

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -82,15 +82,26 @@ view.open = function(self, ctx, sources)
 
     -- create filtered entries.
     local offset = ctx.cursor.col
+    local group_entries = {}
+    local max_item_counts = {}
     for i, s in ipairs(source_group) do
       if s.offset <= ctx.cursor.col then
         if not has_triggered_by_symbol_source or s.is_triggered_by_symbol then
+          -- prepare max_item_counts map for filtering after sort.
+          if max_item_counts[s.name] == nil then
+            local max_item_count = s:get_source_config().max_item_count
+            if max_item_count ~= nil then
+              max_item_counts[s.name] = max_item_count
+            end
+          end
+
           -- source order priority bonus.
           local priority = s:get_source_config().priority or ((#source_group - (i - 1)) * config.get().sorting.priority_weight)
 
           for _, e in ipairs(s:get_entries(ctx)) do
             e.score = e.score + priority
-            table.insert(entries, e)
+            e.source_name = s.name -- store source name for filtering after sort.
+            table.insert(group_entries, e)
             offset = math.min(offset, e:get_offset())
           end
         end
@@ -99,7 +110,7 @@ view.open = function(self, ctx, sources)
 
     -- sort.
     local comparetors = config.get().sorting.comparators
-    table.sort(entries, function(e1, e2)
+    table.sort(group_entries, function(e1, e2)
       for _, fn in ipairs(comparetors) do
         local diff = fn(e1, e2)
         if diff ~= nil then
@@ -107,8 +118,21 @@ view.open = function(self, ctx, sources)
         end
       end
     end)
-    local max_item_count = config.get().performance.max_view_entries or 200
-    entries = vim.list_slice(entries, 1, max_item_count)
+
+    -- filter by max_item_count.
+    for _, e in ipairs(group_entries) do
+      if max_item_counts[e.source_name] ~= nil then
+        if max_item_counts[e.source_name] >= 0 then
+          max_item_counts[e.source_name] = max_item_counts[e.source_name] - 1
+          table.insert(entries, e)
+        end
+      else
+        table.insert(entries, e)
+      end
+    end
+
+    local max_view_entries = config.get().performance.max_view_entries or 200
+    entries = vim.list_slice(entries, 1, max_view_entries)
 
     -- open
     if #entries > 0 then

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -98,7 +98,6 @@ view.open = function(self, ctx, sources)
 
           for _, e in ipairs(s:get_entries(ctx)) do
             e.score = e.score + priority
-            e.source_name = s.name -- store source name for filtering after sort.
             table.insert(group_entries, e)
             offset = math.min(offset, e:get_offset())
           end
@@ -119,9 +118,9 @@ view.open = function(self, ctx, sources)
 
     -- filter by max_item_count.
     for _, e in ipairs(group_entries) do
-      if max_item_counts[e.source_name] ~= nil then
-        if max_item_counts[e.source_name] >= 0 then
-          max_item_counts[e.source_name] = max_item_counts[e.source_name] - 1
+      if max_item_counts[e.source.name] ~= nil then
+        if max_item_counts[e.source.name] >= 0 then
+          max_item_counts[e.source.name] = max_item_counts[e.source.name] - 1
           table.insert(entries, e)
         end
       else

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -88,11 +88,9 @@ view.open = function(self, ctx, sources)
       if s.offset <= ctx.cursor.col then
         if not has_triggered_by_symbol_source or s.is_triggered_by_symbol then
           -- prepare max_item_counts map for filtering after sort.
-          if max_item_counts[s.name] == nil then
-            local max_item_count = s:get_source_config().max_item_count
-            if max_item_count ~= nil then
-              max_item_counts[s.name] = max_item_count
-            end
+          local max_item_count = s:get_source_config().max_item_count
+          if max_item_count ~= nil then
+            max_item_counts[s.name] = max_item_count
           end
 
           -- source order priority bonus.


### PR DESCRIPTION
Hi,

When using the prop `max_item_count`, there is a known catch (sorting issue) from the doc:
```
sources[n].max_item_count~
  `number`
  The source-specific maximum item count option
  Note: This is applied before sorting, so items that aren't well-matched may be selected.
```

This PR makes it so the source entries are sorted before being sliced and fed to the full list of entries and then sorted again.
If the performance hit is too big, we could maybe add an optional boolean option such as `sort_before = true` along with `max_item_count`, to make sure the user still wants this sorting to happen even if it is slower.

EDIT:
Just had another thought... We could maybe avoid all this sorting X times per source + 1 time per group index, while still keeping the results accuracy, but it would bring some changes to how the final list is created. I'll try that later and maybe create another PR if it's worth it.

EDIT2:
Sorry for editing this PR once again but the first version felt wrong.
So this time what i did is just moving the whole `max_item_count` handling.
We fetch all the entries, we sort them, and at the end, depending on the source of the entry, we filter them out if they reached `max_item_count`.
I don't have that much experience with array manipulation in lua but i feel like the second commit would be way better performance-wise than the first one.

Thanks for your time.