### PR TITLE
docs: fix invalid WindowConfig schema, should match to the docs

### DIFF
--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -107,10 +107,6 @@ cmp.ItemField = {
 ---@field public async_budget integer Maximum time (in ms) an async function is allowed to run during one step of the event loop.
 ---@field public max_view_entries integer
 
----@class cmp.WindowConfig
----@field completion? cmp.WindowConfig
----@field documentation? cmp.WindowConfig|nil
-
 ---@class cmp.CompletionConfig
 ---@field public autocomplete? cmp.TriggerEvent[]|false
 ---@field public completeopt? string
@@ -119,13 +115,23 @@ cmp.ItemField = {
 ---@field public keyword_pattern? string
 
 ---@class cmp.WindowConfig
+---@field public completion? cmp.CompletionWindowOptions
+---@field public documentation? cmp.DocumentationWindowOptions|nil
+
+---@class cmp.WindowOptions
 ---@field public border? string|string[]
 ---@field public winhighlight? string
 ---@field public zindex? integer|nil
----@field public max_width? integer|nil
----@field public max_height? integer|nil
+
+---@class cmp.CompletionWindowOptions: cmp.WindowOptions
 ---@field public scrolloff? integer|nil
+---@field public col_offset? integer|nil
+---@field public side_padding? integer|nil
 ---@field public scrollbar? boolean|true
+
+---@class cmp.DocumentationWindowOptions: cmp.WindowOptions
+---@field public max_height? integer|nil
+---@field public max_width? integer|nil
 
 ---@class cmp.ConfirmationConfig
 ---@field public default_behavior cmp.ConfirmBehavior

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -118,6 +118,8 @@ end
 
 custom_entries_view.open = function(self, offset, entries)
   local completion = config.get().window.completion
+  assert(completion, 'config.get() must resolve window.completion with defaults')
+
   self.offset = offset
   self.entries = {}
   self.column_width = { abbr = 0, kind = 0, menu = 0 }


### PR DESCRIPTION
Problem: `cmp.WindowConfig` was defined twice, and not consistent with docs |cmp.txt|.

Solution: Introduce `cmp.CompletionWindowOptions` and `cmp.DocumentationWindowOptions`.
Make fields of these two class consistent with |cmp-config.window.*|
