### PR TITLE
fix: one more item than max_item_count is displayed

### DIFF
--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -119,7 +119,7 @@ view.open = function(self, ctx, sources)
     -- filter by max_item_count.
     for _, e in ipairs(group_entries) do
       if max_item_counts[e.source.name] ~= nil then
-        if max_item_counts[e.source.name] >= 0 then
+        if max_item_counts[e.source.name] > 0 then
           max_item_counts[e.source.name] = max_item_counts[e.source.name] - 1
           table.insert(entries, e)
         end


### PR DESCRIPTION
I found `nvim-cmp` always displays one more item than the `source[n].max_item_count`.

I checked the implementation, which seems to be working like if `max_item_count` is greater **or equal to** zero, append one item and reduce the `max_item_count` by one :)