### PR TITLE
feat: default to `vim.snippet` for snippet expansion if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ lua <<EOF
         -- require('luasnip').lsp_expand(args.body) -- For `luasnip` users.
         -- require('snippy').expand_snippet(args.body) -- For `snippy` users.
         -- vim.fn["UltiSnips#Anon"](args.body) -- For `ultisnips` users.
+        -- vim.snippet.expand(args.body) -- For native neovim snippets (Neovim v0.10+)
       end,
     },
     window = {

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -85,6 +85,7 @@ A recommended configuration can be found below.
           -- require('luasnip').lsp_expand(args.body) -- For `luasnip` users.
           -- require'snippy'.expand_snippet(args.body) -- For `snippy` users.
           -- vim.fn["UltiSnips#Anon"](args.body) -- For `ultisnips` users.
+          -- vim.snippet.expand(args.body) -- For native neovim snippets (Neovim v0.10+)
         end,
       },
       window = {

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -29,7 +29,9 @@ return function()
     mapping = {},
 
     snippet = {
-      expand = function(_)
+      expand = vim.snippet and function(args)
+        vim.snippet.expand(args.body)
+      end or function(_)
         error('snippet engine is not configured.')
       end,
     },


### PR DESCRIPTION
Neovim v0.10 is introducing a native snippet engine. It seems like a good default to configure that for snippet expansion if it is available. Let me know what you think and if I should include any more details in the documentation!