### PR TITLE
fix: small windows no longer constantly throw errors

### DIFF
--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -133,7 +133,7 @@ end
 ---Update
 window.update = function(self)
   local info = self:info()
-  if info.scrollable then
+  if info.scrollable and self.style.height > 0 then
     -- Draw the background of the scrollbar
 
     if not info.border_info.visible then

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -212,7 +212,14 @@ custom_entries_view.open = function(self, offset, entries)
     border = completion.border,
     zindex = completion.zindex or 1001,
   })
-  -- always set cursor when starting. It will be adjusted on the call to _select
+
+  -- Don't set the cursor if the entries_win:open function fails
+  -- due to the window's width or height being less than 1
+  if self.entries_win.win == nil then
+    return
+  end
+
+  -- Always set cursor when starting. It will be adjusted on the call to _select
   vim.api.nvim_win_set_cursor(self.entries_win.win, { 1, 0 })
   if preselect_index > 0 and config.get().preselect == types.cmp.PreselectMode.Item then
     self:_select(preselect_index, { behavior = types.cmp.SelectBehavior.Select, active = false })


### PR DESCRIPTION
Fixes #827 and #1759

The `entries_win:open` function will fail when either the width or the height of the window is less than 1, which will result in the `nvim_win_set_cursor` being passed a `nil` value for `self.entries_win.win` instead of a number, which causes an error to constantly appear when the window is small. Hence, a guard clause to check for whether `self.entries_win.win` is `nil` is added to stop the error from occurring.

Also fixed the rarer 'height' must be a positive Integer error caused by the `window.update` function, within the clause to draw the scrollbar background. This error happens on small windows when pressing and holding down the backspace key to delete a lot of characters at once. The `nvim_open_win` function call to create the scrollbar background throws the error when `self.style.height` is `0`. Hence, an additional check is added alongside the `info.scrollable` check which also skips drawing the scrollbar thumb as it is not needed when the height is `0` and will result in a weird scrollbar thumb floating some distance away from the text when holding down backspace to delete a lot of characters.