### PR TITLE
fix: issue#1832

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -434,6 +434,10 @@ entry.get_documentation = function(self)
   local item = self:get_completion_item()
 
   local documents = {}
+  
+  if type(item.detail) == 'table' then
+    item.detail = item.detail[1]
+  end
 
   -- detail
   if item.detail and item.detail ~= '' then


### PR DESCRIPTION
Add type check for `item.detail` that contains description, In that case while navigating in menu for select snippet `item.detail` contains table, but expected string

#1832 