### PR TITLE
Use `get_word` so that the word is the same as in `core.confirm`

### DIFF
--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -74,7 +74,7 @@ end
 ---  This function calculates the bytes of the entry to display calculating the number
 ---  of character differences instead of just byte difference.
 ghost_text_view.text_gen = function(self, line, cursor_col)
-  local word = self.entry:get_insert_text()
+  local word = self.entry:get_word()
   word = str.oneline(word)
   local word_clen = vim.str_utfindex(word)
   local cword = string.sub(line, self.entry:get_offset(), cursor_col)


### PR DESCRIPTION
## Problem

Build a `CompletionResponse` in the following way:
```lua
local label = cursor_before_line .. suggestions
-- CompletionResponse
{
  label = label,
  word = label,
  textEdit = {
    range = {
      start = { line = line, character = character },
      ['end'] = { line = line, character = character },
    },
    newText = suggestions,
  },
}
```
When `cursor_before_line` is `e` and `suggestions` is `mail`, ghost_text will show `ail` and will be missing a character `m`.
However, when you preview it from `<Tab>`, the `mail` is displayed correctly.

## Solution

Use `get_word` so that the word is the same as in `core.confirm`
