### PR TITLE
feat: make winblend configurable

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -698,6 +698,12 @@ window.{completion,documentation}.winhighlight~
   Specify the window's winhighlight option.
   See |nvim_open_win|.
 
+                     *cmp-config.window.{completion,documentation}.winblend*
+window.{completion,documentation}.winblend~
+  `string | cmp.WinhighlightConfig`
+  Specify the window's winblend option.
+  See |nvim_open_win|.
+
                            *cmp-config.window.{completion,documentation}.zindex*
 window.{completion,documentation}.zindex~
   `number`

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -107,6 +107,7 @@ return function()
       completion = {
         border = { '', '', '', '', '', '', '', '' },
         winhighlight = 'Normal:Pmenu,FloatBorder:Pmenu,CursorLine:PmenuSel,Search:None',
+        winblend = vim.o.pumblend,
         scrolloff = 0,
         col_offset = 0,
         side_padding = 1,
@@ -117,6 +118,7 @@ return function()
         max_width = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
         border = { '', '', '', ' ', '', '', '', ' ' },
         winhighlight = 'FloatBorder:NormalFloat',
+        winblend = vim.o.pumblend,
       },
     },
   }

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -121,6 +121,7 @@ cmp.ItemField = {
 ---@class cmp.WindowOptions
 ---@field public border? string|string[]
 ---@field public winhighlight? string
+---@field public winblend? number
 ---@field public zindex? integer|nil
 
 ---@class cmp.CompletionWindowOptions: cmp.WindowOptions

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -201,7 +201,7 @@ custom_entries_view.open = function(self, offset, entries)
   end
 
   -- Apply window options (that might be changed) on the custom completion menu.
-  self.entries_win:option('winblend', vim.o.pumblend)
+  self.entries_win:option('winblend', completion.winblend)
   self.entries_win:option('winhighlight', completion.winhighlight)
   self.entries_win:option('scrolloff', completion.scrolloff)
   self.entries_win:open({

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -100,7 +100,7 @@ docs_view.open = function(self, e, view)
   end
 
   -- Render window.
-  self.window:option('winblend', vim.o.pumblend)
+  self.window:option('winblend', documentation.winblend)
   self.window:option('winhighlight', documentation.winhighlight)
   local style = {
     relative = 'editor',


### PR DESCRIPTION
Set cmp window's `winblend` to `pumblend` makes it consistent with neovim itself, but there is a case:

![image](https://github.com/hrsh7th/nvim-cmp/assets/61115159/b03e326a-c4f9-46d3-9779-46cbb028320a)

As you can see above, some of the nerd icons on the left side of the window are small, that's because terminals render nerd icons as two characters wide if there is a space on their right. If `pumblend` is set, the right of the nerd icon will be a character under the window instead of a space. So I think a positive value of `winblend` is not suit for cmp in some case.

In current implementation, there's no way to make cmp's winblend different from other popup windows, if I want to change cmp, I must change them all. So I recommend making this option configurable.