### PR TITLE
Fix: remove undo break when confirm complete

### DIFF
--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -371,6 +371,14 @@ core.confirm = function(self, e, option, callback)
 
   feedkeys.call(keymap.indentkeys(), 'n')
   feedkeys.call('', 'n', function()
+    -- Emulate `<C-y>` behavior to save `.` register.
+    local ctx = context.new()
+    local keys = {}
+    table.insert(keys, keymap.backspace(ctx.cursor_before_line:sub(e:get_offset())))
+    table.insert(keys, e:get_word())
+    feedkeys.call(table.concat(keys, ''), 'in')
+  end)
+  feedkeys.call('', 'n', function()
     -- Restore the line at the time of request.
     local ctx = context.new()
     if api.is_cmdline_mode() then

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -371,15 +371,6 @@ core.confirm = function(self, e, option, callback)
 
   feedkeys.call(keymap.indentkeys(), 'n')
   feedkeys.call('', 'n', function()
-    -- Emulate `<C-y>` behavior to save `.` register.
-    local ctx = context.new()
-    local keys = {}
-    table.insert(keys, keymap.backspace(ctx.cursor_before_line:sub(e:get_offset())))
-    table.insert(keys, e:get_word())
-    table.insert(keys, keymap.undobreak())
-    feedkeys.call(table.concat(keys, ''), 'in')
-  end)
-  feedkeys.call('', 'n', function()
     -- Restore the line at the time of request.
     local ctx = context.new()
     if api.is_cmdline_mode() then


### PR DESCRIPTION
When there is no snippet expansion, I expect cmp's behavior is the same as builtin omnifunc completion.
The issue is after confirmation, the '[' mark and undo behavior is not matched. Undo will undo all input for that insert session but '[' mark is after previous completion.

https://github.com/hrsh7th/nvim-cmp/assets/25120292/e9f0d03b-8e87-48ec-a5b3-03309aee79b7

Omnifunc completion behavior and after the PR:

https://github.com/hrsh7th/nvim-cmp/assets/25120292/16045bc7-a0fe-4c5f-98a2-733ce383c33c

