### PR TITLE
enable ghost_text for multi-line completions

### DIFF
--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -60,11 +60,17 @@ ghost_text_view.new = function()
 
       local text = self.text_gen(self, line, col)
       if #text > 0 then
+        local virt_lines = {}
+        for _, l in ipairs(vim.fn.split(text, '\n')) do
+          table.insert(virt_lines, { { l, type(c) == 'table' and c.hl_group or 'Comment' } })
+        end
+        local first_line = table.remove(virt_lines, 1)
         self.extmark_buf = vim.api.nvim_get_current_buf()
         self.extmark_id = vim.api.nvim_buf_set_extmark(self.extmark_buf, ghost_text_view.ns, row - 1, col, {
           right_gravity = true,
-          virt_text = { { text, type(c) == 'table' and c.hl_group or 'Comment' } },
+          virt_text = first_line,
           virt_text_pos = has_inline and 'inline' or 'overlay',
+          virt_lines = virt_lines,
           hl_mode = 'combine',
           ephemeral = false,
         })
@@ -82,7 +88,6 @@ ghost_text_view.text_gen = function(self, line, cursor_col)
   if self.entry:get_completion_item().insertTextFormat == types.lsp.InsertTextFormat.Snippet then
     word = tostring(snippet.parse(word))
   end
-  word = str.oneline(word)
   local word_clen = vim.str_utfindex(word)
   local cword = string.sub(line, self.entry:get_offset(), cursor_col)
   local cword_clen = vim.str_utfindex(cword)


### PR DESCRIPTION
This is a simple PR that enables ghost text when the completion candidate has multiple lines. For example, suggestions from Copilot, or multi-line completions provided by a language server:

<img width="540" alt="Screenshot 2024-04-14 at 12 22 54 PM" src="https://github.com/hrsh7th/nvim-cmp/assets/2934282/0a1ea534-9b44-4c15-906e-abaada2610c5"> 

This also partially addresses #1862: if the completion candidate contains multiple lines, then this PR will allow them to be displayed. But to keep the scope small, this PR does not handle expanding snippets. That will need to be solved in another PR to resolve #1862

I know this is unsolicited, so no pressure to merge. But it's a feature I want, and it seemed easy enough to implement so I thought I would offer.

Please let me know if you have any questions, or if there's anything you would like me to change.

Thank you!



