### PR TITLE
Allow comparators access to the complete list of entries

### DIFF
--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -11,7 +11,7 @@ local compare = {}
 
 ---@class cmp.ComparatorFunctor
 ---@overload fun(entry1: cmp.Entry, entry2: cmp.Entry): boolean | nil
----@alias cmp.ComparatorFunction fun(entry1: cmp.Entry, entry2: cmp.Entry): boolean | nil
+---@alias cmp.ComparatorFunction fun(entry1: cmp.Entry, entry2: cmp.Entry, entries?: cmp.Entry[]): boolean | nil
 ---@alias cmp.Comparator cmp.ComparatorFunction | cmp.ComparatorFunctor
 
 ---offset: Entries with smaller offset will be ranked higher.

--- a/lua/cmp/view.lua
+++ b/lua/cmp/view.lua
@@ -109,7 +109,7 @@ view.open = function(self, ctx, sources)
     local comparetors = config.get().sorting.comparators
     table.sort(group_entries, function(e1, e2)
       for _, fn in ipairs(comparetors) do
-        local diff = fn(e1, e2)
+        local diff = fn(e1, e2, group_entries)
         if diff ~= nil then
           return diff
         end


### PR DESCRIPTION
This is a small change that allows comparators to access the entire list of entries, by adding an optional comparator argument that contains the current list of completion entries. This makes it easier for slow comparators (for example, something requiring an API call, disk I/O, or ML model execution) to batch their computations, execute them all at once, and then return cached results for the rest of the comparisons.