### PR TITLE
Fix completion menu showing over the cmd win

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -351,7 +351,7 @@ autocmd.subscribe('CursorMovedI', function()
 end)
 
 -- If make this asynchronous, the completion menu will not close when the command output is displayed.
-autocmd.subscribe({ 'InsertLeave', 'CmdlineLeave' }, function()
+autocmd.subscribe({ 'InsertLeave', 'CmdlineLeave', 'CmdwinEnter' }, function()
   cmp.core:reset()
   cmp.core.view:close()
 end)


### PR DESCRIPTION
The `CmdwinEnter` handler was changed in 5054c1449079e - this reintroduces it to fix #603 