### PR TITLE
Do not use sync code in InserEnter

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -330,7 +330,7 @@ local on_insert_enter = function()
   end
 end
 autocmd.subscribe({ 'CmdlineEnter' }, async.debounce_next_tick(on_insert_enter))
-autocmd.subscribe({ 'InsertEnter' }, async.debounce_next_tick_by_keymap(on_insert_enter))
+autocmd.subscribe({ 'InsertEnter' }, async.debounce_next_tick(on_insert_enter))
 
 -- async.throttle is needed for performance. The mapping `:<C-u>...<CR>` will fire `CmdlineChanged` for each character.
 local on_text_changed = function()


### PR DESCRIPTION
close #1908 
debounce_next_tick_by_keymap is a sync call, and this is the only place it is called.
This change makes o faster.