### PR TITLE
fix: unexpectedly re-open a completion window when setting `autocomplete = false`

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -120,6 +120,7 @@ cmp.abort = cmp.sync(function()
   if cmp.core.view:visible() then
     local release = cmp.core:suspend()
     cmp.core.view:abort()
+    cmp.core:reset()
     vim.schedule(release)
     return true
   else


### PR DESCRIPTION
Fix #1251 and #1919. This comment was very helpful for me. (https://github.com/hrsh7th/nvim-cmp/issues/1251#issuecomment-1365229958)