### PR TITLE
fix: `cmp.close()` when `autocompletion = false`

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -108,6 +108,7 @@ cmp.close = cmp.sync(function()
   if cmp.core.view:visible() then
     local release = cmp.core:suspend()
     cmp.core.view:close()
+    cmp.core:reset()
     vim.schedule(release)
     return true
   else


### PR DESCRIPTION
Fix https://github.com/hrsh7th/nvim-cmp/issues/1919.
cf. https://github.com/hrsh7th/nvim-cmp/pull/1920

Now, `autocomplete = false` got more cozy!
