### PR TITLE
ci: automated releases and luarocks uploads

### DIFF
--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -1,9 +1,13 @@
-name: "release"
+name: "Publish to luarocks"
 on:
   push:
     tags: # Will upload to luarocks.org when a tag is pushed
       - "*"
+  release:
+    types:
+      - created
   pull_request: # Will test a local install without uploading to luarocks.org
+  workflow_dispatch: # Allow triggering manually on tags
 
 jobs:
   luarocks-release:
@@ -12,11 +16,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
       - name: LuaRocks Upload
         uses: nvim-neorocks/luarocks-tag-release@v5
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
+          version: ${{ env.LUAROCKS_VERSION }}
           labels: |
             neovim
             nvim-cmp

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,22 @@
+---
+permissions:
+  contents: write
+  pull-requests: write
+
+name: Release Please
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: simple
+          token: ${{ secrets.PAT }}


### PR DESCRIPTION
Hey :wave:

- Fixes #1880.
- Fixes #906.

This PR introduces a release-please workflow that automatically opens (or updates) a release PR (which updates a changelog) when a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) is merged into the `main` branch.

Here's an example of what a release PR looks like:

- https://github.com/nvim-neorocks/rocks.nvim/pull/316

The nice thing about this workflow is that you get to decide when to merge a release PR.
When doing so, the same workflow creates a release tag and publishes a GitHub release, with the (SemVer) version bump determined from the conventional commit messages.

If you [add a personal access token](https://github.com/nvim-neorocks/sample-luarocks-plugin?tab=readme-ov-file#generating-a-pat-personal-access-token) to this repo's secrets (I assumed it to be named `PAT` in this PR), each release will automatically trigger a luarocks upload. I have modified the workflow file to work nicely with this.

> [!IMPORTANT]
> 
> - If you merge this as is, release-please will compute the version using previous
>   conventional commit messages. As there has not been a release yet,
>   it will likely start at version 1.0.0. You can change the initial version with a [manifest file](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#initial-version).
> - Commits that don't comply with the conventional commits spec won't be
>   included in release notes. You could [enforce this with a GitHub action](https://github.com/marketplace/actions/conventional-pull-request). Personally, I haven't ever had a need to do so.