### PR TITLE
perf: use builtin for key normalization

### DIFF
--- a/lua/cmp/utils/keymap.lua
+++ b/lua/cmp/utils/keymap.lua
@@ -16,7 +16,9 @@ end
 ---Normalize key sequence.
 ---@param keys string
 ---@return string
-keymap.normalize = function(keys)
+keymap.normalize = vim.fn.has('nvim-0.8') == 1 and function(keys)
+  return vim.fn.keytrans(keymap.t(keys))
+end or function(keys)
   local normalize_buf = buffer.ensure('cmp.util.keymap.normalize')
   vim.api.nvim_buf_set_keymap(normalize_buf, 't', keys, '<Plug>(cmp.utils.keymap.normalize)', {})
   for _, map in ipairs(vim.api.nvim_buf_get_keymap(normalize_buf, 't')) do


### PR DESCRIPTION
After https://github.com/hrsh7th/nvim-cmp/pull/986, @zeertzjq added the `keytrans()` function for translating byte rep of keys to key notation form in https://github.com/neovim/neovim/commit/907fc8ac373226556b84c2fdc4fe26525bbdb2c4. This can be used for normalization. 

This reduces running time of `prepare()` from about 16ms to 6ms on my setup. 


btw I' curious about why `keymap.t` manually replaces `<` instead of using `nvim_replace_termcodes` (https://github.com/hrsh7th/nvim-cmp/pull/720/commits/f2f6dce0cc708ebea904ed471849e1d62a19cf96). `nvim_replace_termcodes` is slightly faster. 