### PR TITLE
Changed functions to avoid deprecation notices

### DIFF
--- a/lua/cmp/types/lsp.lua
+++ b/lua/cmp/types/lsp.lua
@@ -202,7 +202,9 @@ lsp.CompletionItemKind = {
   Operator = 24,
   TypeParameter = 25,
 }
-lsp.CompletionItemKind = vim.tbl_add_reverse_lookup(lsp.CompletionItemKind)
+for key, value in pairs(lsp.CompletionItemKind) do
+  lsp.CompletionItemKind[value] = key
+end
 
 ---@class lsp.internal.CompletionItemDefaults
 ---@field public commitCharacters? string[]

--- a/lua/cmp/utils/misc.lua
+++ b/lua/cmp/utils/misc.lua
@@ -88,8 +88,8 @@ misc.none = vim.NIL
 ---@param tbl2 T
 ---@return T
 misc.merge = function(tbl1, tbl2)
-  local is_dict1 = type(tbl1) == 'table' and (not vim.tbl_islist(tbl1) or vim.tbl_isempty(tbl1))
-  local is_dict2 = type(tbl2) == 'table' and (not vim.tbl_islist(tbl2) or vim.tbl_isempty(tbl2))
+  local is_dict1 = type(tbl1) == 'table' and (not vim.islist(tbl1) or vim.tbl_isempty(tbl1))
+  local is_dict2 = type(tbl2) == 'table' and (not vim.islist(tbl2) or vim.tbl_isempty(tbl2))
   if is_dict1 and is_dict2 then
     local new_tbl = {}
     for k, v in pairs(tbl2) do
@@ -163,7 +163,7 @@ misc.copy = function(tbl)
     return tbl
   end
 
-  if vim.tbl_islist(tbl) then
+  if vim.islist(tbl) then
     local copy = {}
     for i, value in ipairs(tbl) do
       copy[i] = misc.copy(value)


### PR DESCRIPTION
In the Neovim latest master branch, I get an warning printed:

```
vim.tbl_add_reverse_lookup is deprecated. :help deprecated
Feature will be removed in Nvim 0.12
stack traceback:
    vim/shared.lua: in function 'tbl_add_reverse_lookup'
    ...sonal/.config/nvim/bundle/nvim-cmp/lua/cmp/types/lsp.lua:205: in main chunk
    [C]: in function 'require'
    ...onal/.config/nvim/bundle/nvim-cmp/lua/cmp/types/init.lua:4: in main chunk
    [C]: in function 'require'
    .../.config/nvim/bundle/nvim-cmp/lua/cmp/config/mapping.lua:1: in main chunk
    [C]: in function 'require'
    ...personal/.config/nvim/bundle/nvim-cmp/lua/cmp/config.lua:1: in main chunk
    [C]: in function 'require'
    ...nal/.config/nvim/bundle/nvim-cmp/lua/cmp/utils/async.lua:2: in main chunk
    ...
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:443: in function 'source_runtime'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:414: in function 'packadd'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:346: in function '_load'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:191: in function 'load'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:342: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:341>
    [C]: in function 'xpcall'
    .../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:113: in function 'try'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:341: in function '_load'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:191: in function 'load'
    ...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:83: in function <...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:72>
vim.tbl_islist is deprecated, use vim.islist instead. :help deprecated
Feature will be removed in Nvim 0.12
stack traceback:
    vim/shared.lua: in function 'tbl_islist'
    ...onal/.config/nvim/bundle/nvim-cmp/lua/cmp/utils/misc.lua:91: in function 'merge'
    ...personal/.config/nvim/bundle/nvim-cmp/lua/cmp/config.lua:124: in function 'callback'
    ...nal/.config/nvim/bundle/nvim-cmp/lua/cmp/utils/cache.lua:38: in function 'get'
    ...s/personal/.config/nvim/bundle/nvim-cmp/lua/cmp/core.lua:346: in main chunk
    [C]: in function 'require'
    ...s/personal/.config/nvim/bundle/nvim-cmp/lua/cmp/init.lua:1: in main chunk
    [C]: in function 'require'
    ...fig/nvim/bundle/cmp_luasnip/after/plugin/cmp_luasnip.lua:1: in main chunk
    [C]: in function 'nvim_exec2'
    ...
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:443: in function 'source_runtime'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:414: in function 'packadd'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:346: in function '_load'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:191: in function 'load'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:342: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:341>
    [C]: in function 'xpcall'
    .../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:113: in function 'try'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:341: in function '_load'
    ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:191: in function 'load'
    ...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:83: in function <...hare/nvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:72>
vim.lsp.get_active_clients() is deprecated, use vim.lsp.get_clients() instead. :help deprecated
Feature will be removed in Nvim 0.12
stack traceback:
    /usr/local/share/nvim/runtime/lua/vim/lsp.lua:785: in function 'get_active_clients'
    ...onfig/nvim/bundle/cmp-nvim-lsp/lua/cmp_nvim_lsp/init.lua:107: in function <...onfig/nvim/bundle/cmp-nvim-lsp/lua/cmp_nvim_lsp/init.lua:101>
vim.lsp.buf_get_clients() is deprecated, use vim.lsp.get_clients() instead. :help deprecated
Feature will be removed in Nvim 0.12
stack traceback:
    /usr/local/share/nvim/runtime/lua/vim/lsp.lua:1092: in function 'buf_get_clients'
    ...fig/nvim/bundle/cmp-nvim-lsp/lua/cmp_nvim_lsp/source.lua:25: in function 'is_available'
    ...onfig/nvim/bundle/cmp-nvim-lsp/lua/cmp_nvim_lsp/init.lua:111: in function <...onfig/nvim/bundle/cmp-nvim-lsp/lua/cmp_nvim_lsp/init.lua:101>
```

This PR fixes the warnings. I hope this helps :)