### PR TITLE
feat: allow more completion highlight control

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -201,7 +201,7 @@ end
 ---Return view information.
 ---@param suggest_offset integer
 ---@param entries_buf integer The buffer this entry will be rendered into.
----@return { abbr: { text: string, bytes: integer, width: integer, hl_group: string }, kind: { text: string, bytes: integer, width: integer, hl_group: string }, menu: { text: string, bytes: integer, width: integer, hl_group: string } }
+---@return { abbr: { text: string, bytes: integer, width: integer, hl_group: string|table }, kind: { text: string, bytes: integer, width: integer, hl_group: string|table }, menu: { text: string, bytes: integer, width: integer, hl_group: string|table } }
 entry.get_view = function(self, suggest_offset, entries_buf)
   local item = self:get_vim_item(suggest_offset)
   return self.cache:ensure('get_view:' .. tostring(entries_buf), function()

--- a/lua/cmp/types/vim.lua
+++ b/lua/cmp/types/vim.lua
@@ -7,9 +7,9 @@
 ---@field public empty 1|nil
 ---@field public dup 1|nil
 ---@field public id any
----@field public abbr_hl_group string|nil
----@field public kind_hl_group string|nil
----@field public menu_hl_group string|nil
+---@field public abbr_hl_group string|table|nil
+---@field public kind_hl_group string|table|nil
+---@field public menu_hl_group string|table|nil
 
 ---@class vim.Position 1-based index
 ---@field public row integer

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -73,10 +73,11 @@ custom_entries_view.new = function()
 
             if type(v[field].hl_group) == 'table' then
               for _, extmark in ipairs(v[field].hl_group) do
-                vim.api.nvim_buf_set_extmark(buf, custom_entries_view.ns, i, o + extmark[1], {
+                local hl_start, hl_end = unpack(extmark.range)
+                vim.api.nvim_buf_set_extmark(buf, custom_entries_view.ns, i, o + hl_start, {
                   end_line = i,
-                  end_col = o + extmark[2],
-                  hl_group = extmark[3],
+                  end_col = o + hl_end,
+                  hl_group = extmark[1],
                   hl_eol = false,
                   ephemeral = true,
                 })

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -70,13 +70,27 @@ custom_entries_view.new = function()
             if field == types.cmp.ItemField.Abbr then
               a = o
             end
-            vim.api.nvim_buf_set_extmark(buf, custom_entries_view.ns, i, o, {
-              end_line = i,
-              end_col = o + v[field].bytes,
-              hl_group = v[field].hl_group,
-              hl_mode = 'combine',
-              ephemeral = true,
-            })
+
+            if type(v[field].hl_group) == 'table' then
+              for _, extmark in ipairs(v[field].hl_group) do
+                vim.api.nvim_buf_set_extmark(buf, custom_entries_view.ns, i, o + extmark[1], {
+                  end_line = i,
+                  end_col = o + extmark[2],
+                  hl_group = extmark[3],
+                  hl_eol = false,
+                  ephemeral = true,
+                })
+              end
+            else
+              vim.api.nvim_buf_set_extmark(buf, custom_entries_view.ns, i, o, {
+                end_line = i,
+                end_col = o + v[field].bytes,
+                hl_group = v[field].hl_group,
+                hl_mode = 'combine',
+                ephemeral = true,
+              })
+            end
+
             o = o + v[field].bytes + (self.column_width[field] - v[field].width) + 1
           end
 


### PR DESCRIPTION
Related: #1887

This PR allows more highlight control by allowing `vim.CompletedItem.{field}_hl_group` values to be of type `table` with the following structure:

```lua
-- inside the cmp.FormattingConfig.format method
vim_item.abbr_hl_group = {
    { '@function', range = { 0, 5 } },
    { 'Comment', range = { 5, 10 } },
}
```

## Examples
### Simple
A simple use case of this is having different highlights for function parameters:

<img width="765" alt="image" src="https://github.com/hrsh7th/nvim-cmp/assets/39461169/a9215d5c-b664-4704-a4a6-8b2fc7519f2f">

<details>
<summary>Code</summary>

```lua
local format = function(entry, vim_item)
    local kind = entry:get_kind()

    if vim.tbl_contains({ 2, 3 }, kind) then -- if kind is a Function (2) or Method (3)
        local start_index, end_index = vim_item.abbr:find('%(.*')
        if start_index then
            vim_item.abbr_hl_group = {
                { '@function', range = { 0, start_index - 1 } },
                { 'Comment', range = { start_index - 1, end_index } },
            }
        else
            vim_item.abbr_hl_group = '@function'
        end
    end

    return vim_item
end
```

</details>

### Treesitter-based
You can also have more complex highlights by using treesitter for example:

<img width="893" alt="image" src="https://github.com/hrsh7th/nvim-cmp/assets/39461169/1b52741d-6fad-4bbd-8740-ca168df70878">

<details>
<summary>Code (borrowed from @xzbdmw)</summary>

```lua
format = function(entry, vim_item)
    local highlights = {}

    -- you will likely not want to get this query every single time for performance but this is an example
    local query = vim.treesitter.query.get(vim.bo.filetype, 'highlights')

    local success, parser = pcall(vim.treesitter.get_string_parser, str, vim.bo.filetype)
    if success then
        local tree = parser:parse(true)[1]
        local root = tree:root()
        for id, node in query:iter_captures(root, str, 0, -1) do
            local name = '@' .. query.captures[id] .. '.' .. vim.bo.filetype
            local hl = vim.api.nvim_get_hl_id_by_name(name)
            local range = { node:range() }
            local _, nscol, _, necol = range[1], range[2], range[3], range[4]

            table.insert(highlights, { hl, range = { nscol, necol } })
        end
    end

    vim_item.abbr_hl_group = highlights

    return vim_item
end,
```
</details>

## Notes
LSP doesn't specify exactly how to use the label fields of a `CompletionItem`, as a result the usage of these values differ a lot between LSP implementations (see table below). This makes getting syntactically correct function signatures inconsistent across different LSP implementations. 

| LS | label | detail | labelDetails.detail | labelDetails.description |
| ------------- | -------------- | -------------- | -- | -- |
| lua_ls | `require(modname)` | `function` | - | - |
| zls | `addManyAt` | `fn (self: *Self, index: usize, count: usize) Allocator.Error![]T` | `(index: usize, count: usize)` | `Allocator.Error![]T` |
| rust-analyzer | `find_map(…)` | `fn(&mut self, F) -> Option<B>` | ` (as Iterator)` | `fn(&mut self, F) -> Option<B>` |

I don't think nvim-cmp should be responsible for properly formatting/highlighting the function signatures. Instead, that logic should be configurable by the user, or delegated to some other plugin in similar style of [lspkind-nvim](https://github.com/onsails/lspkind.nvim).

Suggestions are very welcome!