### PR TITLE
Use `keyword_pattern` for `is_symbol` check

### DIFF
--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -389,8 +389,9 @@ end
 ---Match line.
 ---@param input string
 ---@param matching_config cmp.MatchingConfig
+---@param keyword_pattern string
 ---@return { score: integer, matches: table[] }
-entry.match = function(self, input, matching_config)
+entry.match = function(self, input, matching_config, keyword_pattern)
   -- https://www.lua.org/pil/11.6.html
   -- do not use '..' to allocate multiple strings
   local cache_key = string.format('%s:%d:%d:%d:%d:%d:%d', input, self.resolved_completion_item and 1 or 0, matching_config.disallow_fuzzy_matching and 1 or 0, matching_config.disallow_partial_matching and 1 or 0, matching_config.disallow_prefix_unmatching and 1 or 0, matching_config.disallow_partial_fuzzy_matching and 1 or 0, matching_config.disallow_symbol_nonprefix_matching and 1 or 0)
@@ -403,13 +404,13 @@ entry.match = function(self, input, matching_config)
     end
     return matched
   end
-  matched = self:_match(input, matching_config)
+  matched = self:_match(input, matching_config, keyword_pattern)
   self.match_cache:set(cache_key, matched)
   return matched
 end
 
 ---@package
-entry._match = function(self, input, matching_config)
+entry._match = function(self, input, matching_config, keyword_pattern)
   local completion_item = self.completion_item
   local option = {
     disallow_fuzzy_matching = matching_config.disallow_fuzzy_matching,
@@ -421,6 +422,7 @@ entry._match = function(self, input, matching_config)
       self.word,
       self.completion_item.label,
     },
+    keyword_pattern = keyword_pattern,
   }
 
   local score, matches, filter_text

--- a/lua/cmp/matcher_spec.lua
+++ b/lua/cmp/matcher_spec.lua
@@ -22,6 +22,21 @@ describe('matcher', function()
     assert.is.truthy(matcher.match('fmodify', 'fnamemodify', config.matching) >= 1)
     assert.is.truthy(matcher.match('candlesingle', 'candle#accept#single', config.matching) >= 1)
 
+    local options = {
+      keyword_pattern = [[ \w\+ ]],
+    }
+    assert.is.truthy(matcher.match('ab', 'a_b_c', options) > matcher.match('ac', 'a_b_c', options))
+    assert.is.truthy(matcher.match('a_b', 'a_b_c', options) > matcher.match('ab', 'a_b_c', options))
+    assert.is.truthy(matcher.match('a_b/c', 'a_b/c', options) > matcher.match('a/c', 'a_b/c', options))
+
+    assert.is.truthy(matcher.match('bora', 'border-radius') >= 1)
+    assert.is.truthy(matcher.match('woroff', 'word_offset') >= 1)
+    assert.is.truthy(matcher.match('call', 'call') > matcher.match('call', 'condition_all'))
+    assert.is.truthy(matcher.match('Buffer', 'Buffer') > matcher.match('Buffer', 'buffer'))
+    assert.is.truthy(matcher.match('luacon', 'lua_context') > matcher.match('luacon', 'LuaContext'))
+    assert.is.truthy(matcher.match('fmodify', 'fnamemodify') >= 1)
+    assert.is.truthy(matcher.match('candlesingle', 'candle#accept#single') >= 1)
+
     assert.is.truthy(matcher.match('vi', 'void#', config.matching) >= 1)
     assert.is.truthy(matcher.match('vo', 'void#', config.matching) >= 1)
     assert.is.truthy(matcher.match('var_', 'var_dump', config.matching) >= 1)

--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -120,7 +120,7 @@ source.get_entries = function(self, ctx)
       inputs[o] = string.sub(ctx.cursor_before_line, o)
     end
 
-    local match = e:match(inputs[o], matching_config)
+    local match = e:match(inputs[o], matching_config, self:get_keyword_pattern())
     e.score = match.score
     e.exact = false
     if e.score >= 1 then


### PR DESCRIPTION
Use `keyword_pattern` in place of `char.is_symbol` to improve matching (especially useful for improving for `cmp-path` and `cmp-cmdline` matches in the command-line).

Falls back to original behaviour of using `char.is_symbol` if no `keyword_pattern` is provided/specified for a source.