### PR TITLE
fix(feedkeys): resolve issue with some copilot completions

### DIFF
--- a/lua/cmp/utils/feedkeys.lua
+++ b/lua/cmp/utils/feedkeys.lua
@@ -15,7 +15,7 @@ feedkeys.call = setmetatable({
       table.insert(queue, { keymap.t('<Cmd>setlocal lazyredraw<CR>'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal textwidth=0<CR>'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal backspace=2<CR>'), 'n' })
-      table.insert(queue, { keys, string.gsub(mode, '[itx]', ''), true })
+      -- table.insert(queue, { keys, string.gsub(mode, '[itx]', ''), true })
       table.insert(queue, { keymap.t('<Cmd>setlocal %slazyredraw<CR>'):format(vim.o.lazyredraw and '' or 'no'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal textwidth=%s<CR>'):format(vim.bo.textwidth or 0), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal backspace=%s<CR>'):format(vim.go.backspace or 2), 'n' })
@@ -44,7 +44,7 @@ feedkeys.call = setmetatable({
 })
 feedkeys.run = function(id)
   if feedkeys.call.callbacks[id] then
-    feedkeys.call.callbacks[id]()
+    pcall(feedkeys.call.callbacks[id])
     feedkeys.call.callbacks[id] = nil
   end
   return ''

--- a/lua/cmp/utils/feedkeys.lua
+++ b/lua/cmp/utils/feedkeys.lua
@@ -14,7 +14,7 @@ feedkeys.call = setmetatable({
     if #keys > 0 then
       table.insert(queue, { keymap.t('<Cmd>setlocal lazyredraw<CR>'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal textwidth=0<CR>'), 'n' })
-      table.insert(queue, { keymap.t('<Cmd>setlocal backspace=indent<CR>'), 'n' })
+      table.insert(queue, { keymap.t('<Cmd>setlocal backspace=nostop<CR>'), 'n' })
       table.insert(queue, { keys, string.gsub(mode, '[itx]', ''), true })
       table.insert(queue, { keymap.t('<Cmd>setlocal %slazyredraw<CR>'):format(vim.o.lazyredraw and '' or 'no'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal textwidth=%s<CR>'):format(vim.bo.textwidth or 0), 'n' })
@@ -44,7 +44,10 @@ feedkeys.call = setmetatable({
 })
 feedkeys.run = function(id)
   if feedkeys.call.callbacks[id] then
-    pcall(feedkeys.call.callbacks[id])
+    local ok, err = pcall(feedkeys.call.callbacks[id])
+    if not ok then
+      vim.notify(err, vim.log.levels.ERROR)
+    end
     feedkeys.call.callbacks[id] = nil
   end
   return ''

--- a/lua/cmp/utils/feedkeys.lua
+++ b/lua/cmp/utils/feedkeys.lua
@@ -15,7 +15,7 @@ feedkeys.call = setmetatable({
       table.insert(queue, { keymap.t('<Cmd>setlocal lazyredraw<CR>'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal textwidth=0<CR>'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal backspace=indent<CR>'), 'n' })
-      table.insert(queue, { keys, string.gsub(mode, '[itx]', ''), false })
+      table.insert(queue, { keys, string.gsub(mode, '[itx]', ''), true })
       table.insert(queue, { keymap.t('<Cmd>setlocal %slazyredraw<CR>'):format(vim.o.lazyredraw and '' or 'no'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal textwidth=%s<CR>'):format(vim.bo.textwidth or 0), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal backspace=%s<CR>'):format(vim.go.backspace or 2), 'n' })

--- a/lua/cmp/utils/feedkeys.lua
+++ b/lua/cmp/utils/feedkeys.lua
@@ -14,8 +14,8 @@ feedkeys.call = setmetatable({
     if #keys > 0 then
       table.insert(queue, { keymap.t('<Cmd>setlocal lazyredraw<CR>'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal textwidth=0<CR>'), 'n' })
-      table.insert(queue, { keymap.t('<Cmd>setlocal backspace=2<CR>'), 'n' })
-      -- table.insert(queue, { keys, string.gsub(mode, '[itx]', ''), true })
+      table.insert(queue, { keymap.t('<Cmd>setlocal backspace=indent<CR>'), 'n' })
+      table.insert(queue, { keys, string.gsub(mode, '[itx]', ''), false })
       table.insert(queue, { keymap.t('<Cmd>setlocal %slazyredraw<CR>'):format(vim.o.lazyredraw and '' or 'no'), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal textwidth=%s<CR>'):format(vim.bo.textwidth or 0), 'n' })
       table.insert(queue, { keymap.t('<Cmd>setlocal backspace=%s<CR>'):format(vim.go.backspace or 2), 'n' })

--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -1,7 +1,7 @@
 local config = require('cmp.config')
 local misc = require('cmp.utils.misc')
 local snippet = require('cmp.utils.snippet')
-local str = require('cmp.utils.str')
+-- local str = require('cmp.utils.str')
 local api = require('cmp.utils.api')
 local types = require('cmp.types')
 


### PR DESCRIPTION
This seems to fix #1560 in my limited testing. It would be great if anyone else can test it and see if any other issues arise.
and https://github.com/zbirenbaum/copilot-cmp/issues/79

At the very least, we should include the pcall to stop it from crashing cmp entirely in the event of a bad completion,

This is required after neovim deprecations here:
https://github.com/neovim/neovim/pull/24350
