### PR TITLE
fix: Error on using select_next_entry and select_prev_entry

### DIFF
--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -314,7 +314,7 @@ end
 
 custom_entries_view.select_next_item = function(self, option)
   if self:visible() then
-    local cursor = self:get_selected_index()
+    local cursor = svim.api.nvim_win_get_cursor(self.entries_win.win)[1]
     local is_top_down = self:is_direction_top_down()
     local last = #self.entries
 
@@ -351,7 +351,7 @@ end
 
 custom_entries_view.select_prev_item = function(self, option)
   if self:visible() then
-    local cursor = self:get_selected_index()
+    local cursor = vim.api.nvim_win_get_cursor(self.entries_win.win)[1]
     local is_top_down = self:is_direction_top_down()
     local last = #self.entries
 

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -314,7 +314,7 @@ end
 
 custom_entries_view.select_next_item = function(self, option)
   if self:visible() then
-    local cursor = svim.api.nvim_win_get_cursor(self.entries_win.win)[1]
+    local cursor = vim.api.nvim_win_get_cursor(self.entries_win.win)[1]
     local is_top_down = self:is_direction_top_down()
     local last = #self.entries
 


### PR DESCRIPTION
 
Fixes #1988 
get_selected_index was checking self.active before returning an index, which is actually false when select_next_entry is first called in typical usage using a mapping. Switched to how cursor was calculated before this PR #1986 