### PR TITLE
fixup! fix: remove deprecated use of vim.tbl_add_reverse_lookup (#1931)

### DIFF
--- a/lua/cmp/types/lsp.lua
+++ b/lua/cmp/types/lsp.lua
@@ -202,7 +202,8 @@ lsp.CompletionItemKind = {
   Operator = 24,
   TypeParameter = 25,
 }
-for k, v in pairs(lsp.CompletionItemKind) do
+for _, k in ipairs(vim.tbl_keys(lsp.CompletionItemKind)) do
+  local v = lsp.CompletionItemKind[k]
   lsp.CompletionItemKind[v] = k
 end
 


### PR DESCRIPTION
Fixup for #1931 to use `vim.tbl_keys`, to avoid iterating while adding keys.

Fixes https://github.com/hrsh7th/nvim-cmp/pull/1931#issuecomment-2213094466
Fixes #1939