### PR TITLE
fix: Add newer fallback method for tree-sitter scopes

### DIFF
--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -212,7 +212,9 @@ compare.scopes = setmetatable({
 
       -- Cursor scope.
       local cursor_scope = nil
-      for _, scope in ipairs(locals.get_scopes(buf)) do
+      -- Prioritize the older get_scopes method from nvim-treesitter `master` over get from `main`
+      local scopes = locals.get_scopes and locals.get_scopes(buf) or select(3, locals.get(buf))
+      for _, scope in ipairs(scopes) do
         if scope:start() <= cursor_row and cursor_row <= scope:end_() then
           if not cursor_scope then
             cursor_scope = scope


### PR DESCRIPTION
A few hours ago, the [nvim-treesitter main branch removed `locals.get_scopes` for the newer `locals.get`](https://github.com/nvim-treesitter/nvim-treesitter/commit/0297cc6182fa7bf9608777c180172c35553d6a26#diff-eed1b34be50be29ccfe659070eb48f6ed610abaa7d984e3c5b8ac112cb1cfa38) so this PR adds a fallback to the newer method to help those trying out that branch.