### PR TITLE
fix: Disable compare.scopes when no tree-sitter parser is present

### DIFF
--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -212,7 +212,9 @@ compare.scopes = setmetatable({
 
       -- Cursor scope.
       local cursor_scope = nil
-      for _, scope in ipairs(locals.get_scopes(buf)) do
+      -- Prioritize the older get_scopes method from nvim-treesitter `master` over get from `main`
+      local scopes = locals.get_scopes and locals.get_scopes(buf) or select(3, locals.get(buf))
+      for _, scope in ipairs(scopes) do
         if scope:start() <= cursor_row and cursor_row <= scope:end_() then
           if not cursor_scope then
             cursor_scope = scope

--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -199,6 +199,7 @@ compare.locality = setmetatable({
 ---@type cmp.ComparatorFunctor
 compare.scopes = setmetatable({
   scopes_map = {},
+  has_nvim_0_9_features = vim.fn.has('nvim-0.9') == 1,
   update = function(self)
     local config = require('cmp').get_config()
     if not vim.tbl_contains(config.sorting.comparators, compare.scopes) then
@@ -209,6 +210,9 @@ compare.scopes = setmetatable({
     if ok then
       local win, buf = vim.api.nvim_get_current_win(), vim.api.nvim_get_current_buf()
       local cursor_row = vim.api.nvim_win_get_cursor(win)[1] - 1
+      if self.has_nvim_0_9_features and not vim.b[buf].cmp_buf_has_treesitter then
+        return
+      end
 
       -- Cursor scope.
       local cursor_scope = nil

--- a/lua/cmp/utils/autocmd.lua
+++ b/lua/cmp/utils/autocmd.lua
@@ -19,8 +19,8 @@ autocmd.subscribe = function(events, callback)
       vim.api.nvim_create_autocmd(event, {
         desc = ('nvim-cmp: autocmd: %s'):format(event),
         group = autocmd.group,
-        callback = function()
-          autocmd.emit(event)
+        callback = function(details)
+          autocmd.emit(event, details)
         end,
       })
     end
@@ -41,12 +41,13 @@ end
 
 ---Emit autocmd
 ---@param event string
-autocmd.emit = function(event)
+---@param details table|nil
+autocmd.emit = function(event, details)
   debug.log(' ')
   debug.log(string.format('>>> %s', event))
   autocmd.events[event] = autocmd.events[event] or {}
   for _, callback in ipairs(autocmd.events[event]) do
-    callback()
+    callback(details)
   end
 end
 

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -60,6 +60,11 @@ if vim.fn.has('nvim-0.9') then
       vim.b[details.buf].cmp_buf_has_treesitter = true
     end
   end)
+  autocmd.subscribe({ 'BufUnload' }, function(details)
+    if vim.treesitter.language.get_lang(details.match) then
+      vim.b[details.buf].cmp_buf_has_treesitter = false
+    end
+  end)
 end
 
 vim.api.nvim_create_user_command('CmpStatus', function()

--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -53,6 +53,14 @@ if vim.on_key then
   end, vim.api.nvim_create_namespace('cmp.plugin'))
 end
 
+-- see compare.scopes
+if vim.fn.has('nvim-0.9') then
+  autocmd.subscribe({ 'FileType' }, function(details)
+    if vim.treesitter.language.get_lang(details.match) then
+      vim.b[details.buf].cmp_buf_has_treesitter = true
+    end
+  end)
+end
 
 vim.api.nvim_create_user_command('CmpStatus', function()
   require('cmp').status()


### PR DESCRIPTION
On nvim-treesitter `main`, some of the methods used in cmp's `compare.scopes` now error instead of returning an empty table when no tree-sitter parser exists, (specifically, `locals.get_*`). This implements a basic fix.

Leaving it as a draft because:

- Not sure if this difference in behavior is final.
- Not sure on the best way to track whether a buffer has tree-sitter parsing.
	- Maybe track the buffers in `compare.scopes` instead of `vim.b`?
	- Would it be better to not track buffers and just `pcall` the affected `locals.get_*` methods?
- Not sure about modifying autocmd helpers to include the lua callback table.