### PR TITLE
fix: the height of docs view get wrong when content lines get wrapped

### DIFF
--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -58,6 +58,7 @@ docs_view.open = function(self, e, view)
     local opts = {
       max_width = max_width - border_info.horiz,
     }
+    opts.wrap_at = opts.max_width
     if documentation.max_height > 0 then
       opts.max_height = documentation.max_height
     end
@@ -71,6 +72,7 @@ docs_view.open = function(self, e, view)
   local opts = {
     max_width = max_width - border_info.horiz,
   }
+  opts.wrap_at = opts.max_width
   if documentation.max_height > 0 then
     opts.max_height = documentation.max_height - border_info.vert
   end


### PR DESCRIPTION
When the `wrap_at` option not pass to `vim.lsp.util._make_floating_popup_size()`, it calculates height with unwrapped lines.
Actually the nvim-cmp shows content with wrapped lines in docs view.
So when the content has very long text, the calculated height is smaller than actually required in docs view.

Before:

![2024-09-02_03 57 58@2x](https://github.com/user-attachments/assets/13ff7484-5542-4032-8738-c2ea4785b1b7)

After fixed:

![2024-09-02_03 46 38@2x](https://github.com/user-attachments/assets/78edd5e5-89e3-4642-be50-2f092201cebe)

