### PR TITLE
fix missing required fields in formatting config

### DIFF
--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -151,9 +151,9 @@ cmp.ItemField = {
 ---@field public comparators cmp.Comparator[]
 
 ---@class cmp.FormattingConfig
----@field public fields cmp.ItemField[]
----@field public expandable_indicator boolean
----@field public format fun(entry: cmp.Entry, vim_item: vim.CompletedItem): vim.CompletedItem
+---@field public fields? cmp.ItemField[]
+---@field public expandable_indicator? boolean
+---@field public format? fun(entry: cmp.Entry, vim_item: vim.CompletedItem): vim.CompletedItem
 
 ---@class cmp.SnippetConfig
 ---@field public expand fun(args: cmp.SnippetExpansionParams)


### PR DESCRIPTION
Similar to https://github.com/hrsh7th/nvim-cmp/pull/1723

![2024-09-18_10-09-1726649085](https://github.com/user-attachments/assets/a3cb0fc0-c6f6-49f9-89b8-f504b2f7dfc8)

Default values are set in https://github.com/hrsh7th/nvim-cmp/blob/ae644feb7b67bf1ce4260c231d1d4300b19c6f30/lua/cmp/config/default.lua#L48 so afaik no need to explicitly require them.