### PR TITLE
fix: don't blow up when `nvim_buf_get_lines()` returns Blobs

### DIFF
--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -309,6 +309,9 @@ window.get_content_height = function(self)
   local height = 0
   vim.api.nvim_buf_call(self:get_buffer(), function()
     for _, text in ipairs(vim.api.nvim_buf_get_lines(self:get_buffer(), 0, -1, false)) do
+      if vim.fn.type(text) == vim.v.t_blob then
+        text = vim.fn.string(text)
+      end
       height = height + math.max(1, math.ceil(vim.fn.strdisplaywidth(text) / self.style.width))
     end
   end)


### PR DESCRIPTION
Some LSP servers may return binary garbage and `nvim_buf_get_lines()` will return a `Blob` instead of a `String` in those cases.

I added some `print(vim.inspect())` debugging in
`entry.get_documentation()` to prove that by the time the text passes through there, it's already garbage.

Here's an excerpt from a sample line returned by `nvim_buf_get_lines()`, as rendered by `vim.inspect()`:

    default\0\0\0!      vim.opt.background = 'dark'\0\0\0000

(etc)

Now, this looks like an LSP bug to me, but I think we shouldn't allow buggy LSP output to crash nvim-cmp. "Be conservative in what you send, be liberal in what you accept" and all that.

So, degrade by coercing any `Blob` we see into a `String` before passing it to `strdisplaywidth()`.

Closes: https://github.com/hrsh7th/nvim-cmp/issues/820