### PR TITLE
feat: allow individual hl custamization of scrollbar for docs and menu

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -721,6 +721,18 @@ window.{completion,documentation}.winhighlight~
   Specify the window's winhighlight option.
   See |nvim_open_win|.
 
+                     *cmp-config.window.{completion,documentation}.scrollbar_winhighlight*
+window.{completion,documentation}.scrollbar_winhighlight~
+  `string | nil`
+  Specify the winhighlight option for the scrollbar background.
+  See |nvim_open_win|.
+
+                     *cmp-config.window.{completion,documentation}.scrollbar_thumb_winhighlight*
+window.{completion,documentation}.scrollbar_thumb_winhighlight~
+  `string | nil`
+  Specify the winhighlight option for the scrollbar thumb.
+  See |nvim_open_win|.
+
                      *cmp-config.window.{completion,documentation}.winblend*
 window.{completion,documentation}.winblend~
   `string | cmp.WinhighlightConfig`

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -109,6 +109,8 @@ return function()
       completion = {
         border = { '', '', '', '', '', '', '', '' },
         winhighlight = 'Normal:Pmenu,FloatBorder:Pmenu,CursorLine:PmenuSel,Search:None',
+        scrollbar_winhighlight = 'EndOfBuffer:PmenuSbar,NormalFloat:PmenuSbar',
+        scrollbar_thumb_winhighlight = 'EndOfBuffer:PmenuThumb,NormalFloat:PmenuThumb',
         winblend = vim.o.pumblend,
         scrolloff = 0,
         col_offset = 0,
@@ -120,6 +122,8 @@ return function()
         max_width = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
         border = { '', '', '', ' ', '', '', '', ' ' },
         winhighlight = 'FloatBorder:NormalFloat',
+        scrollbar_winhighlight = 'EndOfBuffer:PmenuSbar,NormalFloat:PmenuSbar',
+        scrollbar_thumb_winhighlight = 'EndOfBuffer:PmenuThumb,NormalFloat:PmenuThumb',
         winblend = vim.o.pumblend,
       },
     },

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -122,6 +122,8 @@ cmp.ItemField = {
 ---@class cmp.WindowOptions
 ---@field public border? string|string[]
 ---@field public winhighlight? string
+---@field public scrollbar_winhighlight? string
+---@field public scrollbar_thumb_winhighlight? string
 ---@field public winblend? number
 ---@field public zindex? integer|nil
 

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -19,6 +19,7 @@ local config = require('cmp.config')
 ---@field public thumb_win integer|nil
 ---@field public sbar_win integer|nil
 ---@field public style cmp.WindowStyle
+---@field public is_doc boolean|nil
 ---@field public opt table<string, any>
 ---@field public buffer_opt table<string, any>
 local window = {}
@@ -134,6 +135,8 @@ end
 window.update = function(self)
   local info = self:info()
   if info.scrollable and self.style.height > 0 then
+    local scrollbar_winhighlight = self.is_doc and config.get().window.completion.scrollbar_winhighlight or config.get().window.documentation.scrollbar_winhighlight
+    local scrollbar_thumb_winhighlight = self.is_doc and config.get().window.completion.scrollbar_thumb_winhighlight or config.get().window.documentation.scrollbar_thumb_winhighlight
     -- Draw the background of the scrollbar
 
     if not info.border_info.visible then
@@ -151,7 +154,7 @@ window.update = function(self)
       else
         style.noautocmd = true
         self.sbar_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'sbar_buf'), false, style)
-        opt.win_set_option(self.sbar_win, 'winhighlight', 'EndOfBuffer:PmenuSbar,NormalFloat:PmenuSbar')
+        opt.win_set_option(self.sbar_win, 'winhighlight', scrollbar_winhighlight)
       end
     end
 
@@ -173,7 +176,7 @@ window.update = function(self)
     else
       style.noautocmd = true
       self.thumb_win = vim.api.nvim_open_win(buffer.ensure(self.name .. 'thumb_buf'), false, style)
-      opt.win_set_option(self.thumb_win, 'winhighlight', 'EndOfBuffer:PmenuThumb,NormalFloat:PmenuThumb')
+      opt.win_set_option(self.thumb_win, 'winhighlight', scrollbar_thumb_winhighlight)
     end
   else
     if self.sbar_win and vim.api.nvim_win_is_valid(self.sbar_win) then

--- a/lua/cmp/view/docs_view.lua
+++ b/lua/cmp/view/docs_view.lua
@@ -19,6 +19,7 @@ docs_view.new = function()
   self.window:option('wrap', true)
   self.window:buffer_option('filetype', 'cmp_docs')
   self.window:buffer_option('buftype', 'nofile')
+  self.window.is_doc = true
   return self
 end
 


### PR DESCRIPTION
This allows you to set the highlight group of the scrollbar in the completion menu and doc menu to be something you'd want to be specifically. This solves this issue here: https://github.com/hrsh7th/nvim-cmp/issues/1775

This is just an example of the change here (I chose wild colors just to make them stand out):
<img width="1110" alt="Screenshot 2024-11-02 at 2 05 07 PM" src="https://github.com/user-attachments/assets/c4866026-012f-4efc-8e17-90c0648810ff">