### PR TITLE
fix: some symbols can't be mapped correctly

### DIFF
--- a/lua/cmp/utils/keymap.lua
+++ b/lua/cmp/utils/keymap.lua
@@ -8,7 +8,7 @@ local keymap = {}
 ---@param keys string
 ---@return string
 keymap.t = function(keys)
-  return (string.gsub(keys, '(<[A-Za-z0-9\\%-%[%]%^@;_]->)', function(match)
+  return (string.gsub(keys, '(<[A-Za-z0-9\\%-%[%]%^@;_,%./]->)', function(match)
     return vim.api.nvim_eval(string.format([["\%s"]], match))
   end))
 end
@@ -17,7 +17,7 @@ end
 ---@param keys string
 ---@return string
 keymap.normalize = vim.fn.has('nvim-0.8') == 1 and function(keys)
-    local t = string.gsub(keys, '<([A-Za-z0-9\\%-%[%]%^@;_]-)>', function(match)
+    local t = string.gsub(keys, '<([A-Za-z0-9\\%-%[%]%^@;_,%./]-)>', function(match)
       -- Use the \<* notation, which distinguishes <C-J> from <NL>, etc.
       return vim.api.nvim_eval(string.format([["\<*%s>"]], match))
     end)

--- a/lua/cmp/utils/keymap_spec.lua
+++ b/lua/cmp/utils/keymap_spec.lua
@@ -19,6 +19,8 @@ describe('keymap', function()
       '<C-;>',
       '<C-,>',
       '<C-:>',
+      '<C-.>',
+      '<C-/>',
       '<C-_>',
       '<Tab>',
       '<S-Tab>',


### PR DESCRIPTION
#1935 will cause some symbols to not be mapped correctly. I have added the symbols that I need to map. I'm not very familiar with others' habits, but I believe there should be some other symbols that need to be added to this patter.

Fix #2080.