### PR TITLE
fix: make sure nvim-cmp keymaps are registered

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -328,9 +328,13 @@ cmp.setup = setmetatable({
   end,
 })
 
+local cmp_prepared = false
+
 -- In InsertEnter autocmd, vim will detects mode=normal unexpectedly.
 local on_insert_enter = function()
-  if config.enabled() then
+  if not cmp_prepared or config.enabled() then
+    cmp_prepared = true
+
     cmp.config.compare.scopes:update()
     cmp.config.compare.locality:update()
     cmp.core:prepare()

--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -334,10 +334,12 @@ local cmp_prepared = false
 local on_insert_enter = function()
   if not cmp_prepared or config.enabled() then
     cmp_prepared = true
-
     cmp.config.compare.scopes:update()
     cmp.config.compare.locality:update()
     cmp.core:prepare()
+  end
+
+  if config.enabled() then
     cmp.core:on_change('InsertEnter')
   end
 end


### PR DESCRIPTION
## Context

When editing files with the https://github.com/microsoft/compose-language-service LSP, the popup would always appear on new lines like so:

<details>
<summary>Completion appears on fully whitespace line</summary>

As you can see, this interferes with my fallback Tab keymap which indents the code and its very annoying

https://github.com/user-attachments/assets/865dcb18-72f8-4d67-8b07-39e29aaa36db

This is with `keyword_length = 1`


</details>


## The underlying issue



I think the underlying issue is:
1. docker compose LSP acts differently (this does not happen on other lsps)
2. nvim-cmp, even with `keyword_length = 1` still shows the menu when there are no keywords (fully whitespace line), unless this is the expected behavior


## Workaround

I started using this config to workaround the issue

```
enabled = function()
    return #vim.trim(vim.api.nvim_get_current_line()) ~= 0
end,
```

But then I saw that sometimes my completion selection just stopped working altogether like so: 

<details>
<summary>Completion stops</summary>


https://github.com/user-attachments/assets/b8436986-e773-484f-9265-ebbf0301dbc0



</details>

## This PR

This pr makes the workaround actually work

<details>
<summary>With this PR</summary>


https://github.com/user-attachments/assets/70e812ae-def6-4e6d-bdc1-1755cb4c3168



</details>