### PR TITLE
fix: make <c-,> and <c-:> work again

### DIFF
--- a/lua/cmp/utils/keymap.lua
+++ b/lua/cmp/utils/keymap.lua
@@ -8,7 +8,7 @@ local keymap = {}
 ---@param keys string
 ---@return string
 keymap.t = function(keys)
-  return (string.gsub(keys, '(<[A-Za-z0-9\\%-%[%]%^@;_]->)', function(match)
+  return (string.gsub(keys, '(<[A-Za-z0-9\\%-%[%]%^@;,:_]->)', function(match)
     return vim.api.nvim_eval(string.format([["\%s"]], match))
   end))
 end
@@ -17,7 +17,7 @@ end
 ---@param keys string
 ---@return string
 keymap.normalize = vim.fn.has('nvim-0.8') == 1 and function(keys)
-    local t = string.gsub(keys, '<([A-Za-z0-9\\%-%[%]%^@;_]-)>', function(match)
+    local t = string.gsub(keys, '<([A-Za-z0-9\\%-%[%]%^@;,:_]-)>', function(match)
       -- Use the \<* notation, which distinguishes <C-J> from <NL>, etc.
       return vim.api.nvim_eval(string.format([["\<*%s>"]], match))
     end)

--- a/lua/cmp/utils/keymap_spec.lua
+++ b/lua/cmp/utils/keymap_spec.lua
@@ -17,6 +17,8 @@ describe('keymap', function()
       '<C-@>',
       '<C-\\>',
       '<C-;>',
+      '<C-,>',
+      '<C-:>',
       '<C-_>',
       '<Tab>',
       '<S-Tab>',


### PR DESCRIPTION
Fixes <c-,> and \<c-:\> in the same way <c-;> was fixed