### PR TITLE
Fix :checkhealth warnings

### DIFF
--- a/lua/cmp/utils/misc.lua
+++ b/lua/cmp/utils/misc.lua
@@ -197,7 +197,7 @@ end
 ---@return integer
 misc.to_utfindex = function(text, vimindex)
   vimindex = vimindex or #text + 1
-  return vim.str_utfindex(text, math.max(0, math.min(vimindex - 1, #text)))
+  return vim.str_utfindex(text, "utf-8", math.max(0, math.min(vimindex - 1, #text)))
 end
 
 ---Safe version of vim.str_byteindex
@@ -208,7 +208,7 @@ misc.to_vimindex = function(text, utfindex)
   utfindex = utfindex or #text
   for i = utfindex, 1, -1 do
     local s, v = pcall(function()
-      return vim.str_byteindex(text, i) + 1
+	   return vim.str_byteindex(text, "utf-8", i) + 1
     end)
     if s then
       return v


### PR DESCRIPTION
Fix the following warning when running `:checkhealth`

  ```
  - WARNING vim.str_utfindex is deprecated. Feature will be removed in Nvim 1.0
  - ADVICE:
    - use vim.str_utfindex(s, encoding, index, strict_indexing) instead.
  ```
```typescript
function vim.str_utfindex(s: string, encoding: "utf-16"|"utf-32"|"utf-8", index?: integer, strict_indexing?: boolean)
  -> integer
```

Additionally, update vim.str_byteindex to match:
```typescript
function vim.str_byteindex(s: string, encoding: "utf-16"|"utf-32"|"utf-8", index: integer, strict_indexing?: boolean)
  -> integer
```

