### PR TITLE
Mark vimscript block as "vim"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Setup
 
 This example configuration uses `vim-plug` as the plugin manager and `vim-vsnip` as a snippet plugin.
 
-```lua
+```vim
 call plug#begin(s:plug_dir)
 Plug 'neovim/nvim-lspconfig'
 Plug 'hrsh7th/cmp-nvim-lsp'


### PR DESCRIPTION
The example configuration is Vimscript, with a heredoc containing some Lua code. Using "lua" as a language identifier results neither the Vimscript portion nor the Lua portion being highlighted propertly.

Mark the code block as "vim".  Neovim (with treesitter) properly highlights the outer block as Vimscript, and the Lua heredoc as Lua code.