### PR TITLE
fix: enable sort_text comparator by default

### DIFF
--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -73,7 +73,7 @@ return function()
         compare.recently_used,
         compare.locality,
         compare.kind,
-        -- compare.sort_text,
+        compare.sort_text,
         compare.length,
         compare.order,
       },


### PR DESCRIPTION
This effectively reverts 11a95792a5be0f5a40bab5fc5b670e5b1399a939 - @hrsh7th is there a reason why it was commented out?

This means items will now be shown in the order requested by the LSP server.

Related to #1654, enabling sort_text again fixes https://github.com/saecki/crates.nvim/issues/69.

Also P.S. any chance #1991 could be merged...

Fixes #1984
Closes #2020