### PR TITLE
fix: Outdated completion item with mini.snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Plug 'hrsh7th/vim-vsnip'
 " Plug 'L3MON4D3/LuaSnip'
 " Plug 'saadparwaiz1/cmp_luasnip'
 
+" For mini.snippets users.
+" Plug 'echasnovski/mini.snippets'
+" Plug 'abeldekat/cmp-mini-snippets'
+
 " For ultisnips users.
 " Plug 'SirVer/ultisnips'
 " Plug 'quangnguyen30192/cmp-nvim-ultisnips'
@@ -69,6 +73,12 @@ lua <<EOF
         -- require('snippy').expand_snippet(args.body) -- For `snippy` users.
         -- vim.fn["UltiSnips#Anon"](args.body) -- For `ultisnips` users.
         -- vim.snippet.expand(args.body) -- For native neovim snippets (Neovim v0.10+)
+
+        -- For `mini.snippets` users:
+        -- local insert = MiniSnippets.config.expand.insert or MiniSnippets.default_insert
+        -- insert({ body = args.body }) -- Insert at cursor
+        -- cmp.resubscribe({ "TextChangedI", "TextChangedP" })
+        -- require("cmp.config").set_onetime({ sources = {} })
       end,
     },
     window = {

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -62,6 +62,10 @@ A recommended configuration can be found below.
   " Plug 'L3MON4D3/LuaSnip'
   " Plug 'saadparwaiz1/cmp_luasnip'
 
+  " For mini.snippets users.
+  " Plug 'echasnovski/mini.snippets'
+  " Plug 'abeldekat/cmp-mini-snippets'
+
   " For snippy users.
   " Plug 'dcampos/nvim-snippy'
   " Plug 'dcampos/cmp-snippy'
@@ -86,6 +90,12 @@ A recommended configuration can be found below.
           -- require'snippy'.expand_snippet(args.body) -- For `snippy` users.
           -- vim.fn["UltiSnips#Anon"](args.body) -- For `ultisnips` users.
           -- vim.snippet.expand(args.body) -- For native neovim snippets (Neovim v0.10+)
+
+          -- For `mini.snippets` users:
+          -- local insert = MiniSnippets.config.expand.insert or MiniSnippets.default_insert
+          -- insert({ body = args.body }) -- Insert at cursor
+          -- cmp.resubscribe({ "TextChangedI", "TextChangedP" })
+          -- require("cmp.config").set_onetime({ sources = {} })
         end,
       },
       window = {

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -494,7 +494,6 @@ core.confirm = function(self, e, option, callback)
         (#texts == 1 and (completion_item.textEdit.range.start.character + #texts[1]) or #texts[#texts]),
       })
       if is_snippet then
-        config.set_onetime({ sources = {} })
         config.get().snippet.expand({
           body = new_text,
           insert_text_mode = completion_item.insertTextMode,

--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -494,6 +494,7 @@ core.confirm = function(self, e, option, callback)
         (#texts == 1 and (completion_item.textEdit.range.start.character + #texts[1]) or #texts[#texts]),
       })
       if is_snippet then
+        config.set_onetime({ sources = {} })
         config.get().snippet.expand({
           body = new_text,
           insert_text_mode = completion_item.insertTextMode,

--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -328,6 +328,12 @@ cmp.status = function()
   end
 end
 
+---Ensures that cmp is the last receiver of the events specified.
+---@param events string[]
+cmp.resubscribe = function(events)
+  autocmd.resubscribe(events)
+end
+
 ---@type cmp.Setup
 cmp.setup = setmetatable({
   global = function(c)

--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -366,7 +366,7 @@ local on_text_changed = function()
     cmp.core:on_change('TextChanged')
   end
 end
-autocmd.subscribe({ 'TextChangedI', 'TextChangedP' }, on_text_changed)
+autocmd.subscribe({ 'TextChangedI', 'TextChangedP' }, async.debounce_next_tick(on_text_changed))
 autocmd.subscribe('CmdlineChanged', async.debounce_next_tick(on_text_changed))
 
 autocmd.subscribe('CursorMovedI', function()

--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -366,7 +366,7 @@ local on_text_changed = function()
     cmp.core:on_change('TextChanged')
   end
 end
-autocmd.subscribe({ 'TextChangedI', 'TextChangedP' }, async.debounce_next_tick(on_text_changed))
+autocmd.subscribe({ 'TextChangedI', 'TextChangedP' }, on_text_changed)
 autocmd.subscribe('CmdlineChanged', async.debounce_next_tick(on_text_changed))
 
 autocmd.subscribe('CursorMovedI', function()

--- a/lua/cmp/utils/autocmd.lua
+++ b/lua/cmp/utils/autocmd.lua
@@ -6,6 +6,16 @@ autocmd.group = vim.api.nvim_create_augroup('___cmp___', { clear = true })
 
 autocmd.events = {}
 
+local function create_autocmd(event)
+  vim.api.nvim_create_autocmd(event, {
+    desc = ('nvim-cmp: autocmd: %s'):format(event),
+    group = autocmd.group,
+    callback = function()
+      autocmd.emit(event)
+    end,
+  })
+end
+
 ---Subscribe autocmd
 ---@param events string|string[]
 ---@param callback function
@@ -16,13 +26,7 @@ autocmd.subscribe = function(events, callback)
   for _, event in ipairs(events) do
     if not autocmd.events[event] then
       autocmd.events[event] = {}
-      vim.api.nvim_create_autocmd(event, {
-        desc = ('nvim-cmp: autocmd: %s'):format(event),
-        group = autocmd.group,
-        callback = function()
-          autocmd.emit(event)
-        end,
-      })
+      create_autocmd(event)
     end
     table.insert(autocmd.events[event], callback)
   end
@@ -47,6 +51,26 @@ autocmd.emit = function(event)
   autocmd.events[event] = autocmd.events[event] or {}
   for _, callback in ipairs(autocmd.events[event]) do
     callback()
+  end
+end
+
+---Resubscribe to events
+---@param events string[]
+autocmd.resubscribe = function(events)
+  -- Delete the autocommands if present
+  local found = vim.api.nvim_get_autocmds({
+    group = autocmd.group,
+    event = events,
+  })
+  for _, to_delete in ipairs(found) do
+    vim.api.nvim_del_autocmd(to_delete.id)
+  end
+
+  -- Recreate if event is known
+  for _, event in ipairs(events) do
+    if autocmd.events[event] then
+      create_autocmd(event)
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #2119 

The issue as described by @xzbdmw has been debated in several other places:

[.. triggers completion when it should not ..](https://github.com/abeldekat/cmp-mini-snippets/issues/6)
[beta testing mini.snippets: expanding snippets from lsp](https://github.com/abeldekat/cmp-mini-snippets/issues/9)

@xzbdmw provided a clear explanation:

>>I'll try to explain more detail:
mini.snippets: insert mode -> type 'f' -> both mini.snippets and cmp detects TextChangedI -> cmp-nvim-lsp sends request -> lua_ls receives the buffer content, which is vim.schedule(ffn) -> mini.snippets clears the placeholder fn, it becomes vim.schedule(f) -> "fun" completion_item contains TextEdits that want to clear the fn , now what in fn's original place is now the right pair -> right pair gone, before snippets expanding. Neither mini.snippets or cmp is to blame here IMO, they all do what they supposed to do.

>>luasnip: select mode -> type 'f' -> nvim clears the placeholder, by the definition of select mode -> cmp-nvim-lsp sends request -> lua_ls receives the buffer content, which is vim.schedule(f) -> all good.

@hrsh7th

I considered solving the problem in `cmp-nvim-lsp`, introducing some kind of flag indicating whether the call to `complete` should be scheduled or not.

Then I saw that `TextChangedI` and `TextChangedP` do not yet use `async.debounce_next_tick`. 

I think this solves the issue on a more appropriate level.