### PR TITLE
Preserve 'buflisted' state when applying LSP text edits

### DIFF
--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -433,11 +433,11 @@ core.confirm = function(self, e, option, callback)
           return
         end
         vim.cmd([[silent! undojoin]])
-        vim.lsp.util.apply_text_edits(text_edits, ctx.bufnr, e.source:get_position_encoding_kind())
+        api.apply_text_edits(text_edits, ctx.bufnr, e.source:get_position_encoding_kind())
       end)
     else
       vim.cmd([[silent! undojoin]])
-      vim.lsp.util.apply_text_edits(e.completion_item.additionalTextEdits, ctx.bufnr, e.source:get_position_encoding_kind())
+      api.apply_text_edits(e.completion_item.additionalTextEdits, ctx.bufnr, e.source:get_position_encoding_kind())
     end
   end)
   feedkeys.call('', 'n', function()
@@ -486,7 +486,7 @@ core.confirm = function(self, e, option, callback)
       if is_snippet then
         completion_item.textEdit.newText = ''
       end
-      vim.lsp.util.apply_text_edits({ completion_item.textEdit }, ctx.bufnr, 'utf-8')
+      api.apply_text_edits({ completion_item.textEdit }, ctx.bufnr, 'utf-8')
 
       local texts = vim.split(completion_item.textEdit.newText, '\n')
       vim.api.nvim_win_set_cursor(0, {

--- a/lua/cmp/utils/api.lua
+++ b/lua/cmp/utils/api.lua
@@ -67,4 +67,15 @@ api.get_cursor_before_line = function()
   return string.sub(api.get_current_line(), 1, cursor[2])
 end
 
+--- Applies a list of text edits to a buffer. Preserves 'buflisted' state.
+---@param text_edits lsp.TextEdit[]
+---@param bufnr integer Buffer id
+---@param position_encoding 'utf-8'|'utf-16'|'utf-32'
+api.apply_text_edits = function(text_edits, bufnr, position_encoding)
+  -- preserve 'buflisted' state because vim.lsp.util.apply_text_edits forces it to true
+  local prev_buflisted = vim.bo[bufnr].buflisted
+  vim.lsp.util.apply_text_edits(text_edits, bufnr, position_encoding)
+  vim.bo[bufnr].buflisted = prev_buflisted
+end
+
 return api


### PR DESCRIPTION
fixes https://github.com/olimorris/codecompanion.nvim/issues/1060

This change preserves the original `buflisted` state of the current buffer when applying LSP text edits. The function `vim.lsp.util.apply_text_edits` forces `buflisted` to true (see https://github.com/neovim/neovim/issues/12488 and https://github.com/neovim/neovim/pull/12489), which is useful for non-current buffers but not desired for the current one. This fix saves the state before applying edits and restores it afterward.

Same as https://github.com/Saghen/blink.cmp/pull/1432

`make test` and `make lint` passed locally.