### PR TITLE
Supporting different ghost_text highlight when selected

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -787,7 +787,7 @@ window.documentation.max_height~
 
                                             *cmp-config.experimental.ghost_text*
 experimental.ghost_text~
-  `boolean | { hl_group = string }`
+  `boolean | { hl_group = string, hl_group_selected = string | nil}`
   Whether to enable the ghost_text feature.
 
 ==============================================================================

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -164,6 +164,7 @@ cmp.ItemField = {
 
 ---@class cmp.GhostTextConfig
 ---@field hl_group string
+---@field hl_group_selected string|nil
 
 ---@class cmp.SourceConfig
 ---@field public name string

--- a/lua/cmp/view/ghost_text_view.lua
+++ b/lua/cmp/view/ghost_text_view.lua
@@ -62,9 +62,13 @@ ghost_text_view.new = function()
 
       local text = self.text_gen(self, line, col)
       if #text > 0 then
+        local text_hl = 'Comment'
+        if type(c) == 'table' then
+          text_hl = require('cmp').core.view:get_selected_entry() and (c.hl_group_selected or c.hl_group) or c.hl_group
+        end
         local virt_lines = {}
         for _, l in ipairs(vim.fn.split(text, '\n')) do
-          table.insert(virt_lines, { { l, type(c) == 'table' and c.hl_group or 'Comment' } })
+          table.insert(virt_lines, { { l, text_hl} })
         end
         local first_line = table.remove(virt_lines, 1)
         self.extmark_buf = vim.api.nvim_get_current_buf()
@@ -87,7 +91,7 @@ end
 ---  of character differences instead of just byte difference.
 ghost_text_view.text_gen = function(self, line, cursor_col)
   local word = self.entry:get_insert_text()
-  if self.entry:get_completion_item().insertTextFormat == types.lsp.InsertTextFormat.Snippet then
+  if self.entry.completion_item.insertTextFormat == types.lsp.InsertTextFormat.Snippet then
     word = tostring(snippet.parse(word))
   end
   local word_clen = vim.str_utfindex(word)


### PR DESCRIPTION
# Problem
I had a visual problem in ghost text when using rust-tools, since it does pre-selects sometimes and sometimes not when no preferred completing item is available.  
Now with current ghost text view, I can't know if it's the item is from the first item in the table or a pre-selected one:  
Consider following images:
### not pre-selected
![not pre-selected](https://github.com/user-attachments/assets/bd4110d1-c549-4093-9422-9e2ae87b0a2a)
### pre-selected
![pre-selected](https://github.com/user-attachments/assets/d88ff194-cf27-4680-8b62-cd06d48c10d4)

But the key difference is, in first instance, I need to select (Tab) then confirm (hit Enter) to get the ghost to real text while in second instance, I need hit enter stright up! Hitting Tab + Enter give wrong item!

To handle this, I need to keep checking **the large** completing menu to know if the ghost text item is pre-selected or not.  
Hence ghost-text fails to achieve the actual moto i.e. accept completing without moving your eye off from the cursor.

# Solution
I have made a slight change to allow to use different highlight group for not pre-selected ghost text (i.e. text due to first item in the menu) and pre-selected ghost text as you can see below

### not pre-selected
![image](https://github.com/user-attachments/assets/9aa0e619-eb96-49bf-bf64-3531dc3fe26a)
### pre-selected
![image](https://github.com/user-attachments/assets/763e1615-ee51-42db-a01d-0c6108a79107)

Config used:
```lua
M.experimental = {
    ghost_text = {
        hl_group = 'Comment',
        hl_group_selected = "CmpItemAbbrMatch"
    }
}
```

So I just introduced one more option in `M.experimental.ghost_text` i.e. hl_group_selected (can be nil for backward compatibility) that applies on ghost-text when item is selected in completing menu.



