### PR TITLE
fix: handle winborder in neovim-0.11

### DIFF
--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -145,6 +145,7 @@ window.update = function(self)
         row = info.row,
         col = info.col + info.width - info.scrollbar_offset, -- info.col was already contained the scrollbar offset.
         zindex = (self.style.zindex and (self.style.zindex + 1) or 1),
+        border = "none",
       }
       if self.sbar_win and vim.api.nvim_win_is_valid(self.sbar_win) then
         vim.api.nvim_win_set_config(self.sbar_win, style)
@@ -176,6 +177,7 @@ window.update = function(self)
       row = info.row + thumb_offset + (info.border_info.visible and info.border_info.top or 0),
       col = info.col + info.width - 1, -- info.col was already added scrollbar offset.
       zindex = (self.style.zindex and (self.style.zindex + 2) or 2),
+      border = "none",
     }
     if self.thumb_win and vim.api.nvim_win_is_valid(self.thumb_win) then
       vim.api.nvim_win_set_config(self.thumb_win, style)


### PR DESCRIPTION
neovim 0.11 introduced winborder: https://github.com/neovim/neovim/pull/31074 This means that the user may override the global window border for all windows for which the border wasn't explicitly set. For the scrollbar and the scrollbar thumb, we don't want any border.

In the past we achieved that by not specifying any border, but with winborder, the user may set the border and then the scrollbar looks broken. So now we explicitly say that we want no border on these two windows, fixing the issue.

I tested this commit on neovim 0.10.2 as well, without issues.

To reproduce the issue on neovim 0.11, run:
```
:lua vim.o.winborder = "rounded"
```

and then invoke nvim-cmp on a completion where the scrollbar will be displayed.