### PR TITLE
fix thumb weird look after using `vim.o.winborder = 'rounded'`

### DIFF
--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -176,6 +176,8 @@ window.update = function(self)
       row = info.row + thumb_offset + (info.border_info.visible and info.border_info.top or 0),
       col = info.col + info.width - 1, -- info.col was already added scrollbar offset.
       zindex = (self.style.zindex and (self.style.zindex + 2) or 2),
+	  -- force thumb to not have borders, so `vim.o.winborder` can't have an effect on thumb
+	  border = 'none',
     }
     if self.thumb_win and vim.api.nvim_win_is_valid(self.thumb_win) then
       vim.api.nvim_win_set_config(self.thumb_win, style)


### PR DESCRIPTION
if using `vim.o.winborder = 'rounded'`, the scrollbar/scroll thumb is weird looking:
<img width="504" alt="before" src="https://github.com/user-attachments/assets/ba78f1ff-7451-4456-b23c-80dc47674195" />

after fix:
<img width="489" alt="after" src="https://github.com/user-attachments/assets/da93054a-c6a5-4b53-ad13-976a60b0dcbc" />

this also needed to be fixed upstream, which had been merged recently: [pr](https://github.com/neovim/neovim/pull/32984)


As of right now, the neovim in `nixpkgs` is not yet fixed, have to use newest `homebrew` [neovim](https://github.com/Homebrew/homebrew-core/blob/dae846ae5347d31b610aebc2df6267f9a734f5a4/Formula/n/neovim.rb) and apply this fix to make it look normal