### PR TITLE
fix: Use winborder for window menu and fix scrollbar window

### DIFF
--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -1,5 +1,6 @@
 local compare = require('cmp.config.compare')
 local types = require('cmp.types')
+local window = require('cmp.config.window')
 
 local WIDE_HEIGHT = 40
 
@@ -107,7 +108,7 @@ return function()
 
     window = {
       completion = {
-        border = { '', '', '', '', '', '', '', '' },
+        border = window.get_border(),
         winhighlight = 'Normal:Pmenu,FloatBorder:Pmenu,CursorLine:PmenuSel,Search:None',
         winblend = vim.o.pumblend,
         scrolloff = 0,
@@ -118,7 +119,7 @@ return function()
       documentation = {
         max_height = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
         max_width = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
-        border = { '', '', '', ' ', '', '', '', ' ' },
+        border = window.get_border(),
         winhighlight = 'FloatBorder:NormalFloat',
         winblend = vim.o.pumblend,
       },

--- a/lua/cmp/config/window.lua
+++ b/lua/cmp/config/window.lua
@@ -13,4 +13,13 @@ window.bordered = function(opts)
   }
 end
 
+window.get_border = function()
+  -- On neovim 0.11+, use the vim.o.winborder option by default
+  local has_winborder, winborder = pcall(function() return vim.o.winborder end)
+  if has_winborder and winborder ~= '' then return winborder end
+
+  -- On lower versions return the default
+  return 'none'
+end
+
 return window

--- a/lua/cmp/utils/window.lua
+++ b/lua/cmp/utils/window.lua
@@ -145,6 +145,7 @@ window.update = function(self)
         row = info.row,
         col = info.col + info.width - info.scrollbar_offset, -- info.col was already contained the scrollbar offset.
         zindex = (self.style.zindex and (self.style.zindex + 1) or 1),
+        border = 'none',
       }
       if self.sbar_win and vim.api.nvim_win_is_valid(self.sbar_win) then
         vim.api.nvim_win_set_config(self.sbar_win, style)
@@ -176,6 +177,7 @@ window.update = function(self)
       row = info.row + thumb_offset + (info.border_info.visible and info.border_info.top or 0),
       col = info.col + info.width - 1, -- info.col was already added scrollbar offset.
       zindex = (self.style.zindex and (self.style.zindex + 2) or 2),
+      border = 'none',
     }
     if self.thumb_win and vim.api.nvim_win_is_valid(self.thumb_win) then
       vim.api.nvim_win_set_config(self.thumb_win, style)


### PR DESCRIPTION
Use win border as the default border option in config, also fix scrollbar window

scrollbar before: 
<img width="122" alt="Screenshot 2025-04-01 at 4 43 10 PM" src="https://github.com/user-attachments/assets/9044eb03-9b77-4976-bb59-d0daa2d1fdbd" />

scrollbar after (also with rounded win border): 
<img width="112" alt="Screenshot 2025-04-01 at 5 23 53 PM" src="https://github.com/user-attachments/assets/7a490a1b-ba0c-4c2e-b2ac-aeb217aee0d0" />
