### PR TITLE
feat: a 'disallow_case_insensetive_matching' option to fail a match on different cases

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -592,6 +592,12 @@ matching.disallow_symbol_nonprefix_matching
   `boolean`
   Whether to allow symbols in matches if the match is not a prefix match.
 
+                                cmp-config.matching.disallow_case_insensetive_matching
+matching.disallow_case_insensetive_matching
+  `boolean`
+  Whether to perform a case sensetive matching and return 0 score if the cases
+  don't match.
+
                                             *cmp-config.sorting.priority_weight*
 sorting.priority_weight~
   `number`

--- a/lua/cmp/config/default.lua
+++ b/lua/cmp/config/default.lua
@@ -61,6 +61,7 @@ return function()
       disallow_partial_matching = false,
       disallow_prefix_unmatching = false,
       disallow_symbol_nonprefix_matching = true,
+      disallow_case_insensetive_matching = false
     },
 
     sorting = {

--- a/lua/cmp/entry.lua
+++ b/lua/cmp/entry.lua
@@ -393,7 +393,17 @@ end
 entry.match = function(self, input, matching_config)
   -- https://www.lua.org/pil/11.6.html
   -- do not use '..' to allocate multiple strings
-  local cache_key = string.format('%s:%d:%d:%d:%d:%d:%d', input, self.resolved_completion_item and 1 or 0, matching_config.disallow_fuzzy_matching and 1 or 0, matching_config.disallow_partial_matching and 1 or 0, matching_config.disallow_prefix_unmatching and 1 or 0, matching_config.disallow_partial_fuzzy_matching and 1 or 0, matching_config.disallow_symbol_nonprefix_matching and 1 or 0)
+
+  local cache_key = string.format('%s:%d:%d:%d:%d:%d:%d:%d',
+    input,
+    self.resolved_completion_item and 1 or 0,
+    matching_config.disallow_fuzzy_matching and 1 or 0,
+    matching_config.disallow_partial_matching and 1 or 0,
+    matching_config.disallow_prefix_unmatching and 1 or 0,
+    matching_config.disallow_partial_fuzzy_matching and 1 or 0,
+    matching_config.disallow_symbol_nonprefix_matching and 1 or 0,
+    matching_config.disallow_case_insensetive_matching and 1 or 0)
+
   local matched = self.match_cache:get(cache_key)
   if matched then
     if self.match_view_args_ret and self.match_view_args_ret.input ~= input then
@@ -417,6 +427,7 @@ entry._match = function(self, input, matching_config)
     disallow_partial_matching = matching_config.disallow_partial_matching,
     disallow_prefix_unmatching = matching_config.disallow_prefix_unmatching,
     disallow_symbol_nonprefix_matching = matching_config.disallow_symbol_nonprefix_matching,
+    disallow_case_insensentive_matching = matching_config.disallow_case_insensetive_matching,
     synonyms = {
       self.word,
       self.completion_item.label,

--- a/lua/cmp/matcher_spec.lua
+++ b/lua/cmp/matcher_spec.lua
@@ -52,6 +52,7 @@ describe('matcher', function()
       disallow_prefix_unmatching = false,
       disallow_partial_fuzzy_matching = false,
       disallow_symbol_nonprefix_matching = true,
+      disallow_case_insensetive_matching = false,
     })
     assert.is.truthy(score >= 1)
     assert.equals(matches[1].word_match_start, 5)
@@ -62,6 +63,7 @@ describe('matcher', function()
       disallow_prefix_unmatching = false,
       disallow_partial_fuzzy_matching = true,
       disallow_symbol_nonprefix_matching = true,
+      disallow_case_insensetive_matching = false,
     })
     assert.is.truthy(score == 0)
   end)
@@ -91,6 +93,11 @@ describe('matcher', function()
   it('disallow_symbol_nonprefix_matching', function()
     assert.is.truthy(matcher.match('foo_', 'b foo_bar', { disallow_symbol_nonprefix_matching = true }) == 0)
     assert.is.truthy(matcher.match('foo_', 'b foo_bar', { disallow_symbol_nonprefix_matching = false }) >= 1)
+  end)
+
+  it('disallow_case_insensetive_matching', function()
+    assert.is.truthy(matcher.match('Test', 'test', { disallow_case_insensetive_matching = true }) == 0)
+    assert.is.truthy(matcher.match('Test', 'test', { disallow_case_insensetive_matching = false}) >= 1)
   end)
 
   it('debug', function()

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -146,6 +146,7 @@ cmp.ItemField = {
 ---@field public disallow_partial_matching boolean
 ---@field public disallow_prefix_unmatching boolean
 ---@field public disallow_symbol_nonprefix_matching boolean
+---@field public disallow_case_insensetive_matching boolean
 
 ---@class cmp.SortingConfig
 ---@field public priority_weight integer

--- a/lua/cmp/utils/char.lua
+++ b/lua/cmp/utils/char.lua
@@ -102,11 +102,16 @@ char.get_next_semantic_index = function(text, current_index)
   return #text + 1
 end
 
----Ignore case match
+---Ignore case match by default
 ---@param byte1 integer
 ---@param byte2 integer
+---@param is_case_sensetive boolean? default:false whether the match should be case sensetive
 ---@return boolean
-char.match = function(byte1, byte2)
+char.match = function(byte1, byte2, is_case_sensetive)
+  if is_case_sensetive then
+      return byte1 == byte2
+  end
+
   if not char.is_alpha(byte1) or not char.is_alpha(byte2) then
     return byte1 == byte2
   end


### PR DESCRIPTION
The option if enabled will fail matches where the difference between the characters relies only on their cases. New changes will keep the default logic while adding extra precision to match results when it is necessary.

Even though there is a scoring bonus that gives more 'points' for a matching when characters have correct cases when I needed to introduce my own sorting logic I needed to completely eliminate the matches that don't have correct cases, it's extremely useful when working with camel cases.

Example: 
"Text" won't match "text" and vice versa.