### PR TITLE
fix: remove redundant UIEnter subscription

### DIFF
--- a/plugin/cmp.lua
+++ b/plugin/cmp.lua
@@ -25,7 +25,7 @@ for kind in pairs(types.lsp.CompletionItemKind) do
   end
 end
 
-autocmd.subscribe({ 'ColorScheme', 'UIEnter' }, function()
+autocmd.subscribe({ 'ColorScheme' }, function()
   highlight.inherit('CmpItemAbbrDefault', 'Pmenu', { bg = 'NONE', default = false })
   highlight.inherit('CmpItemAbbrDeprecatedDefault', 'Comment', { bg = 'NONE', default = false })
   highlight.inherit('CmpItemAbbrMatchDefault', 'Pmenu', { bg = 'NONE', default = false })


### PR DESCRIPTION
The UIEnter event is not needed for setting up the highlight groups in cmp.lua.

This caused a bug displaying ANSI escape sequences in neovim in tmux, kitty, and alacritty.

I found this bug after 2 days of debugging, searching for the cause in the wrong place - zsh, tmux, kitty, then testing on alacritty and xterm, and finally realizing that the issue was in the Neovim configuration itself.

If this does not in fact fix the issue, even though I tested it thoroughly, it is still a redundant call in my opinion, especially since `ColorScheme` event is immediately triggered after the subscription.