### PR TITLE
fix: feedkeys might insert cmp.utils.feedkeys... into acrtive text buffer

### DIFF
--- a/lua/cmp/utils/async.lua
+++ b/lua/cmp/utils/async.lua
@@ -170,7 +170,9 @@ end
 ---Wait and callback for consuming next keymap.
 async.debounce_next_tick_by_keymap = function(callback)
   return function()
-    feedkeys.call('', '', callback)
+    -- Use vim.schedule instead of feedkeys to prevent command text insertion
+    -- into buffers
+    vim.schedule(callback)
   end
 end
 


### PR DESCRIPTION
Use `vim.schedule` instead of `cmp.utils.feedkeys` to prevent command text insertion into a text buffer.

The feedkeys mechanism was causing 'lua require"cmp.utils.feedkeys".run(#)' to be inserted into buffers instead of being executed as a command as intended.

This should close #1619 and #2033 and others related to the command showing up in the edit buffer.
