### PR TITLE
Fix: Type mismatch in nvim-cmp documentation configuration

### DIFF
--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -117,7 +117,7 @@ cmp.ItemField = {
 
 ---@class cmp.WindowConfig
 ---@field public completion? cmp.CompletionWindowOptions
----@field public documentation? cmp.DocumentationWindowOptions|nil
+---@field public documentation? cmp.DocumentationWindowOptions|vim.NIL
 
 ---@class cmp.WindowOptions
 ---@field public border? string|string[]


### PR DESCRIPTION
Resolved an `assign-type-mismatch` error reported by `lua_ls` when `cmp.config.disable` was used for documentation settings, where `vim.NIL` was incorrectly assigned.