### PR TITLE
locality: fix perf issue with long lines

### DIFF
--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -159,7 +159,8 @@ compare.locality = setmetatable({
       local locality_map = self.lines_cache:ensure({ 'line', buffer }, function()
         local locality_map = {}
         local regexp = vim.regex(config.completion.keyword_pattern)
-        while buffer ~= '' do
+        -- the buffer length check is to avoid performance issues on very long lines, #1841
+        while buffer ~= '' and #buffer < 5000 do
           local s, e = regexp:match_str(buffer)
           if s and e then
             local w = string.sub(buffer, s + 1, e)


### PR DESCRIPTION
fixes #1841

i also attempted to use vim.fn.matchstrpos to avoid the substring operations, but it seems it's not really the substring that's slow, but truly the regexes (or the populating of the locality map).

this is a very simple fix that solves a really problematic issue.