### PR TITLE
chore: use vim.lsp.config instead of require('lspconfig')

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ lua <<EOF
       { name = 'buffer' },
     })
  })
- require("cmp_git").setup() ]]-- 
+ require("cmp_git").setup() ]]--
 
   -- Use buffer source for `/` and `?` (if you enabled `native_menu`, this won't work anymore).
   cmp.setup.cmdline({ '/', '?' }, {
@@ -136,9 +136,9 @@ lua <<EOF
   -- Set up lspconfig.
   local capabilities = require('cmp_nvim_lsp').default_capabilities()
   -- Replace <YOUR_LSP_SERVER> with each lsp server you've enabled.
-  require('lspconfig')['<YOUR_LSP_SERVER>'].setup {
+  vim.lsp.config('<YOUR_LSP_SERVER>', {
     capabilities = capabilities
-  }
+  })
 EOF
 ```
 

--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -140,9 +140,9 @@ A recommended configuration can be found below.
 
     -- Setup lspconfig.
     local capabilities = require('cmp_nvim_lsp').default_capabilities()
-    require('lspconfig')[%YOUR_LSP_SERVER%].setup {
+    vim.lsp.config(%YOUR_LSP_SERVER%, {
       capabilities = capabilities
-    }
+    })
   EOF
 <
 ==============================================================================

--- a/utils/vimrc.vim
+++ b/utils/vimrc.vim
@@ -46,8 +46,8 @@ EOF
 lua << EOF
 local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
-require'lspconfig'.cssls.setup {
+vim.lsp.config('cssls', {
   capabilities = capabilities,
-}
+})
 EOF
 


### PR DESCRIPTION
Because https://github.com/neovim/nvim-lspconfig/pull/4077

I found places to update using `rg 'require.*lspconfig' nvim-cmp`