### PR TITLE
ci: fix `Setup tools` step failure

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -28,7 +28,7 @@ jobs:
         luaVersion: "luajit-openresty"
 
     - name: Setup luarocks
-      uses: leafo/gh-actions-luarocks@v4
+      uses: leafo/gh-actions-luarocks@v6
 
     - name: Setup tools
       shell: bash


### PR DESCRIPTION
This resolves the "Setup tools" failure by upgrading gh-actions-luarocks
from v4 to v6.

This update bumps the underlying Luarocks version to 3.12.2,
which contains the fix for the "main function has more than 65536 constants"
error.

See: luarocks/luarocks#1797
