### PR TITLE
feat: max_height for completion window

### DIFF
--- a/doc/cmp.txt
+++ b/doc/cmp.txt
@@ -787,6 +787,13 @@ window.completion.scrollbar~
   `boolean`
   Whether the scrollbar should be enabled if there are more items that fit
 
+                                     *cmp-config.window.completion.max_height*
+window.completion.max_height~
+  `number | nil`
+  The completion window's max height, can be set to 0 to use all available
+  space. To use `vim.o.pumheight` set this to `nil`.
+  See |'pumheight'|.
+
                                      *cmp-config.window.documentation.max_width*
 window.documentation.max_width~
   `number`

--- a/lua/cmp/config/window.lua
+++ b/lua/cmp/config/window.lua
@@ -10,6 +10,7 @@ window.bordered = function(opts)
     col_offset = opts.col_offset or 0,
     side_padding = opts.side_padding or 1,
     scrollbar = opts.scrollbar == nil and true or opts.scrollbar,
+    max_height = opts.max_height or nil,
   }
 end
 

--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -131,6 +131,7 @@ cmp.ItemField = {
 ---@field public col_offset? integer|nil
 ---@field public side_padding? integer|nil
 ---@field public scrollbar? boolean|true
+---@field public max_height? integer|nil
 
 ---@class cmp.DocumentationWindowOptions: cmp.WindowOptions
 ---@field public max_height? integer|nil

--- a/lua/cmp/view/custom_entries_view.lua
+++ b/lua/cmp/view/custom_entries_view.lua
@@ -174,7 +174,7 @@ custom_entries_view.open = function(self, offset, entries)
   width = width + self.column_width.kind + (self.column_width.menu > 0 and 1 or 0)
   width = width + self.column_width.menu + 1
 
-  local height = vim.api.nvim_get_option_value('pumheight', {})
+  local height = completion.max_height or vim.api.nvim_get_option_value('pumheight', {})
   height = height ~= 0 and height or #self.entries
   height = math.min(height, #self.entries)
 


### PR DESCRIPTION
- Max height can be set separately from ['pumheight'](https://neovim.io/doc/user/options.html#'pumheight')
- Default behaviour is still to use pumheight, so existing configs won't be affected. 
- A negative `max_height` will not display the menu. (Should it fallback to use all available space?)
```lua
	cmp.setup({
		...
		window = {
			completion = cmp.config.window.bordered({ max_height = 5 }), -- ignores pumheight
			-- completion = cmp.config.window.bordered({ max_height = 0 }), -- Uses all available space, ignores pumheight 
			-- completion = cmp.config.window.bordered(), -- Uses pumheight, default
			-- completion = cmp.config.window.bordered({ max_height = nil }), -- Uses pumheight, same as default
			
			-- completion = cmp.config.window.bordered({ max_height = -5 }), -- Menu not displayed
		},
		...
	})
```

Screenshots:
(`max_height` set to 5):
<img width="582" height="186" alt="image" src="https://github.com/user-attachments/assets/af5838bc-20d4-45fa-9400-24da4c12caf4" />

(`max_height` set to 0):
<img width="579" height="627" alt="image" src="https://github.com/user-attachments/assets/3aed9b0e-18bc-4471-95ef-127fd7f579f6" />

(`max_height` set to 5, `pumheight` set to 1, ignores `pumheight`):
<img width="580" height="220" alt="image" src="https://github.com/user-attachments/assets/97095496-b746-4cee-819c-bbb3df7cf4f2" />

(`max_height` set to `nil` (default), `pumheight` set to 1, uses `pumheight`):
<img width="420" height="216" alt="image" src="https://github.com/user-attachments/assets/c2207544-e4b2-47f6-802d-bb6c3ee0939f" />