### PR TITLE
feat: respect winborder variable

### DIFF
--- a/lua/cmp/config/window.lua
+++ b/lua/cmp/config/window.lua
@@ -3,7 +3,7 @@ local window = {}
 window.bordered = function(opts)
   opts = opts or {}
   return {
-    border = opts.border or 'rounded',
+    border = opts.border or window.get_border(),
     winhighlight = opts.winhighlight or 'Normal:Normal,FloatBorder:FloatBorder,CursorLine:Visual,Search:None',
     zindex = opts.zindex or 1001,
     scrolloff = opts.scrolloff or 0,


### PR DESCRIPTION
If `window.bordered()` is used without specifying a border in its argument, the fallback should respect the user's winborder variable, instead of defaulting to `rounded`.