### PR TITLE
fix: checking arduino ls response length when receiving userdata type

### DIFF
--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -355,7 +355,7 @@ source.complete = function(self, ctx, callback)
 
       self.incomplete = response.isIncomplete or false
 
-      if #(response.items or response) > 0 then
+      if type(response.items) ~= 'userdata' and #(response.items or response) > 0 then
         debug.log(self:get_debug_name(), 'retrieve', #(response.items or response))
         local old_offset = self.offset
         local old_entries = self.entries


### PR DESCRIPTION
Keep getting this error non-stop when using arduino language server.
```bash
vim.schedule callback: .../dosx/.local/share/nvim/lazy/nvim-cmp/lua/cmp/source.lua:358: attempt to get length of local 'response' (a userdata value)
stack traceback:
        .../dosx/.local/share/nvim/lazy/nvim-cmp/lua/cmp/source.lua:358: in function 'fn'
        [string "vim/_core/editor"]:273: in function <[string "vim/_core/editor"]:272>
```