### PR TITLE
fix(#2219): trigger on_changed also for text alteration (!= deletion)

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -372,19 +372,20 @@ local on_text_changed = function()
     cmp.core:on_change('TextChanged')
   end
 end
-local lp = { 0, 0, buf = 0 }
+local lp = { 0, 0, buf = 0, text = '' }
 autocmd.subscribe({ 'TextChangedI', 'TextChangedP' }, function(s)
   local pos = vim.api.nvim_win_get_cursor(0)
   pos.buf = s.buf
-  if
-    s.buf ~= lp.buf -- same buf
-    or not (lp[1] == pos[1] and lp[2] + 1 == pos[2]) -- same line
-    -- or not (lp[1] + 1 == pos[1] and lp[2] == 0) -- beginning of next line
-  then
-    lp = pos
-    return
-  else
-    lp = pos
+  pos.text = vim.api.nvim_get_current_line()
+  local is_new_text = s.buf ~= lp.buf -- different buf (may show cmp for 1st delete, but better than hiding for 1st input)
+    or (lp[1] == pos[1] - 1 and lp[2] == 0) -- beginning of next line
+    or (
+      lp[1] == pos[1] -- same line
+      and lp.text:sub(1, pos[2]) ~= pos.text:sub(1, pos[2])
+    )
+
+  lp = pos
+  if is_new_text then
     on_text_changed()
   end
 end)


### PR DESCRIPTION
My original implementation discarded any change that altered the text in any other way than writing 1 char. This discarded pasted text as well as other plugins that may alter the text but are meant just to help with text input.

It can be argued that in most cases when a larger text change is made - whether by a plugin or by the user pasting in some text - the user likely doesn't actually want to see any completion. So this change may actually introduce back some minor annoyances in very rare cases, where even after the text alteration there still exist some completion items that could match it.

Ideally, this would be even more configurable, in essence just leaving the text change triggering to the user completely or at least have the condition be determined via a function in the config.

I can make that change here straight away (with this as the default), if you thing it is better in order to solve this issue once and for all.

Fixes https://github.com/happy663/dotfiles/issues/301