### PR TITLE
Fix cmp.PreselectMode type alias mismatch

### DIFF
--- a/lua/cmp/types/cmp.lua
+++ b/lua/cmp/types/cmp.lua
@@ -26,7 +26,7 @@ cmp.TriggerEvent = {
   TextChanged = 'TextChanged',
 }
 
----@alias cmp.PreselectMode 'item' | 'None'
+---@alias cmp.PreselectMode 'item' | 'none'
 cmp.PreselectMode = {
   Item = 'item',
   None = 'none',


### PR DESCRIPTION
`cmp.PreselectMode` is typed as an enum of strings `"item"` and `"None"`, but actually it's an enum of `"item"` and `"none"` (lower-case). This causes type errors, for instance when setting
```lua
preselect = cmp.PreselectMode.None
```
inside `cmp.setup`, as preselect expects `"None"` but receives `"none"`.